### PR TITLE
Fix AddAutoExe Unable to select file

### DIFF
--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -741,7 +741,7 @@ void COptionsWindow::OnAddAutoCmd()
 
 void COptionsWindow::OnAddAutoExe()
 {
-	QString Value = QFileDialog::getOpenFileName(this, tr("Select Program"), "", tr("Executables (*.exe|*.cmd)")).replace("/", "\\");;
+	QString Value = QFileDialog::getOpenFileName(this, tr("Select Program"), "", tr("Executables (*.exe *.cmd);;All files (*.*)")).replace("/", "\\");;
 	if (Value.isEmpty())
 		return;
 


### PR DESCRIPTION
On the sandboxie-plus 0.5.4d.
Select 
Sandbox Options(DefaultBox) -> General Options -> Auto Start -> Add program -> OK 
A dialog box will pop up to select the file.
However, it is not actually possible to select any files because the QFileDialog filter is set incorrectly.
According to the QT documentation, the code should look like this.
```cpp
QString fileName = QFileDialog::getOpenFileName(
        this,
        title,
        directory,
        tr("JPEG (*.jpg *.jpeg);; TIFF (*.tif);; All files (*.*)")
);
```

So I've fixed it here.