### PR TITLE
Align default settings of AutoRecover and Favorites to the Plus version

### DIFF
--- a/Sandboxie/apps/control/Box.cpp
+++ b/Sandboxie/apps/control/Box.cpp
@@ -259,7 +259,7 @@ void CBox::SetDefaultSettings()
 
     if (ok)
     {
-        ok = ini.SetBool(m_name, _AutoRecover, TRUE);
+        ok = ini.SetBool(m_name, _AutoRecover, FALSE);
         ok = ini.SetBool(m_name, L"BlockNetworkFiles", TRUE);
     }
 
@@ -269,7 +269,7 @@ void CBox::SetDefaultSettings()
     if (ok)
         ok = AddOrRemoveQuickRecoveryFolder(L"%Desktop%",    TRUE);
     if (ok)
-        ok = AddOrRemoveQuickRecoveryFolder(L"%Favorites%",  TRUE);
+        ok = AddOrRemoveQuickRecoveryFolder(L"%Favorites%",  FALSE);
     if (ok)
         ok = AddOrRemoveQuickRecoveryFolder(L"%Personal%",   TRUE);
     if (ok && CMyApp::m_WindowsVista) {


### PR DESCRIPTION
Change default settings for AutoRecover and Favorites, as in the Plus version.