### PR TITLE
Fix Plus upgrade install with full uninstall of service and driver

### DIFF
--- a/Installer/Sandboxie-Plus.iss
+++ b/Installer/Sandboxie-Plus.iss
@@ -267,6 +267,10 @@ begin
   Exec(ExpandConstant('{app}\kmdutil.exe'), 'stop SbieSvc', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExecRet);
   Exec(ExpandConstant('{app}\kmdutil.exe'), 'stop SbieDrv', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExecRet);
 
+  // uninstall the driver
+  Exec(ExpandConstant('{app}\kmdutil.exe'), 'delete SbieSvc', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExecRet);
+  Exec(ExpandConstant('{app}\kmdutil.exe'), 'delete SbieDrv', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExecRet);
+
   Result := True;
 end;
 
@@ -385,10 +389,6 @@ begin
     Abort();
     exit;
   end;
-
-  // uninstall the driver
-  Exec(ExpandConstant('{app}\kmdutil.exe'), 'delete SbieSvc', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExecRet);
-  Exec(ExpandConstant('{app}\kmdutil.exe'), 'delete SbieDrv', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExecRet);
 
   // remove from autostart
   RegDeleteValue(HKEY_CURRENT_USER, 'Software\Microsoft\Windows\CurrentVersion\Run', 'SandboxiePlus_AutoRun');


### PR DESCRIPTION
Moved the `kmdutil.exe delete SbieSvc` and `kmdutil delete SbieDrv` Exec commands into *ShutdownSbie()*. Makes the upgrade install several seconds longer though recent and previous testing shows the elimination of the ***The service cannot accept control messages at this time*** messagebox.

 * Fix #968
 * Fix #1139

Was not aware of a reboot needed due to the issue. Unless the shell has some handles or something locked open, then fingers crossed, this should prevent a needed reboot.