### PR TITLE
Display PDF/Print category in Plus UI

### DIFF
--- a/SandboxiePlus/QSbieAPI/Sandboxie/SbieTemplates.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/SbieTemplates.cpp
@@ -258,7 +258,7 @@ void CSbieTemplates::CollectTemplates()
 
 	QStringList Templates;
 	Templates.append(GetTemplateNames("EmailReader"));
-	Templates.append(GetTemplateNames("Print"));
+	Templates.append("PDF/" + GetTemplateNames("Print"));
 	Templates.append(GetTemplateNames("Security"));
 	Templates.append(GetTemplateNames("Desktop"));
 	Templates.append(GetTemplateNames("Download"));


### PR DESCRIPTION
@DavidXanatos I need a review about the validity of this commit. 
The scope of this commit is to rename the Print category to PDF/Print (only in Plus UI).