### PR TITLE
Add Chinese Traditional Translation

### DIFF
--- a/SandboxiePlus/SandMan/sandman_zh-TW.ts
+++ b/SandboxiePlus/SandMan/sandman_zh-TW.ts
@@ -1,0 +1,2322 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh-TW">
+<context>
+    <name>CApiMonModel</name>
+    <message>
+        <source>Message</source>
+        <translation>訊息</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>時間標記</translation>
+    </message>
+    <message>
+        <source>Process</source>
+        <translation>處理程序</translation>
+    </message>
+</context>
+<context>
+    <name>CMultiErrorDialog</name>
+    <message>
+        <source>Message</source>
+        <translation>訊息</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus - Error</source>
+        <translation>Sandboxie-Plus - 錯誤</translation>
+    </message>
+</context>
+<context>
+    <name>CNewBoxWindow</name>
+    <message>
+        <source>New Box</source>
+        <translation>新沙盒</translation>
+    </message>
+    <message>
+        <source>Hardened</source>
+        <translation>強化</translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation>預設</translation>
+    </message>
+    <message>
+        <source>Legacy (old sbie behaviour)</source>
+        <translation type="vanished">遺留 (舊沙盒行為)</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus - Create New Box</source>
+        <translation>Sandboxie-Plus - 建立新沙盒</translation>
+    </message>
+    <message>
+        <source>Legacy Sandboxie Behaviour</source>
+        <translation type="unfinished">遺留 Sandboxie 行為</translation>
+    </message>
+</context>
+<context>
+    <name>COptionsWindow</name>
+    <message>
+        <source>Always show</source>
+        <translation>總是顯示</translation>
+    </message>
+    <message>
+        <source>Template values can not be edited.</source>
+        <translation>模板值無法編輯。</translation>
+    </message>
+    <message>
+        <source>Lingerer</source>
+        <translation>駐留項目</translation>
+    </message>
+    <message>
+        <source>Browse for File</source>
+        <translation>瀏覽檔案</translation>
+    </message>
+    <message>
+        <source>Please enter a menu title</source>
+        <translation>請輸入選單標題</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>選取目錄</translation>
+    </message>
+    <message>
+        <source>Please enter a name for the new group</source>
+        <translation>請輸入新的群組名稱</translation>
+    </message>
+    <message>
+        <source>Please enter a program file name</source>
+        <translation>請輸入程式檔名稱</translation>
+    </message>
+    <message>
+        <source>Template values can not be removed.</source>
+        <translation>模板值無法刪除。</translation>
+    </message>
+    <message>
+        <source>Display box name in title</source>
+        <translation>標題顯示沙盒名稱</translation>
+    </message>
+    <message>
+        <source>Folder</source>
+        <translation>資料夾</translation>
+    </message>
+    <message>
+        <source>Sandboxie Plus - &apos;%1&apos; Options</source>
+        <translation>Sandboxie Plus - &apos;%1&apos; 選項</translation>
+    </message>
+    <message>
+        <source>Leader</source>
+        <translation>導引</translation>
+    </message>
+    <message>
+        <source>Group: %1</source>
+        <translation>群組: %1</translation>
+    </message>
+    <message>
+        <source>Process</source>
+        <translation>處理程序</translation>
+    </message>
+    <message>
+        <source>Display [#] indicator only</source>
+        <translation>只顯示 [#] 標記</translation>
+    </message>
+    <message>
+        <source>COM objects must be specified by their GUID, like: {00000000-0000-0000-0000-000000000000}</source>
+        <translation>COM 物件必須被它們的 GUID 所限定，例如: {00000000-0000-0000-0000-000000000000}</translation>
+    </message>
+    <message>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+    <message>
+        <source>Border disabled</source>
+        <translation>邊框禁用</translation>
+    </message>
+    <message>
+        <source>All Categories</source>
+        <translation>所有類別</translation>
+    </message>
+    <message>
+        <source>Please enter a file extension to be excluded</source>
+        <translation>請輸入要排除的副檔名</translation>
+    </message>
+    <message>
+        <source>Exclusion</source>
+        <translation>排除</translation>
+    </message>
+    <message>
+        <source>Select File</source>
+        <translation>選取檔案</translation>
+    </message>
+    <message>
+        <source>This template is enabled globally. To configure it, use the global options.</source>
+        <translation>此模板已全域性啟用。請使用全域性選項配置。</translation>
+    </message>
+    <message>
+        <source>Please select group first.</source>
+        <translation>請先選取群組。</translation>
+    </message>
+    <message>
+        <source>All Files (*.*)</source>
+        <translation>所有檔案 (*.*)</translation>
+    </message>
+    <message>
+        <source>Show only when title is in focus</source>
+        <translation>僅在標題處在焦點時顯示</translation>
+    </message>
+    <message>
+        <source>Select Program</source>
+        <translation>選取程式</translation>
+    </message>
+    <message>
+        <source>Please enter a command</source>
+        <translation>請輸入命令</translation>
+    </message>
+    <message>
+        <source>kilobytes (%1)</source>
+        <translation>KB (%1)</translation>
+    </message>
+    <message>
+        <source>Don&apos;t alter the window title</source>
+        <translation>不要改變視窗標題</translation>
+    </message>
+    <message>
+        <source>All Programs</source>
+        <translation>所有程式</translation>
+    </message>
+    <message>
+        <source>Browse for Folder</source>
+        <translation>瀏覽資料夾</translation>
+    </message>
+    <message>
+        <source>Enter program:</source>
+        <translation>輸入程式:</translation>
+    </message>
+    <message>
+        <source>Executables (*.exe|*.cmd)</source>
+        <translation>可執行檔案 (*.exe|*.cmd)</translation>
+    </message>
+    <message>
+        <source>RT interfaces must be specified by their name.</source>
+        <translation>RT 介面必須被它們名稱所限定。</translation>
+    </message>
+    <message>
+        <source>Browse for Program</source>
+        <translation>瀏覽程式</translation>
+    </message>
+    <message>
+        <source>Please enter a program path</source>
+        <translation>請輸入程式路徑</translation>
+    </message>
+    <message>
+        <source>Please enter a service identifier</source>
+        <translation>請輸入服務識別符號</translation>
+    </message>
+    <message>
+        <source>Service</source>
+        <translation>服務</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>程式</translation>
+    </message>
+    <message>
+        <source>Please enter an auto exec command</source>
+        <translation>請輸入自動執行命令</translation>
+    </message>
+    <message>
+        <source>This sandbox has been deleted hence configuration can not be saved.</source>
+        <translation>沙盒已刪除，故配置沒有被儲存</translation>
+    </message>
+    <message>
+        <source>Some changes haven&apos;t been saved yet, do you really want to close this options window?</source>
+        <translation>一些變更尚未儲存，您確定關閉此選項視窗嗎？</translation>
+    </message>
+    <message>
+        <source>Executables (*.exe *.cmd);;All files (*.*)</source>
+        <translation>可執行檔案 (*.exe *.cmd);;所有檔案 (*.*)</translation>
+    </message>
+</context>
+<context>
+    <name>CPopUpMessage</name>
+    <message>
+        <source>?</source>
+        <translation>？</translation>
+    </message>
+    <message>
+        <source>Hide all such messages</source>
+        <translation>隱藏所有類似訊息</translation>
+    </message>
+    <message>
+        <source>Remove this message from the list</source>
+        <translation>從清單中刪除此訊息</translation>
+    </message>
+    <message>
+        <source>Dismiss</source>
+        <translation>忽略</translation>
+    </message>
+    <message>
+        <source>Visit %1 for a detailed explanation.</source>
+        <translation>訪問 %1 以取得詳細說明。</translation>
+    </message>
+</context>
+<context>
+    <name>CPopUpProgress</name>
+    <message>
+        <source>Remove this progress indicator from the list</source>
+        <translation>在清單中刪除此處理程序標記</translation>
+    </message>
+    <message>
+        <source>Dismiss</source>
+        <translation>忽略</translation>
+    </message>
+</context>
+<context>
+    <name>CPopUpPrompt</name>
+    <message>
+        <source>No</source>
+        <translation>否</translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation>是</translation>
+    </message>
+    <message>
+        <source>Requesting process terminated</source>
+        <translation>請求的處理程序被終止</translation>
+    </message>
+    <message>
+        <source>Remember for this process</source>
+        <translation>標記此處理程序</translation>
+    </message>
+    <message>
+        <source>Terminate</source>
+        <translation>終止</translation>
+    </message>
+    <message>
+        <source>Request will time out in %1 sec</source>
+        <translation>請求將在 %1 秒後逾時</translation>
+    </message>
+    <message>
+        <source>Request timed out</source>
+        <translation>請求逾時</translation>
+    </message>
+    <message>
+        <source>Yes and add to allowed programs</source>
+        <translation>確定並新增到允許的程式中</translation>
+    </message>
+</context>
+<context>
+    <name>CPopUpRecovery</name>
+    <message>
+        <source>Recover to:</source>
+        <translation>恢復到:</translation>
+    </message>
+    <message>
+        <source>Browse</source>
+        <translation>瀏覽</translation>
+    </message>
+    <message>
+        <source>Clear folder list</source>
+        <translation>清除資料夾清單</translation>
+    </message>
+    <message>
+        <source>Recover</source>
+        <translation>恢復</translation>
+    </message>
+    <message>
+        <source>Recover the file to original location</source>
+        <translation>恢復檔案到原始位址</translation>
+    </message>
+    <message>
+        <source>Recover &amp;&amp; Explore</source>
+        <translation>恢復 &amp;&amp; 瀏覽</translation>
+    </message>
+    <message>
+        <source>Recover &amp;&amp; Open/Run</source>
+        <translation>恢復 &amp;&amp; 開啟/執行</translation>
+    </message>
+    <message>
+        <source>Open file recovery for this box</source>
+        <translation>為此沙盒開啟檔案恢復</translation>
+    </message>
+    <message>
+        <source>Dismiss</source>
+        <translation>忽略</translation>
+    </message>
+    <message>
+        <source>Don&apos;t recover this file right now</source>
+        <translation>此時暫不恢復此檔案</translation>
+    </message>
+    <message>
+        <source>Dismiss all from this box</source>
+        <translation>此沙盒忽略全部</translation>
+    </message>
+    <message>
+        <source>Disable quick recovery until the box restarts</source>
+        <translation>在沙盒重新啟動前禁用快速恢復</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>選取目錄</translation>
+    </message>
+</context>
+<context>
+    <name>CPopUpWindow</name>
+    <message>
+        <source>an UNKNOWN process.</source>
+        <translation>未知處理程序。</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus Notifications</source>
+        <translation>Sandboxie-Plus 通知</translation>
+    </message>
+    <message>
+        <source>%1 (%2)</source>
+        <translation>%1 (%2)</translation>
+    </message>
+    <message>
+        <source>UNKNOWN</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <source>Do you want to allow the print spooler to write outside the sandbox for %1 (%2)?</source>
+        <translation>您想允許列印服務在沙盒外寫入，因為 %1 (%2) 嗎？</translation>
+    </message>
+    <message>
+        <source>Do you want to allow %4 (%5) to copy a %1 large file into sandbox: %2?
+File name: %3</source>
+        <translation type="vanished">您確定允許 %4 (%5) 複製大型檔案 %1 至沙盒: %2？
+檔案名稱: %3</translation>
+    </message>
+    <message>
+        <source>Do you want to allow %1 (%2) access to the internet?
+Full path: %3</source>
+        <translation type="vanished">您確定允許 %1 (%2) 訪問網路嗎？
+完整位址: %3</translation>
+    </message>
+    <message>
+        <source>%1 is eligible for quick recovery from %2.
+The file was written by: %3</source>
+        <translation type="vanished">%1 可以從 %2 快速恢復。
+檔案寫入自: %3</translation>
+    </message>
+    <message>
+        <source>Migrating a large file %1 into the sandbox %2, %3 left.
+Full path: %4</source>
+        <translation type="vanished">移動大檔案 %1 至沙盒 %2，%3 遺留。
+完整位址: %4</translation>
+    </message>
+    <message>
+        <source>Do you want to allow %4 (%5) to copy a %1 large file into sandbox: %2?
+File name: %3</source>
+        <translation>您確定允許 %4 (%5) 複製大型檔案 %1 至沙盒: %2？
+檔案名稱: %3</translation>
+    </message>
+    <message>
+        <source>Do you want to allow %1 (%2) access to the internet?
+Full path: %3</source>
+        <translation>您確定允許 %1 (%2) 訪問網路嗎？
+完整位址: %3</translation>
+    </message>
+    <message>
+        <source>%1 is eligible for quick recovery from %2.
+The file was written by: %3</source>
+        <translation>%1 可以從 %2 快速恢復。
+檔案寫入自: %3</translation>
+    </message>
+    <message>
+        <source>Migrating a large file %1 into the sandbox %2, %3 left.
+Full path: %4</source>
+        <translation>移動大檔案 %1 至沙盒 %2，%3 遺留。
+完整位址: %4</translation>
+    </message>
+</context>
+<context>
+    <name>CRecoveryWindow</name>
+    <message>
+        <source>File Name</source>
+        <translation>檔案名稱</translation>
+    </message>
+    <message>
+        <source>File Size</source>
+        <translation>檔案大小</translation>
+    </message>
+    <message>
+        <source>Full Path</source>
+        <translation>詳細位址</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>選取取目錄</translation>
+    </message>
+    <message>
+        <source>%1 - File Recovery</source>
+        <translation>%1 - 檔案恢復</translation>
+    </message>
+    <message>
+        <source>One or more selected files are located on a network share, and must be recovered to a local drive, please select a folder to recover all selected files to.</source>
+        <translation>一個或多個被選取的檔案位於網路共享，並且必須恢復到本地磁碟，請選取用於恢復所選檔案的資料夾。</translation>
+    </message>
+    <message>
+        <source>There are %1 files and %2 folders in the sandbox, occupying %3 bytes of disk space.</source>
+        <translation>有 %1 檔案和 %2 資料夾位於沙盒中，佔用磁碟 %3 位元組。</translation>
+    </message>
+</context>
+<context>
+    <name>CResMonModel</name>
+    <message>
+        <source>Type</source>
+        <translation>類別</translation>
+    </message>
+    <message>
+        <source>Value</source>
+        <translation>值</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>狀態</translation>
+    </message>
+    <message>
+        <source>Time Stamp</source>
+        <translation>時間標記</translation>
+    </message>
+    <message>
+        <source>Process</source>
+        <translation>處理程序</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+</context>
+<context>
+    <name>CSandBoxPlus</name>
+    <message>
+        <source>No Admin</source>
+        <translation>無管理員</translation>
+    </message>
+    <message>
+        <source>No INet</source>
+        <translation>無 INet</translation>
+    </message>
+    <message>
+        <source>Normal</source>
+        <translation>標準</translation>
+    </message>
+    <message>
+        <source>API Log</source>
+        <translation>API 日誌</translation>
+    </message>
+    <message>
+        <source>Net Share</source>
+        <translation>網路共享</translation>
+    </message>
+    <message>
+        <source>NOT SECURE (Debug Config)</source>
+        <translation>不安全(除錯配置)</translation>
+    </message>
+    <message>
+        <source>Enhanced Isolation</source>
+        <translation>增強隔離</translation>
+    </message>
+    <message>
+        <source>Reduced Isolation</source>
+        <translation>弱化隔離</translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation>禁用</translation>
+    </message>
+</context>
+<context>
+    <name>CSandMan</name>
+    <message>
+        <source>Exit</source>
+        <translation>退出</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;New Sandboxie-Plus has been downloaded to the following location:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;%2&quot;&gt;%1&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Do you want to begin the installation? If any programs are running sandboxed, they will be terminated.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;新版本 Sandboxie-Plus 將被下載到:&lt;/p&gt;&lt;p&gt;&lt;a href=&quot;%2&quot;&gt;%1&lt;/a&gt;&lt;/p&gt;&lt;p&gt;您想要開始安裝嗎？正在沙盒運作的其他程式將會被終止。&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus was started in portable mode and it needs to create necessary services. This will prompt for administrative privileges.</source>
+        <translation>Sandboxie-Plus 已於便攜模式中啟動，需建立必要的服務。將會提示管理員授權。</translation>
+    </message>
+    <message>
+        <source>Cleanup Processes</source>
+        <translation>清理處理程序</translation>
+    </message>
+    <message>
+        <source>Maintenance operation %1</source>
+        <translation>維護作業 %1</translation>
+    </message>
+    <message>
+        <source>&amp;Help</source>
+        <translation>&amp;幫助</translation>
+    </message>
+    <message>
+        <source>&amp;View</source>
+        <translation>&amp;檢視</translation>
+    </message>
+    <message>
+        <source>Error deleting sandbox folder: %1</source>
+        <translation>刪除沙盒資料夾錯誤: %1</translation>
+    </message>
+    <message>
+        <source>About Sandboxie-Plus</source>
+        <translation>關於 Sandboxie-Plus</translation>
+    </message>
+    <message>
+        <source>Driver version: %1</source>
+        <translation>驅動程式版本: %1</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus v%1</source>
+        <translation>Sandboxie-Plus v%1</translation>
+    </message>
+    <message>
+        <source>Start Driver</source>
+        <translation>啟動驅動程式</translation>
+    </message>
+    <message>
+        <source>Install Driver</source>
+        <translation>安裝驅動程式</translation>
+    </message>
+    <message>
+        <source>Uninstall Driver</source>
+        <translation>解除安裝驅動程式</translation>
+    </message>
+    <message>
+        <source>Check for Updates</source>
+        <translation>檢查更新</translation>
+    </message>
+    <message>
+        <source>Visit Support Forum</source>
+        <translation>支援論壇</translation>
+    </message>
+    <message>
+        <source>Failed to copy configuration from sandbox %1: %2</source>
+        <translation>複製沙盒配置 %1: %2 失敗</translation>
+    </message>
+    <message>
+        <source>Do you want to check if there is a new version of Sandboxie-Plus?</source>
+        <translation>你想要檢查 Sandboxie-Plus 是否存在新版本嗎？</translation>
+    </message>
+    <message>
+        <source>Cleanup Api Call Log</source>
+        <translation>清理 API 呼叫日誌</translation>
+    </message>
+    <message>
+        <source>Simple View</source>
+        <translation>簡易檢視</translation>
+    </message>
+    <message>
+        <source>%1 (%2): </source>
+        <translation>%1 (%2): </translation>
+    </message>
+    <message>
+        <source>Login Failed: %1</source>
+        <translation>登入失敗: %1</translation>
+    </message>
+    <message>
+        <source>Clean Up</source>
+        <translation>清理</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>不再顯示此訊息。</translation>
+    </message>
+    <message>
+        <source>Uninstall Service</source>
+        <translation>解除安裝服務</translation>
+    </message>
+    <message>
+        <source>Start Service</source>
+        <translation>啟動服務</translation>
+    </message>
+    <message>
+        <source>Install Service</source>
+        <translation>安裝服務</translation>
+    </message>
+    <message>
+        <source>Failed to remove old snapshot directory &apos;%1&apos;</source>
+        <translation>刪除舊版快照目錄 &apos;%1&apos; 失敗</translation>
+    </message>
+    <message>
+        <source>The changes will be applied automatically as soon as the editor is closed.</source>
+        <translation>變更將在編輯器關閉後自動提交。</translation>
+    </message>
+    <message>
+        <source>Can&apos;t remove a snapshot that is shared by multiple later snapshots</source>
+        <translation>無法刪除由多個後續快照共享的快照</translation>
+    </message>
+    <message>
+        <source>Do you want to close Sandboxie Manager?</source>
+        <translation>您確定要關閉 Sandboxie 管理員？</translation>
+    </message>
+    <message>
+        <source>Support Sandboxie-Plus with a Donation</source>
+        <translation>捐贈支持 Sandboxie-Plus</translation>
+    </message>
+    <message>
+        <source>Unknown Error Status: %1</source>
+        <translation>未知錯誤程式碼: %1</translation>
+    </message>
+    <message>
+        <source>Failed to create directory for new snapshot</source>
+        <translation>建立新的快照目錄失敗</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus was running in portable mode, now it has to clean up the created services. This will prompt for administrative privileges.</source>
+        <translation>Sandboxie-Plus 正運作於便攜模式中，現在將清理所建立的服務。將會提示管理員授權。</translation>
+    </message>
+    <message>
+        <source>   -   Portable</source>
+        <translation>   -   便攜</translation>
+    </message>
+    <message>
+        <source>Failed to download update from: %1</source>
+        <translation>在: %1 下載更新失敗</translation>
+    </message>
+    <message>
+        <source>Api Call Log</source>
+        <translation>API 呼叫日誌</translation>
+    </message>
+    <message>
+        <source>The sandbox name can not be longer than 32 characters.</source>
+        <translation>沙盒名稱不能超過32個字元。</translation>
+    </message>
+    <message>
+        <source>Stop Driver</source>
+        <translation>停止驅動程式</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this announcement in the future.</source>
+        <translation>此後不再顯示此通告。</translation>
+    </message>
+    <message>
+        <source>Sbie Messages</source>
+        <translation>Sbie 訊息</translation>
+    </message>
+    <message>
+        <source>Failed to recover some files: 
+</source>
+        <translation>恢復某些檔案失敗: 
+</translation>
+    </message>
+    <message>
+        <source>Failed to move directory &apos;%1&apos; to &apos;%2&apos;</source>
+        <translation>移動目錄 &apos;%1&apos; 至 &apos;%2&apos; 失敗</translation>
+    </message>
+    <message>
+        <source>Recovering file %1 to %2</source>
+        <translation>恢復檔案 %1 至 %2</translation>
+    </message>
+    <message>
+        <source>Resource Logging</source>
+        <translation>資源日誌</translation>
+    </message>
+    <message>
+        <source>Online Documentation</source>
+        <translation>線上文件</translation>
+    </message>
+    <message>
+        <source>Ignore this update, notify me about the next one.</source>
+        <translation>忽略此升級，下一個再提示我。</translation>
+    </message>
+    <message>
+        <source>Please enter the duration for disabling forced programs.</source>
+        <translation>請輸入禁用強制執行程式的時間。</translation>
+    </message>
+    <message>
+        <source>Sbie Directory: %1</source>
+        <translation>Sbie 目錄: %1</translation>
+    </message>
+    <message>
+        <source>   -   NOT connected</source>
+        <translation>   -   未連線</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Do you want to download the latest version?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;確定要下載最新版本嗎？&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus - Error</source>
+        <translation>Sandboxie-Plus - 錯誤</translation>
+    </message>
+    <message>
+        <source>The changes will be applied automatically whenever the file gets saved.</source>
+        <translation>每當檔案儲存後更改將自動套用。</translation>
+    </message>
+    <message>
+        <source>Time|Message</source>
+        <translation>時間|訊息</translation>
+    </message>
+    <message>
+        <source>&amp;Options</source>
+        <translation>&amp;選項</translation>
+    </message>
+    <message>
+        <source>Show/Hide</source>
+        <translation>顯示/隱藏</translation>
+    </message>
+    <message>
+        <source>Resource Monitor</source>
+        <translation>資源監控</translation>
+    </message>
+    <message>
+        <source>Do you want to open %1 in a sandboxed (yes) or unsandboxed (no) Web browser?</source>
+        <translation>確定要在沙盒化 (是) 未沙盒化 (否) 的瀏覽器中開啟  %1 嗎？</translation>
+    </message>
+    <message>
+        <source>Reset all hidden messages</source>
+        <translation>重置所有隱藏訊息</translation>
+    </message>
+    <message>
+        <source>A sandbox must be emptied before it can be deleted.</source>
+        <translation>刪除沙盒之前必須清空。</translation>
+    </message>
+    <message>
+        <source>The sandbox name can contain only letters, digits and underscores which are displayed as spaces.</source>
+        <translation>沙盒名稱不能為空白，只能包含字母、數字和下劃線。</translation>
+    </message>
+    <message>
+        <source>A sandbox must be emptied before it can be renamed.</source>
+        <translation>重新命名沙盒之前必須清空。</translation>
+    </message>
+    <message>
+        <source>API Call Logging</source>
+        <translation>API 呼叫日誌</translation>
+    </message>
+    <message>
+        <source>Loaded Config: %1</source>
+        <translation>載入的配置: %1</translation>
+    </message>
+    <message>
+        <source>Reload ini file</source>
+        <translation>重新載入 ini 檔案</translation>
+    </message>
+    <message>
+        <source>Remember choice for later.</source>
+        <translation>以後記住選擇。</translation>
+    </message>
+    <message>
+        <source>&amp;Maintenance</source>
+        <translation>&amp;維護</translation>
+    </message>
+    <message>
+        <source>The sandbox name can not be a device name.</source>
+        <translation>沙盒名稱不能為裝置名稱。</translation>
+    </message>
+    <message>
+        <source>Operation failed for %1 item(s).</source>
+        <translation> %1 項作業失敗。</translation>
+    </message>
+    <message>
+        <source>Global Settings</source>
+        <translation>全域性設定</translation>
+    </message>
+    <message>
+        <source>Downloading new version...</source>
+        <translation>下載新版本...</translation>
+    </message>
+    <message>
+        <source>&amp;Sandbox</source>
+        <translation>&amp;沙盒</translation>
+    </message>
+    <message>
+        <source>&lt;h3&gt;About Sandboxie-Plus&lt;/h3&gt;&lt;p&gt;Version %1&lt;/p&gt;&lt;p&gt;Copyright (c) 2020-2021 by DavidXanatos&lt;/p&gt;</source>
+        <translation>&lt;h3&gt;關於 Sandboxie-Plus&lt;/h3&gt;&lt;p&gt;版本 %1&lt;/p&gt;&lt;p&gt;Copyright (c) 2020-2021 by DavidXanatos&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Cleanup</source>
+        <translation>清理</translation>
+    </message>
+    <message>
+        <source>Failed to check for updates, error: %1</source>
+        <translation>檢查更新失敗，錯誤: %1</translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation>斷開連線</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation>連線</translation>
+    </message>
+    <message>
+        <source>Only Administrators can change the config.</source>
+        <translation>僅限管理員可更改配置。</translation>
+    </message>
+    <message>
+        <source>Disable Forced Programs</source>
+        <translation>禁用強制執行程式</translation>
+    </message>
+    <message>
+        <source>Snapshot not found</source>
+        <translation>未發現快照</translation>
+    </message>
+    <message>
+        <source>Failed to remove old RegHive</source>
+        <translation>刪除舊版登錄檔項目失敗</translation>
+    </message>
+    <message>
+        <source>Stop All</source>
+        <translation>停止所有</translation>
+    </message>
+    <message>
+        <source>Can&apos;t find Sandboxie installation path.</source>
+        <translation>無法找到 Sandboxie 安裝位址。</translation>
+    </message>
+    <message>
+        <source>Delete protection is enabled for the sandbox</source>
+        <translation>沙盒的刪除保護被已啟用</translation>
+    </message>
+    <message>
+        <source>&amp;Advanced</source>
+        <translation>&amp;進階</translation>
+    </message>
+    <message>
+        <source>An incompatible Sandboxie %1 was found. Compatible versions: %2</source>
+        <translation>已發現不相容的 Sandboxie %1。相容版本為: %2</translation>
+    </message>
+    <message>
+        <source>Administrator rights are required for this operation.</source>
+        <translation>此作業需要管理員授權。</translation>
+    </message>
+    <message>
+        <source>Executing maintenance operation, please wait...</source>
+        <translation>執行維護作業，請稍等...</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;There is a new version of Sandboxie-Plus available.&lt;br /&gt;&lt;font color=&apos;red&apos;&gt;New version:&lt;/font&gt; &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;有新版本 Sandboxie-Plus 可用。&lt;br /&gt;&lt;font color=&apos;red&apos;&gt;新版本:&lt;/font&gt; &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Stop Service</source>
+        <translation>停止服務</translation>
+    </message>
+    <message>
+        <source>Create New Box</source>
+        <translation>建立新沙盒</translation>
+    </message>
+    <message>
+        <source>Failed to copy RegHive</source>
+        <translation>複製登錄檔項目失敗</translation>
+    </message>
+    <message>
+        <source>Failed to terminate all processes</source>
+        <translation>終止所有處理程序失敗</translation>
+    </message>
+    <message>
+        <source>Advanced View</source>
+        <translation>進階檢視</translation>
+    </message>
+    <message>
+        <source>Failed to delete sandbox %1: %2</source>
+        <translation>刪除沙盒 %1: %2 失敗</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Do you want to go to the &lt;a href=&quot;%1&quot;&gt;download page&lt;/a&gt;?&lt;/p&gt;</source>
+        <translation>&lt;p&gt;確定要開啟 &lt;a href=&quot;%1&quot;&gt;下載頁面&lt;/a&gt;？&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Maintenance operation Successful</source>
+        <translation>維護作業成功</translation>
+    </message>
+    <message>
+        <source>PID %1: </source>
+        <translation>PID %1: </translation>
+    </message>
+    <message>
+        <source>Error Status: %1</source>
+        <translation>錯誤程式碼: %1</translation>
+    </message>
+    <message>
+        <source>Terminate All Processes</source>
+        <translation>終止所有處理程序</translation>
+    </message>
+    <message>
+        <source>Please enter the configuration password.</source>
+        <translation>請輸入配置密碼。</translation>
+    </message>
+    <message>
+        <source>Do you also want to reset hidden message boxes (yes), or only all log messages (no)?</source>
+        <translation>確定連隱藏訊息視窗一起重置 (是) 或僅用於所有日誌訊息 (否)？</translation>
+    </message>
+    <message>
+        <source>You are not authorized to update configuration in section &apos;%1&apos;</source>
+        <translation>您無權在此處更新配置 &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Failed to connect to the driver</source>
+        <translation>連線驅動程式失敗</translation>
+    </message>
+    <message>
+        <source>Failed to communicate with Sandboxie Service: %1</source>
+        <translation>無法與 Sandboxie 服務取得聯絡: %1</translation>
+    </message>
+    <message>
+        <source>Failed to execute: %1</source>
+        <translation>執行失敗: %1</translation>
+    </message>
+    <message>
+        <source>This Snapshot operation can not be performed while processes are still running in the box.</source>
+        <translation>因處理程序正在沙盒中運作，此快照操作無法完成。</translation>
+    </message>
+    <message>
+        <source>server not reachable</source>
+        <translation>伺服器無法訪問</translation>
+    </message>
+    <message>
+        <source>Error merging snapshot directories &apos;%1&apos; with &apos;%2&apos;, the snapshot has not been fully merged.</source>
+        <translation>合併快照目錄 &apos;%1&apos; 和 &apos;%2&apos; 錯誤，快照沒有全部合併。</translation>
+    </message>
+    <message>
+        <source>Edit ini file</source>
+        <translation>編輯 ini 檔案</translation>
+    </message>
+    <message>
+        <source>Checking for updates...</source>
+        <translation>檢查更新...</translation>
+    </message>
+    <message>
+        <source>No sandboxes found; creating: %1</source>
+        <translation>沒找到沙盒；建立: %1</translation>
+    </message>
+    <message>
+        <source>Cleanup Resource Log</source>
+        <translation>清理資源日誌</translation>
+    </message>
+    <message>
+        <source>Cleanup Message Log</source>
+        <translation>清理訊息日誌</translation>
+    </message>
+    <message>
+        <source>About the Qt Framework</source>
+        <translation>關於 Qt 框架</translation>
+    </message>
+    <message>
+        <source>Keep terminated</source>
+        <translation>保持終止</translation>
+    </message>
+    <message>
+        <source>A sandbox of the name %1 already exists</source>
+        <translation>沙盒名稱 %1 已存在</translation>
+    </message>
+    <message>
+        <source>Failed to set configuration setting %1 in section %2: %3</source>
+        <translation>配置設定 %1 失敗於 %2: %3 </translation>
+    </message>
+    <message>
+        <source>Copy Cell</source>
+        <translation>複製單元格</translation>
+    </message>
+    <message>
+        <source>Copy Row</source>
+        <translation>複製列</translation>
+    </message>
+    <message>
+        <source>Copy Panel</source>
+        <translation>複製表格</translation>
+    </message>
+    <message>
+        <source>Failed to stop all Sandboxie components</source>
+        <translation>停止所有 Sandboxie 元件失敗</translation>
+    </message>
+    <message>
+        <source>Failed to start required Sandboxie components</source>
+        <translation>啟動所需 Sandboxie 元件失敗</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus was started in portable mode, do you want to put the SandBox folder into its parent directory?</source>
+        <translation>Sandboxie-Plus 於便攜模式中啟動，您想將沙盒目錄放到它的上級目錄嗎？</translation>
+    </message>
+    <message>
+        <source>The file %1 already exists, do you want to overwrite it?</source>
+        <translation>檔案 %1 已存在，您確定要覆蓋它嗎？</translation>
+    </message>
+    <message>
+        <source>Do this for all files!</source>
+        <translation>為所有檔案執行此操作！</translation>
+    </message>
+    <message>
+        <source>To use API logging you must first set up the LogApiDll from https://github.com/sandboxie-plus/LogApiDll with one or more sandboxes.
+Please download the latest release and set it up with the Sandboxie.ini as instructed in the README.md of the project.</source>
+        <translation>要使用API記錄日誌首先必須從 https://github.com/sandboxie-plus/LogApiDll 下載 LogApiDll，並使用沙盒建立。
+請下載最新發布版本，並使用 sandboxie.ini 安裝，詳情請參考 README.md 中此項目的說明。</translation>
+    </message>
+    <message>
+        <source>No new updates found, your Sandboxie-Plus is up-to-date.</source>
+        <translation>無可用更新，您的 Sandboxie-Plus 已為最新</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Sandboxie-Plus is an open source continuation of Sandboxie.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Visit &lt;a href=&quot;https://sandboxie-plus.com&quot;&gt;sandboxie-plus.com&lt;/a&gt; for more information.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;Icons from &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Sandboxie-Plus 是著名程式 Sandboxie 的開源延續。&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;訪問 &lt;a href=&quot;https://sandboxie-plus.com&quot;&gt;sandboxie-plus.com&lt;/a&gt; 以取得更多資訊。&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;圖示來自 &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Always on Top</source>
+        <translation>保持視窗置頂</translation>
+    </message>
+    <message>
+        <source>Sellect box:</source>
+        <translation type="vanished">選取沙盒:</translation>
+    </message>
+    <message>
+        <source>Some compatybility templates (%1) are missing, probably deleted, do you want to remove them from all boxes?</source>
+        <translation type="vanished">一些相容性模板 (%1) 丟失，可能已被刪除，您確定要從所有沙盒中刪除它們嗎？</translation>
+    </message>
+    <message>
+        <source>Cleaned up removed templates...</source>
+        <translation>清理已刪除的模板...</translation>
+    </message>
+    <message>
+        <source>Can not create snapshot of an empty sandbox</source>
+        <translation>無法為空白沙盒建立快照</translation>
+    </message>
+    <message>
+        <source>A sandbox with that name already exists</source>
+        <translation>已存在同名沙盒</translation>
+    </message>
+    <message>
+        <source>Reset Columns</source>
+        <translation>重設欄</translation>
+    </message>
+    <message>
+        <source>Window Finder</source>
+        <translation>尋找視窗</translation>
+    </message>
+    <message>
+        <source>Show Hidden Boxes</source>
+        <translation>顯示隱藏沙盒</translation>
+    </message>
+    <message>
+        <source>Select box:</source>
+        <translation>選取沙盒:</translation>
+    </message>
+    <message>
+        <source>Some compatibility templates (%1) are missing, probably deleted, do you want to remove them from all boxes?</source>
+        <translation>一些相容性模板已丟失，可能是已被刪除，是否從所有沙盒中移除它們？</translation>
+    </message>
+    <message>
+        <source>Do you want to terminate all processes in all sandboxes?</source>
+        <translation>是否終止所有沙盒中的所有處理程式？</translation>
+    </message>
+    <message>
+        <source>Terminate all without asking</source>
+        <translation>終止全部並不再詢問</translation>
+    </message>
+    <message>
+        <source>The selected window is running as part of program %1 in sandbox %2</source>
+        <translation>所選取的視窗正作為沙盒 %2 中的程式 %1 運作</translation>
+    </message>
+    <message>
+        <source>The selected window is not running as part of any sandboxed program.</source>
+        <translation>所選取的視窗並不屬於任何沙盒化程式。</translation>
+    </message>
+    <message>
+        <source>Drag the Finder Tool over a window to select it, then release the mouse to check if the window is sandboxed.</source>
+        <translation>托拽尋找工具至一個視窗上以選取它，然後釋放滑鼠以檢查其是否已被沙盒化。</translation>
+    </message>
+    <message>
+        <source>Sandboxie-Plus - Window Finder</source>
+        <translation>Sandboxie-Plus - 尋找視窗</translation>
+    </message>
+</context>
+<context>
+    <name>CSbieModel</name>
+    <message>
+        <source>Name</source>
+        <translation>名稱</translation>
+    </message>
+    <message>
+        <source>Box Groupe</source>
+        <translation>沙盒群組</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>狀態</translation>
+    </message>
+    <message>
+        <source>Path / Command Line</source>
+        <translation>位址 / 命令列</translation>
+    </message>
+    <message>
+        <source>Start Time</source>
+        <translation>開始時間</translation>
+    </message>
+    <message>
+        <source>Process ID</source>
+        <translation>處理程序 ID</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation>標題</translation>
+    </message>
+</context>
+<context>
+    <name>CSbieProcess</name>
+    <message>
+        <source>Terminated</source>
+        <translation>已終止</translation>
+    </message>
+    <message>
+        <source>Running</source>
+        <translation>運作中</translation>
+    </message>
+</context>
+<context>
+    <name>CSbieView</name>
+    <message>
+        <source>Run</source>
+        <translation>執行</translation>
+    </message>
+    <message>
+        <source>Create Shortcut to sandbox %1</source>
+        <translation>為沙盒 %1 建立捷徑</translation>
+    </message>
+    <message>
+        <source>Options:
+    </source>
+        <translation>選項:
+    </translation>
+    </message>
+    <message>
+        <source>Drop Admin Rights</source>
+        <translation>撤銷管理員授權</translation>
+    </message>
+    <message>
+        <source>Run eMail Client</source>
+        <translation>執行郵件用戶端</translation>
+    </message>
+    <message>
+        <source>Remove Group</source>
+        <translation>刪除群組</translation>
+    </message>
+    <message>
+        <source>Sandbox Options</source>
+        <translation>沙盒選項</translation>
+    </message>
+    <message>
+        <source>Sandbox Presets</source>
+        <translation>沙盒預設</translation>
+    </message>
+    <message>
+        <source>Do you want to %1 the selected process(es)</source>
+        <translation>確定要 %1 所選處理程序</translation>
+    </message>
+    <message>
+        <source>Move to Group</source>
+        <translation>移動至群組</translation>
+    </message>
+    <message>
+        <source>Remove Sandbox</source>
+        <translation>刪除沙盒</translation>
+    </message>
+    <message>
+        <source>Rename Sandbox</source>
+        <translation>重新命名沙盒</translation>
+    </message>
+    <message>
+        <source>Run from Start Menu</source>
+        <translation>從開始選單執行</translation>
+    </message>
+    <message>
+        <source>Preset</source>
+        <translation>預設</translation>
+    </message>
+    <message>
+        <source>Please enter a new group name</source>
+        <translation>請輸入新的群組名稱</translation>
+    </message>
+    <message>
+        <source>Enable API Call logging</source>
+        <translation>啟用 API 呼叫日誌</translation>
+    </message>
+    <message>
+        <source>[None]</source>
+        <translation>[無]</translation>
+    </message>
+    <message>
+        <source>Please enter a new name for the Sandbox.</source>
+        <translation>請為沙盒輸入新名稱</translation>
+    </message>
+    <message>
+        <source>Add Group</source>
+        <translation>新增群組</translation>
+    </message>
+    <message>
+        <source>Delete Content</source>
+        <translation>刪除內容</translation>
+    </message>
+    <message>
+        <source>Create Shortcut</source>
+        <translation>建立捷徑</translation>
+    </message>
+    <message>
+        <source>Do you really want to remove the selected sandbox(es)?</source>
+        <translation>確定要刪除所選沙盒嗎？</translation>
+    </message>
+    <message>
+        <source>Run Program</source>
+        <translation>執行程式</translation>
+    </message>
+    <message>
+        <source>    IPC root: %1
+</source>
+        <translation>    IPC 根目錄: %1
+</translation>
+    </message>
+    <message>
+        <source>Block and Terminate</source>
+        <translation>阻止並終止</translation>
+    </message>
+    <message>
+        <source>    Registry root: %1
+</source>
+        <translation>    登錄檔根目錄: %1
+</translation>
+    </message>
+    <message>
+        <source>    File root: %1
+</source>
+        <translation>    檔案根目錄: %1
+</translation>
+    </message>
+    <message>
+        <source>Terminate</source>
+        <translation>終止</translation>
+    </message>
+    <message>
+        <source>Set Leader Process</source>
+        <translation>設定導引處理程序</translation>
+    </message>
+    <message>
+        <source>Terminate All Programs</source>
+        <translation>終止所有程式</translation>
+    </message>
+    <message>
+        <source>Do you really want to remove the selected group(s)?</source>
+        <translation>確定要刪除所選群組嗎？</translation>
+    </message>
+    <message>
+        <source>Run Web Browser</source>
+        <translation>執行網頁瀏覽器</translation>
+    </message>
+    <message>
+        <source>Force into this sandbox</source>
+        <translation>強制加入此沙盒</translation>
+    </message>
+    <message>
+        <source>Allow Network Shares</source>
+        <translation>允許網路共享</translation>
+    </message>
+    <message>
+        <source>Run Cmd.exe</source>
+        <translation>執行 Cmd.exe</translation>
+    </message>
+    <message>
+        <source>Snapshots Manager</source>
+        <translation>快照管理</translation>
+    </message>
+    <message>
+        <source>Run Explorer</source>
+        <translation>執行檔案總管</translation>
+    </message>
+    <message>
+        <source>Block Internet Access</source>
+        <translation>禁止網路訪問</translation>
+    </message>
+    <message>
+        <source>Set Linger Process</source>
+        <translation>設定駐留處理程序</translation>
+    </message>
+    <message>
+        <source>Create New Box</source>
+        <translation>建立新沙盒</translation>
+    </message>
+    <message>
+        <source>Pin to Run Menu</source>
+        <translation>固定到執行選單</translation>
+    </message>
+    <message>
+        <source>Recover Files</source>
+        <translation>恢復檔案</translation>
+    </message>
+    <message>
+        <source>This box does not have Internet restrictions in place, do you want to enable them?</source>
+        <translation>此沙盒無網際網路限制，確定要啟用它們嗎？</translation>
+    </message>
+    <message>
+        <source>Explore Content</source>
+        <translation>瀏覽內容</translation>
+    </message>
+    <message>
+        <source>Allow internet access</source>
+        <translation>允許網路訪問</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again.</source>
+        <translation>不再顯示此訊息</translation>
+    </message>
+    <message>
+        <source>This Sandbox is already empty.</source>
+        <translation>此沙盒為空。</translation>
+    </message>
+    <message>
+        <source>Do you want to delete the content of the selected sandbox?</source>
+        <translation>您確定要刪除所選沙盒的內容？</translation>
+    </message>
+    <message>
+        <source>Do you really want to delete the content of multiple sandboxes?</source>
+        <translation>您確定要刪除多個沙盒的內容？</translation>
+    </message>
+    <message>
+        <source>Do you want to terminate all processes in the selected sandbox(es)?</source>
+        <translation>您確定要終止選定沙盒中的所有處理程序？</translation>
+    </message>
+    <message>
+        <source>This sandbox is disabled, do you want to enable it?</source>
+        <translation>此沙盒已禁用，是否啟用？</translation>
+    </message>
+</context>
+<context>
+    <name>CSettingsWindow</name>
+    <message>
+        <source>Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <source>Please enter the new configuration password.</source>
+        <translation>請輸入新配置密碼。</translation>
+    </message>
+    <message>
+        <source>Close to Tray</source>
+        <translation>關閉到工作列</translation>
+    </message>
+    <message>
+        <source>Select Directory</source>
+        <translation>選取目錄</translation>
+    </message>
+    <message>
+        <source>Please enter a program file name</source>
+        <translation>請輸入程式檔名</translation>
+    </message>
+    <message>
+        <source>Folder</source>
+        <translation>資料夾</translation>
+    </message>
+    <message>
+        <source>Prompt before Close</source>
+        <translation>關閉前提示</translation>
+    </message>
+    <message>
+        <source>Process</source>
+        <translation>處理程序</translation>
+    </message>
+    <message>
+        <source>Sandboxie Plus - Settings</source>
+        <translation>Sandboxie Plus - 設定</translation>
+    </message>
+    <message>
+        <source>Please re-enter the new configuration password.</source>
+        <translation>請再次輸入新配置密碼。</translation>
+    </message>
+    <message>
+        <source>Passwords did not match, please retry.</source>
+        <translation>密碼不正確，請重新輸入。</translation>
+    </message>
+</context>
+<context>
+    <name>CSnapshotsWindow</name>
+    <message>
+        <source>Do you really want to delete the selected snapshot?</source>
+        <translation>確定要刪除所選快照？</translation>
+    </message>
+    <message>
+        <source>New Snapshot</source>
+        <translation>新快照</translation>
+    </message>
+    <message>
+        <source>Snapshot</source>
+        <translation>快照</translation>
+    </message>
+    <message>
+        <source>Do you really want to switch the active snapshot? Doing so will delete the current state!</source>
+        <translation>確定要切換正在使用的快照？這樣做會刪除當前狀態！</translation>
+    </message>
+    <message>
+        <source>%1 - Snapshots</source>
+        <translation>%1 - 快照</translation>
+    </message>
+    <message>
+        <source>Please enter a name for the new Snapshot.</source>
+        <translation>請輸入新快照名稱。</translation>
+    </message>
+</context>
+<context>
+    <name>NewBoxWindow</name>
+    <message>
+        <source>Copy options from an existing box:</source>
+        <translation>從已有沙盒複製選項:</translation>
+    </message>
+    <message>
+        <source>Initial sandbox configuration:</source>
+        <translation>初始沙盒配置:</translation>
+    </message>
+    <message>
+        <source>Select restriction/isolation template:</source>
+        <translation>選取限制/隔離模板:</translation>
+    </message>
+    <message>
+        <source>SandboxiePlus new box</source>
+        <translation>SandboxiePlus 新沙盒</translation>
+    </message>
+    <message>
+        <source>Enter a name for the new box:</source>
+        <translation type="vanished">輸入新沙盒名稱:</translation>
+    </message>
+    <message>
+        <source>Sandbox Name:</source>
+        <translation>沙盒名稱:</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsWindow</name>
+    <message>
+        <source>Name</source>
+        <translation>名稱</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>位址</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>類別</translation>
+    </message>
+    <message>
+        <source>Allow only selected programs to start in this sandbox. *</source>
+        <translation>僅允許被選取的程式在此沙盒中啟動。 *</translation>
+    </message>
+    <message>
+        <source>Force Folder</source>
+        <translation>強制執行資料夾</translation>
+    </message>
+    <message>
+        <source>Add IPC Path</source>
+        <translation>新增 IPC 位址</translation>
+    </message>
+    <message>
+        <source>Sandbox Indicator in title:</source>
+        <translation>在標題顯示沙盒標記:</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation>除錯</translation>
+    </message>
+    <message>
+        <source>Users</source>
+        <translation>使用者</translation>
+    </message>
+    <message>
+        <source>&lt;- for this one the above does not apply</source>
+        <translation>&lt;- 因為此原因，以上不套用</translation>
+    </message>
+    <message>
+        <source>Block network files and folders, unless specifically opened.</source>
+        <translation>禁用網路檔案和資料夾，除非額外開啟。</translation>
+    </message>
+    <message>
+        <source>Command Line</source>
+        <translation>命令列</translation>
+    </message>
+    <message>
+        <source>Don&apos;t alter window class names created by sandboxed programs</source>
+        <translation>不要改變由沙盒程式建立的視窗類名</translation>
+    </message>
+    <message>
+        <source>Prevent change to network and firewall parameters</source>
+        <translation>阻止更改網路和防火牆引數</translation>
+    </message>
+    <message>
+        <source>Internet Restrictions</source>
+        <translation>網路限制</translation>
+    </message>
+    <message>
+        <source>Configure which processes can access what resources. Double click on an entry to edit it.
+&apos;Direct&apos; File and Key access only applies to program binaries located outside the sandbox.
+Note that all Close...=!&lt;program&gt;,... exclusions have the same limitations.
+For files access you can use &apos;Direct All&apos; instead to make it apply to all programs.</source>
+        <translation>配置處理程序所訪問的資源。雙擊進入編輯。
+&apos;管理&apos; 檔案和機碼僅適用於沙盒外的程式二進位制檔案。
+注意所有關閉的...=!&lt;程式&gt;,... 例外也有相同限制。
+想要管理檔案訪問可使用 &apos;管理全部&apos; 使其套用至至全部程式。</translation>
+    </message>
+    <message>
+        <source>Log Debug Output to the Trace Log</source>
+        <translation>日誌除錯輸出到追蹤日誌</translation>
+    </message>
+    <message>
+        <source>Forced Programs</source>
+        <translation>強制執行程式</translation>
+    </message>
+    <message>
+        <source>Add Wnd Class</source>
+        <translation>新增視窗類別</translation>
+    </message>
+    <message>
+        <source>Access Tracing</source>
+        <translation>訪問追蹤</translation>
+    </message>
+    <message>
+        <source>File Options</source>
+        <translation>檔案選項</translation>
+    </message>
+    <message>
+        <source>General Options</source>
+        <translation>通用選項</translation>
+    </message>
+    <message>
+        <source>Open Windows Credentials Store</source>
+        <translation>開啟 Windows 憑證儲存空間</translation>
+    </message>
+    <message>
+        <source>kilobytes</source>
+        <translation>KB</translation>
+    </message>
+    <message>
+        <source>Lingering programs will be automatically terminated if they are still running after all other processes have been terminated.
+
+If leader processes are defined, all others are treated as lingering processes.</source>
+        <translation>如果其他所有程式已經終止後，駐留程式仍在運作，將自動終止。
+
+如果導引處理程序已確定，所有其他處理程序將被視為駐留處理程序。</translation>
+    </message>
+    <message>
+        <source>Allow all programs to start in this sandbox.</source>
+        <translation>允許所有程式在此沙盒中啟動。</translation>
+    </message>
+    <message>
+        <source>Enable Immediate Recovery prompt to be able to recover files as soon as thay are created.</source>
+        <translation>啟用快速恢復提示以便建立檔案時能儘快恢復。</translation>
+    </message>
+    <message>
+        <source>General restrictions</source>
+        <translation>通用限制</translation>
+    </message>
+    <message>
+        <source>Move Up</source>
+        <translation>上移</translation>
+    </message>
+    <message>
+        <source>Access</source>
+        <translation>訪問</translation>
+    </message>
+    <message>
+        <source>These options are intended for debugging compatibility issues, please do not use them in production use. </source>
+        <translation>這些選項是計劃除錯裝置而設計的，在日常使用時請不要使用。</translation>
+    </message>
+    <message>
+        <source>Text Filter</source>
+        <translation>文字過濾</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Restrict Resource Access monitor to administrators only</source>
+        <translation>限制資源訪問監視器僅限管理員使用</translation>
+    </message>
+    <message>
+        <source>Protect the sandbox integrity itself</source>
+        <translation>沙盒完整性保護</translation>
+    </message>
+    <message>
+        <source>Add Folder</source>
+        <translation>新增資料夾</translation>
+    </message>
+    <message>
+        <source>Prompt user whether to allow an exemption from the blockade.</source>
+        <translation>提示使用者是否允許例外免於封鎖。</translation>
+    </message>
+    <message>
+        <source>IPC Trace</source>
+        <translation>IPC 追蹤</translation>
+    </message>
+    <message>
+        <source>Limit access to the emulated service control manager to privileged processes</source>
+        <translation>限制訪問模擬服務控制管理員來提權處理程序</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>刪除</translation>
+    </message>
+    <message>
+        <source>Add File/Folder</source>
+        <translation>新增檔案/資料夾</translation>
+    </message>
+    <message>
+        <source>Block internet access for all programs except those added to the list.</source>
+        <translation>禁止所有程式訪問網路，除了這些新增至清單中的。</translation>
+    </message>
+    <message>
+        <source>Issue message 1307 when a program is denied internet access</source>
+        <translation>錯誤程式碼1307，程式被拒絕訪問網路</translation>
+    </message>
+    <message>
+        <source>Compatibility</source>
+        <translation>相容性</translation>
+    </message>
+    <message>
+        <source>Stop Behaviour</source>
+        <translation>停止行為</translation>
+    </message>
+    <message>
+        <source>Note: Programs installed to this sandbox won&apos;t be able to access the internet at all.</source>
+        <translation>注意: 安裝在此沙盒裡的程式將完全無法訪問網路。</translation>
+    </message>
+    <message>
+        <source>Box Options</source>
+        <translation>沙盒選項</translation>
+    </message>
+    <message>
+        <source>Don&apos;t allow sandboxed processes to see processes running in other boxes</source>
+        <translation>不允許沙盒化的處理程序檢視其他沙盒裡處理程序的運作</translation>
+    </message>
+    <message>
+        <source>Add Group</source>
+        <translation>新增群組</translation>
+    </message>
+    <message>
+        <source>Sandboxed window border:</source>
+        <translation>沙盒化視窗邊框:</translation>
+    </message>
+    <message>
+        <source>Prevent selected programs from starting in this sandbox.</source>
+        <translation>阻止所選程式在此沙盒中啟動。</translation>
+    </message>
+    <message>
+        <source>Miscellaneous</source>
+        <translation>其他</translation>
+    </message>
+    <message>
+        <source>Issue message 2102 when a file is too large</source>
+        <translation>問題程式碼 2102，檔案過大</translation>
+    </message>
+    <message>
+        <source>File Recovery</source>
+        <translation>檔案恢復</translation>
+    </message>
+    <message>
+        <source>Box Delete options</source>
+        <translation>沙盒刪除選項</translation>
+    </message>
+    <message>
+        <source>Pipe Trace</source>
+        <translation>Pipe 追蹤</translation>
+    </message>
+    <message>
+        <source>File Trace</source>
+        <translation>檔案追蹤</translation>
+    </message>
+    <message>
+        <source>Program</source>
+        <translation>程式</translation>
+    </message>
+    <message>
+        <source>Add Process</source>
+        <translation>新增處理程序</translation>
+    </message>
+    <message>
+        <source>Add Program</source>
+        <translation>新增程式</translation>
+    </message>
+    <message>
+        <source>Filter Categories</source>
+        <translation>篩選類別</translation>
+    </message>
+    <message>
+        <source>Copy file size limit:</source>
+        <translation>複製檔案大小限制:</translation>
+    </message>
+    <message>
+        <source>Open System Protected Storage</source>
+        <translation>開放系統保護儲存空間</translation>
+    </message>
+    <message>
+        <source>Protect the system from sandboxed processes</source>
+        <translation>保護系統免受來自沙盒化處理程序的訪問</translation>
+    </message>
+    <message>
+        <source>Add Leader Program</source>
+        <translation>新增導引程式</translation>
+    </message>
+    <message>
+        <source>SandboxiePlus Options</source>
+        <translation>SandboxiePlus 選項</translation>
+    </message>
+    <message>
+        <source>Category</source>
+        <translation>類別</translation>
+    </message>
+    <message>
+        <source>Drop rights from Administrators and Power Users groups</source>
+        <translation>撤銷管理員和超級使用者群組的授權</translation>
+    </message>
+    <message>
+        <source>Add Reg Key</source>
+        <translation>新增登錄檔機碼</translation>
+    </message>
+    <message>
+        <source>Sandbox protection</source>
+        <translation>沙盒保護</translation>
+    </message>
+    <message>
+        <source>You can group programs together and give them a group name.  Program groups can be used with some of the settings instead of program names.</source>
+        <translation>您可將程式分組並且為它們設定群組名稱。程式群組可以代替程式名稱被用於一些設定。</translation>
+    </message>
+    <message>
+        <source>Protect sandboxed SYSTEM processes from unprivileged unsandboxed processes</source>
+        <translation>保護沙盒化系統處理程序免受來自未授權的未沙盒化處理程序訪問</translation>
+    </message>
+    <message>
+        <source>COM Class Trace</source>
+        <translation>COM 元件追蹤</translation>
+    </message>
+    <message>
+        <source>Add Command</source>
+        <translation>新增命令</translation>
+    </message>
+    <message>
+        <source>Hide Processes</source>
+        <translation>隱藏處理程序</translation>
+    </message>
+    <message>
+        <source>When the Quick Recovery function is invoked, the following folders will be checked for sandboxed content. </source>
+        <translation>當快速恢復功能被啟用，將檢查下列資料夾沙盒化內容。</translation>
+    </message>
+    <message>
+        <source>px Width</source>
+        <translation>px 寬度</translation>
+    </message>
+    <message>
+        <source>Add User</source>
+        <translation>新增使用者</translation>
+    </message>
+    <message>
+        <source>Programs entered here, or programs started from entered locations, will be put in this sandbox automatically, unless thay are explicitly started in another sandbox.</source>
+        <translation>此處輸入的程式，或指定位置啟動的程式，將自動加入此沙盒，除非它們被確定已在其他沙盒啟動。</translation>
+    </message>
+    <message>
+        <source>Force Program</source>
+        <translation>強制運作程式</translation>
+    </message>
+    <message>
+        <source>WARNING, these options can disable core security guarantees and break sandbox security!!!</source>
+        <translation>警告，這些選項可以使核心安全保障失效並且破壞沙盒安全!!!</translation>
+    </message>
+    <message>
+        <source>Edit ini</source>
+        <translation>編輯 ini</translation>
+    </message>
+    <message>
+        <source>Show Templates</source>
+        <translation>顯示模板</translation>
+    </message>
+    <message>
+        <source>Ignore Folder</source>
+        <translation>忽略資料夾</translation>
+    </message>
+    <message>
+        <source>GUI Trace</source>
+        <translation>GUI 追蹤</translation>
+    </message>
+    <message>
+        <source>Key Trace</source>
+        <translation>機碼追蹤</translation>
+    </message>
+    <message>
+        <source>Tracing</source>
+        <translation>追蹤</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>外觀</translation>
+    </message>
+    <message>
+        <source>Add sandboxed processes to job objects (recommended)</source>
+        <translation>新增沙盒化處理程序到工作物件(建議)</translation>
+    </message>
+    <message>
+        <source>Remove Program</source>
+        <translation>刪除程式</translation>
+    </message>
+    <message>
+        <source>You can exclude folders and file types (or file extensions) from Immediate Recovery.</source>
+        <translation>您可從快速恢復中排除資料夾和檔案類別 (或副檔名) 。</translation>
+    </message>
+    <message>
+        <source>Run Menu</source>
+        <translation>執行選單</translation>
+    </message>
+    <message>
+        <source>App Templates</source>
+        <translation>應用程式模板</translation>
+    </message>
+    <message>
+        <source>Remove User</source>
+        <translation>刪除使用者</translation>
+    </message>
+    <message>
+        <source>Ignore Extension</source>
+        <translation>忽略副檔名</translation>
+    </message>
+    <message>
+        <source>Move Down</source>
+        <translation>下移</translation>
+    </message>
+    <message>
+        <source>Protect this sandbox from deletion or emptying</source>
+        <translation>保護此沙盒刪除或清空</translation>
+    </message>
+    <message>
+        <source>Add user accounts and user groups to the list below to limit use of the sandbox to only those accounts.  If the list is empty, the sandbox can be used by all user accounts.
+
+Note:  Forced Programs and Force Folders settings for a sandbox do not apply to user accounts which cannot use the sandbox.</source>
+        <translation>新增使用者賬戶和使用者群組到下面清單中來僅限這些賬戶使用沙盒。如果清單內容為空，所有賬戶都將可以使用沙盒。
+
+注意: 沙盒的強制執行程式和強制執行資料夾設定不接受不能執行沙盒的賬戶。</translation>
+    </message>
+    <message>
+        <source>* Note: Programs installed to this sandbox won&apos;t be able to start at all.</source>
+        <translation>* 注意: 安裝在此沙盒裡的程式將完全無法啟動。</translation>
+    </message>
+    <message>
+        <source>This list contains a large amount of sandbox compatibility enhancing templates</source>
+        <translation>此清單包含大量沙盒相容性增強模板</translation>
+    </message>
+    <message>
+        <source>Add Lingering Program</source>
+        <translation>新增駐留程式</translation>
+    </message>
+    <message>
+        <source>Program Groups</source>
+        <translation>程式群組</translation>
+    </message>
+    <message>
+        <source>Issue message 1308 when a program fails to start</source>
+        <translation>錯誤程式碼 1308，程式啟動失敗</translation>
+    </message>
+    <message>
+        <source>Resource Access</source>
+        <translation>資源訪問</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation>進階選項</translation>
+    </message>
+    <message>
+        <source>Hide host processes from processes running in the sandbox.</source>
+        <translation>隱藏沙盒中執行中處理程序的主處理程序。</translation>
+    </message>
+    <message>
+        <source>File Migration</source>
+        <translation>檔案轉移</translation>
+    </message>
+    <message>
+        <source>Auto delete content when last sandboxed process terminates</source>
+        <translation>當最後的沙盒化的處理程序終止後自動刪除內容</translation>
+    </message>
+    <message>
+        <source>Add COM Object</source>
+        <translation>新增 COM 物件</translation>
+    </message>
+    <message>
+        <source>You can configure custom entries for the sandbox run menu.</source>
+        <translation>您可為沙盒執行選單配置自訂條目。</translation>
+    </message>
+    <message>
+        <source>Start Restrictions</source>
+        <translation>啟動限制</translation>
+    </message>
+    <message>
+        <source>Force usage of custom dummy Manifest files (legacy behaviour)</source>
+        <translation>強制使用自訂虛擬 Manifest 檔案(遺留行為)</translation>
+    </message>
+    <message>
+        <source>Edit ini Section</source>
+        <translation>編輯 ini 部分</translation>
+    </message>
+    <message>
+        <source>Block access to the printer spooler</source>
+        <translation>阻止訪問列印服務</translation>
+    </message>
+    <message>
+        <source>Allow the print spooler to print to files outside the sandbox</source>
+        <translation>允許列印服務在沙盒外列印檔案</translation>
+    </message>
+    <message>
+        <source>Printing</source>
+        <translation>列印</translation>
+    </message>
+    <message>
+        <source>Remove spooler restriction, printers can be installed outside the sandbox</source>
+        <translation>移除列印限制，印表機可安裝至沙盒外</translation>
+    </message>
+    <message>
+        <source>Add program</source>
+        <translation>新增程式</translation>
+    </message>
+    <message>
+        <source>Auto Start</source>
+        <translation>自動啟動</translation>
+    </message>
+    <message>
+        <source>Here you can specify programs and/or services that are to be started automatically in the sandbox when it is activated</source>
+        <translation>這裡您可以指定將在沙盒啟用時自動啟動的程式或服務</translation>
+    </message>
+    <message>
+        <source>Add service</source>
+        <translation>新增服務</translation>
+    </message>
+    <message>
+        <source>Do not start sandboxed services using a system token (recommended)</source>
+        <translation>不啟動使用系統令牌的沙盒化服務 (建議)</translation>
+    </message>
+    <message>
+        <source>Allow access to Smart Cards</source>
+        <translation>允許訪問智慧卡片</translation>
+    </message>
+    <message>
+        <source>Lift security restrictions</source>
+        <translation>提升安全限制</translation>
+    </message>
+    <message>
+        <source>Sandbox isolation</source>
+        <translation>沙盒隔離</translation>
+    </message>
+    <message>
+        <source>Auto Exec</source>
+        <translation>自動執行</translation>
+    </message>
+    <message>
+        <source>Here you can specify a list of commands that are executed every time the sandbox is initially populated.</source>
+        <translation>這裡您可以指定每次沙盒啟動被執行的命令清單。</translation>
+    </message>
+    <message>
+        <source>Log all access events as seen by the driver to the resource access log.
+
+This options set the event mask to &quot;*&quot; - All access events
+You can customize the logging using the ini by specifying
+&quot;A&quot; - Allowed accesses
+&quot;D&quot; - Denied accesses
+&quot;I&quot; - Ignore access requests
+instead of &quot;*&quot;.</source>
+        <translation>將驅動程式所見所有訪問事件記錄到資源訪問日誌中。
+
+這些選項設定事件標記到 &quot;*&quot; - 所有訪問事件
+您可以通過 ini 來詳細訂製記錄
+&quot;A&quot; - 允許訪問
+&quot;D&quot; - 拒絕訪問
+&quot;I&quot; - 忽略拒絕請求
+代替 &quot;*&quot;.</translation>
+    </message>
+</context>
+<context>
+    <name>PopUpWindow</name>
+    <message>
+        <source>SandboxiePlus Notifications</source>
+        <translation>SandboxiePlus 通知</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Drive %1</source>
+        <translation>磁碟 %1</translation>
+    </message>
+</context>
+<context>
+    <name>QPlatformTheme</name>
+    <message>
+        <source>OK</source>
+        <translation type="vanished">確定</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation type="vanished">套用</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="vanished">取消</translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="vanished">&amp;是</translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="vanished">&amp;否</translation>
+    </message>
+</context>
+<context>
+    <name>RecoveryWindow</name>
+    <message>
+        <source>Close</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <source>SandboxiePlus Settings</source>
+        <translation>SandboxiePlus 設定</translation>
+    </message>
+    <message>
+        <source>Add Folder</source>
+        <translation>新增資料夾</translation>
+    </message>
+    <message>
+        <source>Recover to</source>
+        <translation>恢復至</translation>
+    </message>
+    <message>
+        <source>Recover</source>
+        <translation>恢復</translation>
+    </message>
+    <message>
+        <source>Refresh</source>
+        <translation>重新整理</translation>
+    </message>
+    <message>
+        <source>Delete all</source>
+        <translation>刪除全部</translation>
+    </message>
+    <message>
+        <source>Show All Files</source>
+        <translation>顯示所有檔案</translation>
+    </message>
+    <message>
+        <source>TextLabel</source>
+        <translation>文字標籤</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsWindow</name>
+    <message>
+        <source>Name</source>
+        <translation>名稱</translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation>路徑</translation>
+    </message>
+    <message>
+        <source>Change Password</source>
+        <translation>更改密碼</translation>
+    </message>
+    <message>
+        <source>Clear password when main window becomes hidden</source>
+        <translation>主視窗隱藏時清除密碼</translation>
+    </message>
+    <message>
+        <source>SandboxiePlus Settings</source>
+        <translation>SandboxiePlus 設定</translation>
+    </message>
+    <message>
+        <source>Password must be entered in order to make changes</source>
+        <translation>必須輸入密碼以進行更改</translation>
+    </message>
+    <message>
+        <source>Check periodically for updates of Sandboxie-Plus</source>
+        <translation>定期檢查 Sandboxie-Plus 的更新</translation>
+    </message>
+    <message>
+        <source>General Options</source>
+        <translation>一般選項</translation>
+    </message>
+    <message>
+        <source>Program Restrictions</source>
+        <translation>程式限制</translation>
+    </message>
+    <message>
+        <source>Restart required (!)</source>
+        <translation>需要重新啟動 (!)</translation>
+    </message>
+    <message>
+        <source>Tray options</source>
+        <translation>磁碟選項</translation>
+    </message>
+    <message>
+        <source>Use Dark Theme</source>
+        <translation>使用暗色主題</translation>
+    </message>
+    <message>
+        <source>Enable</source>
+        <translation>啟用</translation>
+    </message>
+    <message>
+        <source>Add Folder</source>
+        <translation>新增資料夾</translation>
+    </message>
+    <message>
+        <source>Only Administrator user accounts can make changes</source>
+        <translation>僅限管理員賬戶進行更改</translation>
+    </message>
+    <message>
+        <source>Config protection</source>
+        <translation>配置保護</translation>
+    </message>
+    <message>
+        <source>Sandbox &lt;a href=&quot;sbie://docs/keyrootpath&quot;&gt;registry root&lt;/a&gt;: </source>
+        <translation>沙盒 &lt;a href=&quot;sbie://docs/keyrootpath&quot;&gt;登錄檔根目錄&lt;/a&gt;: </translation>
+    </message>
+    <message>
+        <source>Add Program</source>
+        <translation>新增程式</translation>
+    </message>
+    <message>
+        <source>Sandboxie has detected the following software applications in your system. Click OK to apply configuration settings, which will improve compatibility with these applications. These configuration settings will have effect in all existing sandboxes and in any new sandboxes.</source>
+        <translation>Sandboxie 在您系統中檢測到下列軟體程式. 點選 確定 接受配置設定，將增強這些軟體程式的相容性。這些配置設定將影響所有已存在的沙盒和之後的新沙盒。</translation>
+    </message>
+    <message>
+        <source>Watch Sandboxie.ini for changes</source>
+        <translation>檢視 Sandboxie.ini 變更</translation>
+    </message>
+    <message>
+        <source>Show Sys-Tray</source>
+        <translation>系統工具列顯示</translation>
+    </message>
+    <message>
+        <source>Open urls from this ui sandboxed</source>
+        <translation>在此使用者介面開啟的連結都將沙盒化</translation>
+    </message>
+    <message>
+        <source>In the future, don&apos;t check software compatibility</source>
+        <translation>以後不再檢查軟體相容性</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>禁用</translation>
+    </message>
+    <message>
+        <source>When any of the following programs is launched outside any sandbox, Sandboxie will issue message SBIE1301.</source>
+        <translation>當下列程式在任意沙盒之外啟動時，Sandboxie 將出現錯誤程式碼 SBIE1301。</translation>
+    </message>
+    <message>
+        <source>Remove Program</source>
+        <translation>刪除程式</translation>
+    </message>
+    <message>
+        <source>Software Compatibility</source>
+        <translation>軟體相容性</translation>
+    </message>
+    <message>
+        <source>On main window close:</source>
+        <translation>主窗體關閉時:</translation>
+    </message>
+    <message>
+        <source>Add &apos;Run Sandboxed&apos; to the explorer context menu</source>
+        <translation>在檔案總管新增&apos;在沙盒中執行&apos; </translation>
+    </message>
+    <message>
+        <source>Issue message 1308 when a program fails to start</source>
+        <translation>錯誤程式碼 1308，程式啟動失敗</translation>
+    </message>
+    <message>
+        <source>Sandbox default</source>
+        <translation>沙盒預設</translation>
+    </message>
+    <message>
+        <source>Separate user folders</source>
+        <translation>獨立使用者資料夾</translation>
+    </message>
+    <message>
+        <source>Advanced Options</source>
+        <translation>進階選項</translation>
+    </message>
+    <message>
+        <source>Prevent the listed programs from starting on this system</source>
+        <translation>阻止清單中程式在此系統中啟動</translation>
+    </message>
+    <message>
+        <source>Only Administrator user accounts can use Disable Forced Programs command</source>
+        <translation>僅管理員賬戶可使用禁用強制執行程式命令</translation>
+    </message>
+    <message>
+        <source>Sandbox &lt;a href=&quot;sbie://docs/ipcrootpath&quot;&gt;ipc root&lt;/a&gt;: </source>
+        <translation>沙盒 &lt;a href=&quot;sbie://docs/ipcrootpath&quot;&gt;IPC 根目錄&lt;/a&gt;: </translation>
+    </message>
+    <message>
+        <source>Show Notifications for relevant log Messages</source>
+        <translation>顯示相關日誌訊息的通知</translation>
+    </message>
+    <message>
+        <source>Sandbox &lt;a href=&quot;sbie://docs/filerootpath&quot;&gt;file system root&lt;/a&gt;: </source>
+        <translation>沙盒 &lt;a href=&quot;sbie://docs/filerootpath&quot;&gt;檔案系統根目錄&lt;/a&gt;: </translation>
+    </message>
+    <message>
+        <source>Portable root folder</source>
+        <translation>便攜化根目錄</translation>
+    </message>
+    <message>
+        <source>Start UI with Windows</source>
+        <translation>開機啟動 UI</translation>
+    </message>
+    <message>
+        <source>Start UI when a sandboxed process is started</source>
+        <translation>當沙盒化處理程序啟動時啟動 UI</translation>
+    </message>
+    <message>
+        <source>Show first recovery window when emptying sandboxes</source>
+        <translation>當清空沙盒時顯示第一個恢復視窗</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>...</translation>
+    </message>
+    <message>
+        <source>Other settings</source>
+        <translation>其他設定</translation>
+    </message>
+</context>
+<context>
+    <name>SnapshotsWindow</name>
+    <message>
+        <source>Name:</source>
+        <translation>名稱:</translation>
+    </message>
+    <message>
+        <source>Remove Snapshot</source>
+        <translation>刪除快照</translation>
+    </message>
+    <message>
+        <source>SandboxiePlus Settings</source>
+        <translation>SandboxiePlus 設定</translation>
+    </message>
+    <message>
+        <source>Description:</source>
+        <translation>說明:</translation>
+    </message>
+    <message>
+        <source>Go to Snapshot</source>
+        <translation>進入快照</translation>
+    </message>
+    <message>
+        <source>Take Snapshot</source>
+        <translation>抓取快照</translation>
+    </message>
+    <message>
+        <source>Selected Snapshot Details</source>
+        <translation>所選快照內容</translation>
+    </message>
+    <message>
+        <source>Snapshot Actions</source>
+        <translation>快照行為</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Based on Simplified Chinese (zh) strings, with some improvements and update
the zh(fully as zh-CN, used in China Mainland, displayed as 简体中文) is not equals to zh-TW(used in Taiwan, displayed as 正體中文)