### PR TITLE
Add template for Popcorn Time from popcorntime.app

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2753,7 +2753,7 @@ Tmpl.Title=#4323,Popcorn Time (popcorntime.app)
 Tmpl.Class=TorrentClient
 ForceProcess=Popcorn-Time.exe
 
-[Template_BiglyBT_DirectAccess_Profile]
+[Template_Popcorn-Time_DirectAccess_Profile]
 Tmpl.Title=#4338,Popcorn Time (popcorntime.app)
 Tmpl.Class=TorrentClient
 OpenFilePath=Popcorn-Time.exe,%LocalAppData%\popcorn-time

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2748,6 +2748,16 @@ Tmpl.Title=#4338,BiglyBT
 Tmpl.Class=TorrentClient
 OpenFilePath=BiglyBT.exe,%AppData%\BiglyBT
 
+[Template_Popcorn-Time_Force]
+Tmpl.Title=#4323,Popcorn Time (popcorntime.app)
+Tmpl.Class=TorrentClient
+ForceProcess=Popcorn-Time.exe
+
+[Template_BiglyBT_DirectAccess_Profile]
+Tmpl.Title=#4338,Popcorn Time (popcorntime.app)
+Tmpl.Class=TorrentClient
+OpenFilePath=Popcorn-Time.exe,%LocalAppData%\popcorn-time
+
 #
 # Download Managers
 #


### PR DESCRIPTION
This adds a template for Popcorn Time from popcorntime.app, thus the name. There's more than one fork of Popcorn Time with very similar names, so I figured it would be necessary to have something to tell which one you're enabling a template for.

Downloaded another one, intending to make a template for that one too but it keeps crashing so... yeah.