### PR TITLE
Split anti-phishing rules per browser

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -103,7 +103,7 @@ ForceProcess=iexplore.exe
 Tmpl.Title=#4326,Internet Explorer
 Tmpl.Class=WebBrowser
 OpenFilePath=iexplore.exe,%Favorites%
-OpenFilePath=firefox.exe,%Favorites%
+#OpenFilePath=firefox.exe,%Favorites%
 
 [Template_IExplore_Favorites_RecoverFolder]
 Tmpl.Title=#4327
@@ -160,51 +160,41 @@ OpenKeyPath=iexplore.exe,HKEY_CURRENT_USER\Software\Microsoft\Internet Explorer\
 #
 
 [Template_Firefox_Force]
-Tmpl.Title=#4323,Firefox
+Tmpl.Title=#4323,Mozilla Firefox
 Tmpl.Class=WebBrowser
 ForceProcess=firefox.exe
 
 [Template_Firefox_Bookmarks_DirectAccess]
-Tmpl.Title=#4336,Firefox
+Tmpl.Title=#4336,Mozilla Firefox
 Tmpl.Class=WebBrowser
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\bookmark*
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\places*
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\favicons.sqlite
 
 [Template_Firefox_Cookies_DirectAccess]
-Tmpl.Title=#4328,Firefox
+Tmpl.Title=#4328,Mozilla Firefox
 Tmpl.Class=WebBrowser
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\cookies*
 
 [Template_Firefox_Passwords_DirectAccess]
-Tmpl.Title=#4331,Firefox
+Tmpl.Title=#4331,Mozilla Firefox
 Tmpl.Class=WebBrowser
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\logins.json
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\key*.db
 
-[Template_Firefox_Phishing_DirectAccess]
-Tmpl.Title=#4337,Firefox/Waterfox/Pale Moon/SeaMonkey
-Tmpl.Class=WebBrowser
-ProcessGroup=<FirefoxPrograms>,firefox.exe,waterfox.exe,palemoon.exe,seamonkey.exe
-OpenFilePath=<FirefoxPrograms>,%ProgramFiles%\*\browser\blocklist*
-OpenFilePath=<FirefoxPrograms>,%Tmpl.PaleMoon%\blocklist*
-OpenFilePath=<FirefoxPrograms>,%Tmpl.WaterFox%\blocklist*
-OpenFilePath=<FirefoxPrograms>,%Tmpl.SeaMonkey%\blocklist*
-OpenFilePath=<FirefoxPrograms>,%Tmpl.Firefox%\cert*.db
-OpenFilePath=<FirefoxPrograms>,%Tmpl.PaleMoon%\cert*.db
-OpenFilePath=<FirefoxPrograms>,%Tmpl.WaterFox%\cert*.db
-OpenFilePath=<FirefoxPrograms>,%Tmpl.SeaMonkey%\cert*.db
-OpenFilePath=<FirefoxPrograms>,%Local AppData%\Mozilla\Firefox\Profiles\*\safebrowsing*
-OpenFilePath=<FirefoxPrograms>,%Local AppData%\Waterfox\Profiles\*\safebrowsing*
-OpenFilePath=<FirefoxPrograms>,%Local AppData%\Mozilla\SeaMonkey\Profiles\*\safebrowsing*
-
 [Template_Firefox_Session_DirectAccess]
-Tmpl.Title=#4340,Firefox
+Tmpl.Title=#4340,Mozilla Firefox
 Tmpl.Class=WebBrowser
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\sessionstore.js*
 
+[Template_Firefox_Phishing_DirectAccess]
+Tmpl.Title=#4337,Mozilla Firefox
+Tmpl.Class=WebBrowser
+OpenFilePath=firefox.exe,%Tmpl.Firefox%\cert9.db
+OpenFilePath=firefox.exe,%Local AppData%\Mozilla\Firefox\Profiles\*\safebrowsing*
+
 [Template_Firefox_Profile_DirectAccess]
-Tmpl.Title=#4338,Firefox
+Tmpl.Title=#4338,Mozilla Firefox
 Tmpl.Class=WebBrowser
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\*
 
@@ -242,6 +232,13 @@ OpenFilePath=waterfox.exe,%Tmpl.Waterfox%\key*.db
 Tmpl.Title=#4340,Waterfox
 Tmpl.Class=WebBrowser
 OpenFilePath=waterfox.exe,%Tmpl.Waterfox%\sessionstore.js*
+
+[Template_Waterfox_Phishing_DirectAccess]
+Tmpl.Title=#4337,Waterfox
+Tmpl.Class=WebBrowser
+OpenFilePath=waterfox.exe,%Tmpl.WaterFox%\blocklist.xml
+OpenFilePath=waterfox.exe,%Tmpl.WaterFox%\cert9.db
+OpenFilePath=waterfox.exe,%Local AppData%\Waterfox\Profiles\*\safebrowsing*
 
 [Template_Waterfox_Profile_DirectAccess]
 Tmpl.Title=#4338,Waterfox
@@ -283,6 +280,12 @@ Tmpl.Title=#4340,Pale Moon
 Tmpl.Class=WebBrowser
 OpenFilePath=palemoon.exe,%Tmpl.PaleMoon%\sessionstore.js
 
+[Template_PaleMoon_Phishing_DirectAccess]
+Tmpl.Title=#4337,Pale Moon
+Tmpl.Class=WebBrowser
+OpenFilePath=palemoon.exe,%Tmpl.PaleMoon%\blocklist.xml
+OpenFilePath=palemoon.exe,%Tmpl.PaleMoon%\cert9.db
+
 [Template_PaleMoon_Profile_DirectAccess]
 Tmpl.Title=#4338,Pale Moon
 Tmpl.Class=WebBrowser
@@ -322,6 +325,13 @@ OpenFilePath=seamonkey.exe,%Tmpl.SeaMonkey%\key*.db
 Tmpl.Title=#4340,SeaMonkey
 Tmpl.Class=WebBrowser
 OpenFilePath=seamonkey.exe,%Tmpl.SeaMonkey%\sessionstore.js
+
+[Template_SeaMonkey_Phishing_DirectAccess]
+Tmpl.Title=#4337,SeaMonkey
+Tmpl.Class=WebBrowser
+OpenFilePath=seamonkey.exe,%Tmpl.SeaMonkey%\blocklist.xml
+OpenFilePath=seamonkey.exe,%Tmpl.SeaMonkey%\cert9.db
+OpenFilePath=seamonkey.exe,%Local AppData%\Mozilla\SeaMonkey\Profiles\*\safebrowsing*
 
 [Template_SeaMonkey_Profile_DirectAccess]
 Tmpl.Title=#4338,SeaMonkey
@@ -390,28 +400,10 @@ OpenFilePath=chrome.exe,%Tmpl.Chrome%\Sync Data\*
 OpenFilePath=chrome.exe,%Tmpl.Chrome%\Sync Extension Settings\*
 
 [Template_Chrome_Phishing_DirectAccess]
-Tmpl.Title=#4337,Chromium browsers
+Tmpl.Title=#4337,Google Chrome
 Tmpl.Class=WebBrowser
-ProcessGroup=<ChromePrograms>,chrome.exe,msedge.exe,dragon.exe,iron.exe,vivaldi.exe,brave.exe,Maxthon.exe,opera.exe,browser.exe
-OpenFilePath=<ChromePrograms>,%Local AppData%\Google\Chrome\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\Google\Chrome\User Data\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Local AppData%\Microsoft\Edge\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\Microsoft\Edge\User Data\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Local AppData%\Microsoft\Edge\User Data\SmartScreen
-OpenFilePath=<ChromePrograms>,%Local AppData%\Microsoft\Edge\User Data\Ad Blocking
-OpenFilePath=<ChromePrograms>,%Local AppData%\Comodo\Dragon\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\Comodo\Dragon\User Data\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Local AppData%\Chromium\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\Chromium\User Data\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Local AppData%\Vivaldi\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\Vivaldi\User Data\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Local AppData%\BraveSoftware\Brave-Browser\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\BraveSoftware\Brave-Browser\User Data\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Local AppData%\Maxthon\Application\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\Maxthon\Application\User Data\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Tmpl.Opera%\CertificateRevocation
-OpenFilePath=<ChromePrograms>,%Local AppData%\Yandex\YandexBrowser\User Data\Safe Browsing*
-OpenFilePath=<ChromePrograms>,%Local AppData%\Yandex\YandexBrowser\User Data\CertificateRevocation
+OpenFilePath=chrome.exe,%Local AppData%\Google\Chrome\User Data\Safe Browsing*
+OpenFilePath=chrome.exe,%Local AppData%\Google\Chrome\User Data\CertificateRevocation
 
 [Template_Chrome_Profile_DirectAccess]
 Tmpl.Title=#4338,Google Chrome
@@ -464,6 +456,14 @@ Tmpl.Class=WebBrowser
 OpenFilePath=msedge.exe,%Tmpl.Edge%\Sync Data\*
 OpenFilePath=msedge.exe,%Tmpl.Edge%\Sync Extension Settings\*
 
+[Template_Edge_Phishing_DirectAccess]
+Tmpl.Title=#4337,Microsoft Edge
+Tmpl.Class=WebBrowser
+OpenFilePath=msedge.exe,%Local AppData%\Microsoft\Edge\User Data\Safe Browsing*
+OpenFilePath=msedge.exe,%Local AppData%\Microsoft\Edge\User Data\CertificateRevocation
+OpenFilePath=msedge.exe,%Local AppData%\Microsoft\Edge\User Data\SmartScreen
+OpenFilePath=msedge.exe,%Local AppData%\Microsoft\Edge\User Data\Ad Blocking
+
 [Template_Edge_Profile_DirectAccess]
 Tmpl.Title=#4338,Microsoft Edge
 Tmpl.Class=WebBrowser
@@ -508,6 +508,12 @@ OpenFilePath=dragon.exe,%Tmpl.Dragon%\Login Data*
 Tmpl.Title=#4339,Comodo Dragon
 Tmpl.Class=WebBrowser
 OpenFilePath=dragon.exe,%Tmpl.Dragon%\Preferences*
+
+[Template_Dragon_Phishing_DirectAccess]
+Tmpl.Title=#4337,Comodo Dragon
+Tmpl.Class=WebBrowser
+OpenFilePath=dragon.exe,%Local AppData%\Comodo\Dragon\User Data\Safe Browsing*
+OpenFilePath=dragon.exe,%Local AppData%\Comodo\Dragon\User Data\CertificateRevocation
 
 [Template_Dragon_Profile_DirectAccess]
 Tmpl.Title=#4338,Comodo Dragon
@@ -562,6 +568,12 @@ OpenFilePath=iron.exe,%Tmpl.Iron%\Preferences*
 Tmpl.Title=#4324,SRWare Iron
 Tmpl.Class=WebBrowser
 OpenFilePath=iron.exe,%Tmpl.Iron%\Sync Data\*
+
+[Template_Iron_Phishing_DirectAccess]
+Tmpl.Title=#4337,SRWare Iron
+Tmpl.Class=WebBrowser
+OpenFilePath=iron.exe,%Local AppData%\Chromium\User Data\Safe Browsing*
+OpenFilePath=iron.exe,%Local AppData%\Chromium\User Data\CertificateRevocation
 
 [Template_Iron_Profile_DirectAccess]
 Tmpl.Title=#4338,SRWare Iron
@@ -672,6 +684,12 @@ Tmpl.Class=WebBrowser
 OpenFilePath=vivaldi.exe,%Tmpl.Vivaldi%\Sync Data\*
 OpenFilePath=vivaldi.exe,%Tmpl.Vivaldi%\Sync Extension Settings\*
 
+[Template_Vivaldi_Phishing_DirectAccess]
+Tmpl.Title=#4337,Vivaldi
+Tmpl.Class=WebBrowser
+OpenFilePath=vivaldi.exe,%Local AppData%\Vivaldi\User Data\Safe Browsing*
+OpenFilePath=vivaldi.exe,%Local AppData%\Vivaldi\User Data\CertificateRevocation
+
 [Template_Vivaldi_Profile_DirectAccess]
 Tmpl.Title=#4338,Vivaldi
 Tmpl.Class=WebBrowser
@@ -726,6 +744,12 @@ Tmpl.Title=#4324,Brave Browser
 Tmpl.Class=WebBrowser
 OpenFilePath=brave.exe,%Tmpl.Brave%\Sync Data\*
 
+[Template_Brave_Phishing_DirectAccess]
+Tmpl.Title=#4337,Brave Browser
+Tmpl.Class=WebBrowser
+OpenFilePath=brave.exe,%Local AppData%\BraveSoftware\Brave-Browser\User Data\Safe Browsing*
+OpenFilePath=brave.exe,%Local AppData%\BraveSoftware\Brave-Browser\User Data\CertificateRevocation
+
 [Template_Brave_Profile_DirectAccess]
 Tmpl.Title=#4338,Brave Browser
 Tmpl.Class=WebBrowser
@@ -774,6 +798,12 @@ OpenFilePath=Maxthon.exe,%Tmpl.Maxthon_6%\Login Data*
 Tmpl.Title=#4339,Maxthon 6
 Tmpl.Class=WebBrowser
 OpenFilePath=Maxthon.exe,%Tmpl.Maxthon_6%\Preferences*
+
+[Template_Maxthon6_Phishing_DirectAccess]
+Tmpl.Title=#4337,Maxthon 6
+Tmpl.Class=WebBrowser
+OpenFilePath=Maxthon.exe,%Local AppData%\Maxthon\Application\User Data\Safe Browsing*
+OpenFilePath=Maxthon.exe,%Local AppData%\Maxthon\Application\User Data\CertificateRevocation
 
 [Template_Maxthon6_Profile_DirectAccess]
 Tmpl.Title=#4338,Maxthon 6
@@ -828,6 +858,11 @@ OpenFilePath=opera.exe,%Tmpl.Opera%\Preferences*
 Tmpl.Title=#4324,Opera
 Tmpl.Class=WebBrowser
 OpenFilePath=opera.exe,%Tmpl.Opera%\Sync Data\*
+
+[Template_Opera_Phishing_DirectAccess]
+Tmpl.Title=#4337,Opera
+Tmpl.Class=WebBrowser
+OpenFilePath=opera.exe,%Tmpl.Opera%\CertificateRevocation
 
 [Template_Opera_Profile_DirectAccess]
 Tmpl.Title=#4338,Opera
@@ -884,6 +919,12 @@ OpenFilePath=browser.exe,%Tmpl.Yandex%\Preferences*
 Tmpl.Title=#4324,Yandex Browser
 Tmpl.Class=WebBrowser
 OpenFilePath=browser.exe,%Tmpl.Yandex%\Sync Data\*
+
+[Template_Yandex_Phishing_DirectAccess]
+Tmpl.Title=#4337,Yandex Browser
+Tmpl.Class=WebBrowser
+OpenFilePath=browser.exe,%Local AppData%\Yandex\YandexBrowser\User Data\Safe Browsing*
+OpenFilePath=browser.exe,%Local AppData%\Yandex\YandexBrowser\User Data\CertificateRevocation
 
 [Template_Yandex_Profile_DirectAccess]
 Tmpl.Title=#4338,Yandex Browser


### PR DESCRIPTION
I took some of the changes originally made in #788, in order to update anti-phishing rules per browser without any fuss (so no ScanOption involved).

EDIT: I disabled `OpenFilePath=firefox.exe,%Favorites%` that was present in `Template_IExplore_Favorites_DirectAccess`.