### PR TITLE
Remove notr attributes from translation strings

### DIFF
--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -684,7 +684,7 @@
                </column>
                <column>
                 <property name="text">
-                 <string notr="true">Program/Service</string>
+                 <string>Program/Service</string>
                 </property>
                </column>
               </widget>
@@ -872,7 +872,7 @@
              </property>
              <column>
               <property name="text">
-               <string notr="true">Type</string>
+               <string>Type</string>
               </property>
              </column>
              <column>


### PR DESCRIPTION
I don't know if these lines were modified intentionally, but in this commit I thought to remove some `notr="true"` in order to restore the translation of these strings in other languages.
