### PR TITLE
Fixes qBittorrent and Transmission templates: AppDataLocal -> Local AppData

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2761,7 +2761,7 @@ ForceProcess=qBittorrent.exe
 [Template_qBittorrent_DirectAccess_Profile]
 Tmpl.Title=#4338,qBittorrent
 Tmpl.Class=TorrentClient
-OpenFilePath=qBittorrent.exe,%AppDataLocal%\qBittorrent
+OpenFilePath=qBittorrent.exe,%LocalAppData%\qBittorrent
 OpenFilePath=qBittorrent.exe,%AppData%\qBittorrent
 
 [Template_Transmission_Force]
@@ -2772,7 +2772,7 @@ ForceProcess=transmission-qt.exe
 [Template_Transmission_DirectAccess_Profile]
 Tmpl.Title=#4338,Transmission
 Tmpl.Class=TorrentClient
-OpenFilePath=transmission-qt.exe,%AppDataLocal%\transmission
+OpenFilePath=transmission-qt.exe,%LocalAppData%\transmission
 
 [Template_BiglyBT_Force]
 Tmpl.Title=#4323,BiglyBT

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -1698,7 +1698,7 @@ Tmpl.Url=https://lastpass.com/
 Tmpl.Scan=s
 Tmpl.ScanKey=\REGISTRY\MACHINE\SOFTWARE\Classes\lpgetr
 Tmpl.ScanFile=%{A520A1A4-1780-4FF6-BD18-167343C5AF16}%\LastPass
-OpenFilePath=<Template_LastPass>,%USERPROFILE%\*\LastPass\*
+OpenFilePath=<Template_LastPass>,%UserProfile%\*\LastPass\*
 ProcessGroup=<Template_LastPass>,iexplore.exe,firefox.exe,opera.exe,chrome.exe
 
 [Template_McAfee_Guardian_Firewall]
@@ -2641,7 +2641,7 @@ OpenFilePath=vlc.exe,%AppData%\vlc\*
 [Template_VLC_DirectAccess_Photos]
 Tmpl.Title=#4395,VLC
 Tmpl.Class=MediaPlayer
-OpenFilePath=vlc.exe,%USERPROFILE%\Pictures\*
+OpenFilePath=vlc.exe,%UserProfile%\Pictures\*
 
 [Template_MPC-HC_Force]
 Tmpl.Title=#4323,MPC-HC
@@ -2658,8 +2658,8 @@ OpenFilePath=mpc-hc.exe,%AppData%\MPC-HC\*
 [Template_MPC-HC_DirectAccess_Photos]
 Tmpl.Title=#4395,MPC-HC
 Tmpl.Class=MediaPlayer
-OpenFilePath=mpc-hc64.exe,%USERPROFILE%\Pictures\*
-OpenFilePath=mpc-hc.exe,%USERPROFILE%\Pictures\*
+OpenFilePath=mpc-hc64.exe,%UserProfile%\Pictures\*
+OpenFilePath=mpc-hc.exe,%UserProfile%\Pictures\*
 
 [Template_MPC-BE_Force]
 Tmpl.Title=#4323,MPC-BE
@@ -2676,8 +2676,8 @@ OpenFilePath=mpc-be.exe,%AppData%\MPC-BE\*
 [Template_MPC-BE_DirectAccess_Photos]
 Tmpl.Title=#4395,MPC-BE
 Tmpl.Class=MediaPlayer
-OpenFilePath=mpc-be64.exe,%USERPROFILE%\Pictures\*
-OpenFilePath=mpc-be.exe,%USERPROFILE%\Pictures\*
+OpenFilePath=mpc-be64.exe,%UserProfile%\Pictures\*
+OpenFilePath=mpc-be.exe,%UserProfile%\Pictures\*
 
 [Template_PotPlayer_Force]
 Tmpl.Title=#4323,PotPlayer
@@ -2704,8 +2704,8 @@ OpenFilePath=smplayer.exe,%AppData%\mpv\*
 [Template_SMPlayer_DirectAccess_Photos]
 Tmpl.Title=#4395,SMPlayer
 Tmpl.Class=MediaPlayer
-OpenFilePath=smplayer.exe,%USERPROFILE%\Pictures\smplayer_screenshots
-OpenFilePath=smplayer.exe,%USERPROFILE%\Pictures\smplayer_screenshots
+OpenFilePath=smplayer.exe,%UserProfile%\Pictures\smplayer_screenshots
+OpenFilePath=smplayer.exe,%UserProfile%\Pictures\smplayer_screenshots
 
 [Template_KMPlayer_Force]
 Tmpl.Title=#4323,KMPlayer
@@ -2727,12 +2727,12 @@ ForceProcess=clementine.exe
 [Template_Clementine_DirectAccess_Profile]
 Tmpl.Title=#4338,Clementine
 Tmpl.Class=MediaPlayer
-OpenFilePath=clementine.exe,%USERPROFILE%\current\.config\Clementine\*
+OpenFilePath=clementine.exe,%UserProfile%\current\.config\Clementine\*
 
 [Template_Clementine_DirectAccess_Music]
 Tmpl.Title=#4398,Clementine
 Tmpl.Class=MediaPlayer
-OpenFilePath=clementine.exe,%USERPROFILE%\Music\*
+OpenFilePath=clementine.exe,%UserProfile%\Music\*
 
 [Template_Strawberry_Force]
 Tmpl.Title=#4323,Strawberry Music Player
@@ -2747,7 +2747,7 @@ OpenFilePath=strawberry.exe,%Local AppData%\Strawberry
 [Template_Strawberry_DirectAccess_Music]
 Tmpl.Title=#4398,Strawberry Music Player
 Tmpl.Class=MediaPlayer
-OpenFilePath=strawberry.exe,%USERPROFILE%\Music\*
+OpenFilePath=strawberry.exe,%UserProfile%\Music\*
 
 #
 # Torrent Clients

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2742,7 +2742,7 @@ ForceProcess=strawberry.exe
 [Template_Strawberry_DirectAccess_Profile]
 Tmpl.Title=#4338,Strawberry Music Player
 Tmpl.Class=MediaPlayer
-OpenFilePath=strawberry.exe,%LocalAppData%\Strawberry
+OpenFilePath=strawberry.exe,%Local AppData%\Strawberry
 
 [Template_Strawberry_DirectAccess_Music]
 Tmpl.Title=#4398,Strawberry Music Player
@@ -2761,7 +2761,7 @@ ForceProcess=qBittorrent.exe
 [Template_qBittorrent_DirectAccess_Profile]
 Tmpl.Title=#4338,qBittorrent
 Tmpl.Class=TorrentClient
-OpenFilePath=qBittorrent.exe,%LocalAppData%\qBittorrent
+OpenFilePath=qBittorrent.exe,%Local AppData%\qBittorrent
 OpenFilePath=qBittorrent.exe,%AppData%\qBittorrent
 
 [Template_Transmission_Force]
@@ -2772,7 +2772,7 @@ ForceProcess=transmission-qt.exe
 [Template_Transmission_DirectAccess_Profile]
 Tmpl.Title=#4338,Transmission
 Tmpl.Class=TorrentClient
-OpenFilePath=transmission-qt.exe,%LocalAppData%\transmission
+OpenFilePath=transmission-qt.exe,%Local AppData%\transmission
 
 [Template_BiglyBT_Force]
 Tmpl.Title=#4323,BiglyBT
@@ -2792,7 +2792,7 @@ ForceProcess=Popcorn-Time.exe
 [Template_Popcorn-Time_DirectAccess_Profile]
 Tmpl.Title=#4338,Popcorn Time (popcorntime.app)
 Tmpl.Class=TorrentClient
-OpenFilePath=Popcorn-Time.exe,%LocalAppData%\popcorn-time
+OpenFilePath=Popcorn-Time.exe,%Local AppData%\popcorn-time
 
 #
 # Download Managers


### PR DESCRIPTION
Yeah, so I screwed this up and this PR fixes the qBittorrent and Transmission templates. Sorry for the mistake.

Feel free adding this to the non-release version of 0.7.3.