### PR TITLE
Removes mentions of a paid version in the Swedish translation

### DIFF
--- a/Sandboxie/msgs/Text-Swedish-1053.txt
+++ b/Sandboxie/msgs/Text-Swedish-1053.txt
@@ -2919,7 +2919,7 @@ Följande undantag tillåter webbläsare i sandlådan att göra ändringar utanf
 .
 
 4323;txt;01
-Tvinga %2 att köra i denna sandlåda (bara i betalversionen av Sandboxie)
+Tvinga %2 att köra i denna sandlåda
 .
 
 4325;txt;02


### PR DESCRIPTION
As it is now, almost every template in the Swedish translation mentions features only available in a "paid version"
This is now no longer the case.