### PR TITLE
Add VLC Media Player and the MediaPlayer class to the templates

### DIFF
--- a/Sandboxie/apps/control/AppPage.cpp
+++ b/Sandboxie/apps/control/AppPage.cpp
@@ -1020,13 +1020,6 @@ void CAppPage::AddPages(CPropertySheet &sheet, const CString &BoxName)
     info.WithLink = FALSE;
     info.WithCreate = FALSE;
     m_app_pages.AddTail(new CAppPage(&info, BoxName));
-    
-    info.ClassName = L"MediaPlayer";
-    info.TitleId = MSG_4391;
-    info.LabelId = MSG_4392;
-    info.WithLink = FALSE;
-    info.WithCreate = FALSE;
-    m_app_pages.AddTail(new CAppPage(&info, BoxName));
 
     info.ClassName = L"Print";
     info.TitleId = MSG_4224;
@@ -1046,6 +1039,13 @@ void CAppPage::AddPages(CPropertySheet &sheet, const CString &BoxName)
     info.TitleId = MSG_4228;
     info.LabelId = MSG_4207;
     info.WithLink = TRUE;
+    info.WithCreate = FALSE;
+    m_app_pages.AddTail(new CAppPage(&info, BoxName));
+    
+    info.ClassName = L"MediaPlayer";
+    info.TitleId = MSG_4393;
+    info.LabelId = MSG_4394;
+    info.WithLink = FALSE;
     info.WithCreate = FALSE;
     m_app_pages.AddTail(new CAppPage(&info, BoxName));
 

--- a/Sandboxie/apps/control/ThirdPartyDialog.cpp
+++ b/Sandboxie/apps/control/ThirdPartyDialog.cpp
@@ -816,7 +816,8 @@ void CThirdPartyDialog::CollectTemplates()
     ini.GetTemplateNames(L"Desktop", names);
     ini.GetTemplateNames(L"Download", names);
     ini.GetTemplateNames(L"Misc", names);
-	ini.GetTemplateNames(L"WebBrowser", names);
+    ini.GetTemplateNames(L"WebBrowser", names);
+    ini.GetTemplateNames(L"MediaPlayer", names);
 
     m_templates.RemoveAll();
     while (! names.IsEmpty()) {

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2639,7 +2639,7 @@ Tmpl.Class=MediaPlayer
 OpenFilePath=vlc.exe,%AppData%\vlc\*
 
 [Template_VLC_DirectAccess_Photos]
-Tmpl.Title=#4395
+Tmpl.Title=#4395,VLC
 Tmpl.Class=MediaPlayer
 OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
 

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2625,6 +2625,25 @@ OpenIpcPath=*\BaseNamedObjects*\ZoomTextRunning*
 OpenWinClass=ZT9MainWindow
 
 #
+# Media Players
+#
+
+[Template_VLC_Force]
+Tmpl.Title=#4395
+Tmpl.Class=MediaPlayer
+ForceProcess=vlc.exe
+
+[Template_VLC_DirectAccess_Profile]
+Tmpl.Title=#4396
+Tmpl.Class=MediaPlayer
+OpenFilePath=vlc.exe,%AppData%\vlc\*
+
+[Template_VLC_DirectAccess_Photos]
+Tmpl.Title=#4397
+Tmpl.Class=MediaPlayer
+OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
+
+#
 # Download Managers
 #
 
@@ -2676,26 +2695,6 @@ OpenIpcPath=*\BaseNamedObjects*\{F22F2429-009C-4B5D-959F-519B59E25176}
 OpenIpcPath=*\BaseNamedObjects*\{6560EAD3-F709-4B66-B90B-EA2D2C85AE3B}
 OpenIpcPath=*\BaseNamedObjects*\{3EA1EB13-8045-44FC-AD59-B4F05478B40D}
 OpenIpcPath=*\BaseNamedObjects*\{034DBD6D-6784-4CB3-97D8-749947D01F72}
-
-#
-# Media Players
-#
-
-[Template_VLC_Force]
-Tmpl.Title=#4395
-Tmpl.Class=MediaPlayer
-ForceProcess=vlc.exe
-
-[Template_VLC_DirectAccess_Profile]
-Tmpl.Title=#4396
-Tmpl.Class=MediaPlayer
-OpenFilePath=vlc.exe,%AppData%\vlc\*
-
-[Template_VLC_DirectAccess_Photos]
-Tmpl.Title=#4397
-Tmpl.Class=MediaPlayer
-OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
-
 
 #
 # Other

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2629,7 +2629,7 @@ OpenWinClass=ZT9MainWindow
 #
 
 [Template_VLC_Force]
-Tmpl.Title=#4395
+Tmpl.Title=#4323,VLC
 Tmpl.Class=MediaPlayer
 ForceProcess=vlc.exe
 

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2634,12 +2634,12 @@ Tmpl.Class=MediaPlayer
 ForceProcess=vlc.exe
 
 [Template_VLC_DirectAccess_Profile]
-Tmpl.Title=#4396
+Tmpl.Title=#4338,VLC
 Tmpl.Class=MediaPlayer
 OpenFilePath=vlc.exe,%AppData%\vlc\*
 
 [Template_VLC_DirectAccess_Photos]
-Tmpl.Title=#4397
+Tmpl.Title=#4395
 Tmpl.Class=MediaPlayer
 OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
 

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2678,6 +2678,26 @@ OpenIpcPath=*\BaseNamedObjects*\{3EA1EB13-8045-44FC-AD59-B4F05478B40D}
 OpenIpcPath=*\BaseNamedObjects*\{034DBD6D-6784-4CB3-97D8-749947D01F72}
 
 #
+# Media Players
+#
+
+[Template_VLC_Force]
+Tmpl.Title=Force VLC Media Player to run in the Sandbox
+Tmpl.Class=MediaPlayer
+ForceProcess=vlc.exe
+
+[Template_VLC_DirectAccess_Profile]
+Tmpl.Title=Allow VLC Media Player access to the VLC AppData folder
+Tmpl.Class=MediaPlayer
+OpenFilePath=vlc.exe,%AppData%\vlc\*
+
+[Template_VLC_DirectAccess_Photos]
+Tmpl.Title=Allow VLC Media Player access to the photo folder for easier screenshotting
+Tmpl.Class=MediaPlayer
+OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
+
+
+#
 # Other
 #
 

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2682,17 +2682,17 @@ OpenIpcPath=*\BaseNamedObjects*\{034DBD6D-6784-4CB3-97D8-749947D01F72}
 #
 
 [Template_VLC_Force]
-Tmpl.Title=Force VLC Media Player to run in the Sandbox
+Tmpl.Title=#4395
 Tmpl.Class=MediaPlayer
 ForceProcess=vlc.exe
 
 [Template_VLC_DirectAccess_Profile]
-Tmpl.Title=Allow VLC Media Player access to the VLC AppData folder
+Tmpl.Title=#4396
 Tmpl.Class=MediaPlayer
 OpenFilePath=vlc.exe,%AppData%\vlc\*
 
 [Template_VLC_DirectAccess_Photos]
-Tmpl.Title=Allow VLC Media Player access to the photo folder for easier screenshotting
+Tmpl.Title=#4397
 Tmpl.Class=MediaPlayer
 OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
 

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3289,14 +3289,22 @@ The following exclusions allow Email readers running in this sandbox to access m
 .
 
 4393;txt;01
-Force VLC Media Player to run in the Sandbox
+Media Players
 .
 
 4394;txt;01
+The following exclusions allow Media players running in this sandbox to access files outside the sandbox.
+.
+
+4395;txt;01
+Force VLC Media Player to run in the Sandbox
+.
+
+4396;txt;01
 Allow VLC Media Player access to the VLC AppData folder
 .
-4395;txt;01
-Allow VLC Media Player access to the photo folder for easier screenshotting
+4397;txt;01
+Allow VLC Media Player access to the Photo folder for easier screenshotting
 .
 
 

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3297,14 +3297,15 @@ The following exclusions allow Media players running in this sandbox to access f
 .
 
 4395;txt;01
-Force VLC Media Player to run in the Sandbox
+Force VLC Media Player to run in this Sandbox.
 .
 
 4396;txt;01
-Allow VLC Media Player access to the VLC AppData folder
+Allow VLC Media Player access to the VLC AppData folder.
 .
+
 4397;txt;01
-Allow VLC Media Player access to the Photo folder for easier screenshotting
+Allow VLC Media Player access to the Photo folder for easier screenshotting.
 .
 
 

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3308,7 +3308,6 @@ Allow VLC Media Player access to the VLC AppData folder.
 Allow VLC Media Player access to the Photo folder for easier screenshotting.
 .
 
-
 #----------------------------------------------------------------------------
 # Sandboxie Control:  Sandbox Settings:  User Accounts
 #----------------------------------------------------------------------------

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3297,15 +3297,7 @@ The following exclusions allow Media players running in this sandbox to access f
 .
 
 4395;txt;01
-Force VLC Media Player to run in this Sandbox.
-.
-
-4396;txt;01
-Allow VLC Media Player access to the VLC AppData folder.
-.
-
-4397;txt;01
-Allow VLC Media Player access to the Photo folder for easier screenshotting.
+Allow VLC access to the Photo folder for easier screenshotting.
 .
 
 #----------------------------------------------------------------------------

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3297,7 +3297,7 @@ The following exclusions allow Media players running in this sandbox to access f
 .
 
 4395;txt;01
-Allow VLC access to the Photo folder for easier screenshotting.
+Allow VLC direct access to the Photo folder for easier screenshotting.
 .
 
 #----------------------------------------------------------------------------

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3288,6 +3288,18 @@ Email Reader
 The following exclusions allow Email readers running in this sandbox to access mailbox files outside the sandbox.
 .
 
+4393;txt;01
+Force VLC Media Player to run in the Sandbox
+.
+
+4394;txt;01
+Allow VLC Media Player access to the VLC AppData folder
+.
+4395;txt;01
+Allow VLC Media Player access to the photo folder for easier screenshotting
+.
+
+
 #----------------------------------------------------------------------------
 # Sandboxie Control:  Sandbox Settings:  User Accounts
 #----------------------------------------------------------------------------

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3297,7 +3297,7 @@ The following exclusions allow Media players running in this sandbox to access f
 .
 
 4395;txt;01
-Allow VLC direct access to the Photo folder for easier screenshotting.
+Allow VLC direct access to the Photo folder for easier screen capture.
 .
 
 #----------------------------------------------------------------------------

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3297,7 +3297,7 @@ The following exclusions allow Media players running in this sandbox to access f
 .
 
 4395;txt;01
-Allow VLC direct access to the Photo folder for easier screen capture.
+Allow %2 direct access to the Photo folder for easier screen capture.
 .
 
 #----------------------------------------------------------------------------

--- a/SandboxiePlus/QSbieAPI/Sandboxie/SbieTemplates.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/SbieTemplates.cpp
@@ -264,6 +264,7 @@ void CSbieTemplates::CollectTemplates()
 	Templates.append(GetTemplateNames("Download"));
 	Templates.append(GetTemplateNames("Misc"));
 	Templates.append(GetTemplateNames("WebBrowser"));
+	Templates.append(GetTemplateNames("VideoPlayer"));
 
 	foreach(const QString& Template, Templates)
 		m_Templates.insert(Template, 0);

--- a/SandboxiePlus/QSbieAPI/Sandboxie/SbieTemplates.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/SbieTemplates.cpp
@@ -264,7 +264,7 @@ void CSbieTemplates::CollectTemplates()
 	Templates.append(GetTemplateNames("Download"));
 	Templates.append(GetTemplateNames("Misc"));
 	Templates.append(GetTemplateNames("WebBrowser"));
-	Templates.append(GetTemplateNames("VideoPlayer"));
+	Templates.append(GetTemplateNames("MediaPlayer"));
 
 	foreach(const QString& Template, Templates)
 		m_Templates.insert(Template, 0);


### PR DESCRIPTION
Hello! I've added VLC Media Player to the templates. I've created the new "MediaPlayer" class for it, and I'm planning on expanding that class with MPC-HC if you're OK with this pull request :)

Edit: These templates are waiting for this one to be submitted:
MPC-HC, MPC-BE, PotPlayer, KMPlayer, SMPlayer
SumatraPDF, Foxit Reader

I've also added an option for VLC to access the AppData in order to save the settings, and another one for access to the pictures folder to save screenshots.

Tested by me, and it works great.