### PR TITLE
Added 32-bit MPC-HC and fixed the SMPlayer template for photos

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2647,31 +2647,37 @@ OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
 Tmpl.Title=#4323,MPC-HC
 Tmpl.Class=MediaPlayer
 ForceProcess=mpc-hc64.exe
+ForceProcess=mpc-hc.exe
 
 [Template_MPC-HC_DirectAccess_Profile]
 Tmpl.Title=#4338,MPC-HC
 Tmpl.Class=MediaPlayer
 OpenFilePath=mpc-hc64.exe,%AppData%\MPC-HC\*
+OpenFilePath=mpc-hc.exe,%AppData%\MPC-HC\*
 
 [Template_MPC-HC_DirectAccess_Photos]
 Tmpl.Title=#4395,MPC-HC
 Tmpl.Class=MediaPlayer
 OpenFilePath=mpc-hc64.exe,%USERPROFILE%\Pictures\*
+OpenFilePath=mpc-hc.exe,%USERPROFILE%\Pictures\*
 
 [Template_MPC-BE_Force]
 Tmpl.Title=#4323,MPC-BE
 Tmpl.Class=MediaPlayer
 ForceProcess=mpc-be64.exe
+ForceProcess=mpc-be.exe
 
 [Template_MPC-BE_DirectAccess_Profile]
 Tmpl.Title=#4338,MPC-BE
 Tmpl.Class=MediaPlayer
 OpenFilePath=mpc-be64.exe,%AppData%\MPC-BE\*
+OpenFilePath=mpc-be.exe,%AppData%\MPC-BE\*
 
 [Template_MPC-BE_DirectAccess_Photos]
 Tmpl.Title=#4395,MPC-BE
 Tmpl.Class=MediaPlayer
 OpenFilePath=mpc-be64.exe,%USERPROFILE%\Pictures\*
+OpenFilePath=mpc-be.exe,%USERPROFILE%\Pictures\*
 
 [Template_PotPlayer_Force]
 Tmpl.Title=#4323,PotPlayer
@@ -2698,8 +2704,8 @@ OpenFilePath=smplayer.exe,%AppData%\mpv\*
 [Template_SMPlayer_DirectAccess_Photos]
 Tmpl.Title=#4395,SMPlayer
 Tmpl.Class=MediaPlayer
-OpenFilePath=mpc-hc64.exe,%USERPROFILE%\Pictures\*
-OpenFilePath=mpc-hc.exe,%USERPROFILE%\Pictures\*
+OpenFilePath=smplayer.exe,%USERPROFILE%\Pictures\smplayer_screenshots
+OpenFilePath=smplayer.exe,%USERPROFILE%\Pictures\smplayer_screenshots
 
 [Template_KMPlayer_Force]
 Tmpl.Title=#4323,KMPlayer


### PR DESCRIPTION
Just fixed the SMPlayer template and added 32-bit versions of MPC-HC (and MPC-BE).