### PR TITLE
Fix byte-len vs wchar-len error

### DIFF
--- a/Sandboxie/apps/control/BoxPage.cpp
+++ b/Sandboxie/apps/control/BoxPage.cpp
@@ -966,7 +966,7 @@ void CBoxPage::Appearance_OnOK(CBox &box)
         BOOL enable = (pCheckBox3->GetCheck() == BST_CHECKED ? TRUE : FALSE);
         BOOL title  = (pCheckBox4->GetCheck() == BST_CHECKED ? TRUE : FALSE);
         CString str;
-        GetDlgItem(ID_MIGRATE_KB)->GetWindowText(str);
+        GetDlgItem(ID_BORDER_WIDTH)->GetWindowText(str);
         int width = _wtoi(str);
         ok = box.SetBorder(enable, Appearance_BorderColor, title, width);
     }

--- a/Sandboxie/core/drv/session.c
+++ b/Sandboxie/core/drv/session.c
@@ -974,11 +974,11 @@ _FX NTSTATUS Session_Api_MonitorGetEx(PROCESS *proc, ULONG64 *parms)
     if (log_tid != NULL)
         ProbeForWrite(log_tid, sizeof(ULONG64), sizeof(ULONG64));
 
-	log_len = args->log_len.val / sizeof(WCHAR);
+	log_len = args->log_len.val / sizeof(WCHAR) * sizeof(WCHAR);
     if (!log_len)
         return STATUS_INVALID_PARAMETER;
 	log_data = args->log_ptr.val;
-    ProbeForWrite(log_data, log_len * sizeof(WCHAR), sizeof(WCHAR));
+    ProbeForWrite(log_data, log_len, sizeof(WCHAR));
 
     *log_type = 0;
 	if (log_pid != NULL)

--- a/Sandboxie/core/drv/session.c
+++ b/Sandboxie/core/drv/session.c
@@ -504,7 +504,8 @@ _FX NTSTATUS Session_Api_DisableForce(PROCESS *proc, ULONG64 *parms)
     in_flag = args->set_flag.val;
     if (in_flag) {
         ProbeForRead(in_flag, sizeof(ULONG), sizeof(ULONG));
-        if (*in_flag) {
+        ULONG in_flag_value = *in_flag;
+        if (in_flag_value) {
 
             if (! Session_CheckAdminAccess(L"ForceDisableAdminOnly"))
                     return STATUS_ACCESS_DENIED;
@@ -513,7 +514,7 @@ _FX NTSTATUS Session_Api_DisableForce(PROCESS *proc, ULONG64 *parms)
         } else
             time.QuadPart = 0;
 
-        if (*in_flag == DISABLE_JUST_THIS_PROCESS) {
+        if (in_flag_value == DISABLE_JUST_THIS_PROCESS) {
 
             Process_DfpInsert(PROCESS_TERMINATED, PsGetCurrentProcessId());
 


### PR DESCRIPTION
log_len is initially treated like len in wchars, later from lines 1037++ it's treated like len in bytes.

For example, if args->log_len.val == 2, you get a wrap-around in 1037, an out-of-bounds and out-of-ProbeForWrite write error in 1040.
