### PR TITLE
Fix innosetup script to remove shell integration keys

### DIFF
--- a/Installer/Sandboxie-Plus.iss
+++ b/Installer/Sandboxie-Plus.iss
@@ -404,8 +404,8 @@ begin
   RegDeleteValue(HKEY_CURRENT_USER, 'Software\Microsoft\Windows\CurrentVersion\Run', 'SandboxiePlus_AutoRun');
   
   // remove shell integration
-  RegDeleteValue(HKEY_CURRENT_USER, 'software\classes\*\shell', 'sandbox');
-  RegDeleteValue(HKEY_CURRENT_USER, 'software\classes\folder\shell', 'sandbox');
+  RegDeleteKeyIncludingSubkeys(HKEY_CURRENT_USER, 'software\classes\*\shell\sandbox');
+  RegDeleteKeyIncludingSubkeys(HKEY_CURRENT_USER, 'software\classes\folder\shell\sandbox');
 
   // delete other left overs
   DeleteFile(ExpandConstant('{app}\SbieDrv.sys.w10'));


### PR DESCRIPTION
Remove shell integration in innosetup fix with `RegDeleteKeyIncludingSubkeys` function, instead of `RegDeleteValue` function as `sandbox` is a registry **key**, not a registry **value**. `RegDeleteValue` would have been failing (*with a return value of False*) as it cannot remove keys and the subkeys as it is [documented](https://jrsoftware.org/ishelp/index.php?topic=isxfunc_regdeletevalue) to remove a value.

These are the `sandbox` keys copied from RegEdit that require keys and subkeys removed at uninstall of Sandboxie Plus.

```
HKEY_CURRENT_USER\Software\Classes\*\shell\sandbox
HKEY_CURRENT_USER\Software\Classes\Folder\shell\sandbox
```

This fix has not been compiled and tested, though it should be an improvement. No other registry functions appear to have any similar issues with a quick review of the innosetup source. 