### PR TITLE
Prevent media players from importing video files

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2632,6 +2632,11 @@ OpenWinClass=ZT9MainWindow
 Tmpl.Title=#4323,VLC
 Tmpl.Class=MediaPlayer
 ForceProcess=vlc.exe
+DontCopy=vlc.exe,*.mp4
+DontCopy=vlc.exe,*.mkv
+DontCopy=vlc.exe,*.avi
+DontCopy=vlc.exe,*.flv
+DontCopy=vlc.exe,*.wmv
 
 [Template_VLC_DirectAccess_Profile]
 Tmpl.Title=#4338,VLC

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2628,15 +2628,20 @@ OpenWinClass=ZT9MainWindow
 # Media Players
 #
 
+[Template_No_Importing_Of_Media_Files]
+Tmpl.Title=#4399
+Tmpl.Class=MediaPlayer
+DontCopy=*.mp4
+DontCopy=*.mkv
+DontCopy=*.avi
+DontCopy=*.flv
+DontCopy=*.wmv
+
 [Template_VLC_Force]
 Tmpl.Title=#4323,VLC
 Tmpl.Class=MediaPlayer
 ForceProcess=vlc.exe
-DontCopy=vlc.exe,*.mp4
-DontCopy=vlc.exe,*.mkv
-DontCopy=vlc.exe,*.avi
-DontCopy=vlc.exe,*.flv
-DontCopy=vlc.exe,*.wmv
+
 
 [Template_VLC_DirectAccess_Profile]
 Tmpl.Title=#4338,VLC
@@ -2689,11 +2694,6 @@ Tmpl.Title=#4323,PotPlayer
 Tmpl.Class=MediaPlayer
 ForceProcess=PotPlayerMini64.exe
 ForceProcess=PotPlayerMini.exe
-DontCopy=PotPlayerMini*.exe,*.mp4
-DontCopy=PotPlayerMini*.exe,*.mkv
-DontCopy=PotPlayerMini*.exe,*.avi
-DontCopy=PotPlayerMini*.exe,*.flv
-DontCopy=PotPlayerMini*.exe,*.wmv
 
 [Template_PotPlayer_DirectAccess_Profile]
 Tmpl.Title=#4338,PotPlayer

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2636,6 +2636,11 @@ DontCopy=*.mkv
 DontCopy=*.avi
 DontCopy=*.flv
 DontCopy=*.wmv
+DontCopy=*.mp3
+DontCopy=*.aac
+DontCopy=*.m4a
+DontCopy=*.flac
+DontCopy=*.ogg
 
 [Template_VLC_Force]
 Tmpl.Title=#4323,VLC

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2689,6 +2689,11 @@ Tmpl.Title=#4323,PotPlayer
 Tmpl.Class=MediaPlayer
 ForceProcess=PotPlayerMini64.exe
 ForceProcess=PotPlayerMini.exe
+DontCopy=PotPlayerMini*.exe,*.mp4
+DontCopy=PotPlayerMini*.exe,*.mkv
+DontCopy=PotPlayerMini*.exe,*.avi
+DontCopy=PotPlayerMini*.exe,*.flv
+DontCopy=PotPlayerMini*.exe,*.wmv
 
 [Template_PotPlayer_DirectAccess_Profile]
 Tmpl.Title=#4338,PotPlayer

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2628,7 +2628,7 @@ OpenWinClass=ZT9MainWindow
 # Media Players
 #
 
-[Template_No_Importing_Of_Media_Files]
+[Template_No_Media_Files]
 Tmpl.Title=#4399
 Tmpl.Class=MediaPlayer
 DontCopy=*.mp4
@@ -2641,12 +2641,14 @@ DontCopy=*.aac
 DontCopy=*.m4a
 DontCopy=*.flac
 DontCopy=*.ogg
+DontCopy=*.wav
+DontCopy=*.wma
+DontCopy=*.ape
 
 [Template_VLC_Force]
 Tmpl.Title=#4323,VLC
 Tmpl.Class=MediaPlayer
 ForceProcess=vlc.exe
-
 
 [Template_VLC_DirectAccess_Profile]
 Tmpl.Title=#4338,VLC

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -2628,23 +2628,6 @@ OpenWinClass=ZT9MainWindow
 # Media Players
 #
 
-[Template_No_Media_Files]
-Tmpl.Title=#4399
-Tmpl.Class=MediaPlayer
-DontCopy=*.mp4
-DontCopy=*.mkv
-DontCopy=*.avi
-DontCopy=*.flv
-DontCopy=*.wmv
-DontCopy=*.mp3
-DontCopy=*.aac
-DontCopy=*.m4a
-DontCopy=*.flac
-DontCopy=*.ogg
-DontCopy=*.wav
-DontCopy=*.wma
-DontCopy=*.ape
-
 [Template_VLC_Force]
 Tmpl.Title=#4323,VLC
 Tmpl.Class=MediaPlayer
@@ -3011,6 +2994,39 @@ CopyAlways=*\infcache.1
 CopyAlways=*\cbs.log
 # internet explorer 10 web cache
 CopyAlways=*\webcachev*.dat
+# Media Players
+DontCopy=*.aac
+DontCopy=*.ac3
+DontCopy=*.aiff
+DontCopy=*.ape
+DontCopy=*.asf
+DontCopy=*.avi
+DontCopy=*.f4v
+DontCopy=*.flac
+DontCopy=*.flv
+DontCopy=*.m4a
+DontCopy=*.m4v
+DontCopy=*.mid
+DontCopy=*.mka
+DontCopy=*.mkv
+DontCopy=*.mov
+DontCopy=*.mp3
+DontCopy=*.mp4
+DontCopy=*.mpeg
+DontCopy=*.mpg
+DontCopy=*.oga
+DontCopy=*.ogg
+DontCopy=*.ogv
+DontCopy=*.opus
+DontCopy=*.ra
+DontCopy=*.rm
+DontCopy=*.rmvb
+DontCopy=*.ts
+DontCopy=*.vob
+DontCopy=*.wav
+DontCopy=*.webm
+DontCopy=*.wma
+DontCopy=*.wmv
 
 [Template_RpcPortBindings]
 Tmpl.Title=Default RPC Port Bindings

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3311,9 +3311,6 @@ The following exclusions allow Torrent clients running in this sandbox to access
 4398;txt;01
 Allow %2 direct access to the Music folder for easier music library management.
 .
-4399;txt;01
-Prevent Media players from importing media files to the sandbox.
-.
 
 #----------------------------------------------------------------------------
 # Sandboxie Control:  Sandbox Settings:  User Accounts

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -3311,6 +3311,9 @@ The following exclusions allow Torrent clients running in this sandbox to access
 4398;txt;01
 Allow %2 direct access to the Music folder for easier music library management.
 .
+4399;txt;01
+Prevent Media players from importing media files to the sandbox.
+.
 
 #----------------------------------------------------------------------------
 # Sandboxie Control:  Sandbox Settings:  User Accounts


### PR DESCRIPTION
Hello! This prevents VLC and PotPlayer from importing media files if the template is used.

Until a better fix is available, this fixes https://github.com/sandboxie-plus/Sandboxie/issues/536