### PR TITLE
Fix: elevated-rights-handle visible in user space.

### DIFF
--- a/Sandboxie/core/drv/ipc.c
+++ b/Sandboxie/core/drv/ipc.c
@@ -1164,11 +1164,10 @@ _FX NTSTATUS Ipc_Api_DuplicateObject(PROCESS *proc, ULONG64 *parms)
 
         status = NtDuplicateObject(
                         SourceProcessHandle, SourceHandle,
-                        TargetProcessHandle, TargetHandle,
+                        TargetProcessHandle, &TargetHandleValue,
                         DesiredAccess, HandleAttributes,
                         Options & ~DUPLICATE_CLOSE_SOURCE);
 
-        TargetHandleValue = *TargetHandle;
         *TargetHandle = NULL;
 
         if (NT_SUCCESS(status)) {


### PR DESCRIPTION
TargetHandle references an address in user space and transiently contains a handle with elevated rights. A user thread can steal the handle by constantly polling with InterlockedCompareExchange.

Please review carefully. I'm not set up to test-run driver builds.