### PR TITLE
Update SRWare Iron template to actually work

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -533,7 +533,8 @@ OpenFilePath=dragon.exe,%Tmpl.Dragon%\Bookmarks*
 OpenFilePath=dragon.exe,%Tmpl.Dragon%\Favicons*
 
 [Template_Dragon_History_DirectAccess]
-Tmpl.Title=#4336,Comodo Dragon
+Tmpl.Title=#4336,Comodo
+Dragon
 Tmpl.Class=WebBrowser
 OpenFilePath=dragon.exe,%Tmpl.Dragon%\Bookmarks*
 OpenFilePath=dragon.exe,%Tmpl.Dragon%\Favicons*
@@ -579,54 +580,56 @@ Tmpl.Class=WebBrowser
 [Template_Iron_Force]
 Tmpl.Title=#4323,SRWare Iron
 Tmpl.Class=WebBrowser
-ForceProcess=iron.exe
+
+
+ForceFolder=C:\Program Files\SRWare Iron (64-Bit)
 
 [Template_Iron_Bookmarks_DirectAccess]
 Tmpl.Title=#4356,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Tmpl.Iron%\Bookmarks*
-OpenFilePath=iron.exe,%Tmpl.Iron%\Favicons*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Bookmarks*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Favicons*
 
 [Template_Iron_History_DirectAccess]
 Tmpl.Title=#4336,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Tmpl.Iron%\Bookmarks*
-OpenFilePath=iron.exe,%Tmpl.Iron%\Favicons*
-OpenFilePath=iron.exe,%Tmpl.Iron%\*History*
-OpenFilePath=iron.exe,%Tmpl.Iron%\Current *
-OpenFilePath=iron.exe,%Tmpl.Iron%\Last *
-OpenFilePath=iron.exe,%Tmpl.Iron%\Visited Links*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Bookmarks*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Favicons*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\*History*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Current *
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Last *
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Visited Links*
 
 [Template_Iron_Cookies_DirectAccess]
 Tmpl.Title=#4328,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Tmpl.Iron%\Cookies*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Cookies*
 
 [Template_Iron_Passwords_DirectAccess]
 Tmpl.Title=#4331,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Tmpl.Iron%\Login Data*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Login Data*
 
 [Template_Iron_Preferences_DirectAccess]
 Tmpl.Title=#4339,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Tmpl.Iron%\Preferences*
+OpenFilePath=chrome,%Tmpl.Iron%\Preferences*
 
 [Template_Iron_Sync_DirectAccess]
 Tmpl.Title=#4324,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Tmpl.Iron%\Sync Data\*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Sync Data\*
 
 [Template_Iron_Phishing_DirectAccess]
 Tmpl.Title=#4337,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Local AppData%\Chromium\User Data\Safe Browsing*
-OpenFilePath=iron.exe,%Local AppData%\Chromium\User Data\CertificateRevocation
+OpenFilePath=chrome.exe,%Local AppData%\Chromium\User Data\Safe Browsing*
+OpenFilePath=chrome.exe,%Local AppData%\Chromium\User Data\CertificateRevocation
 
 [Template_Iron_Profile_DirectAccess]
 Tmpl.Title=#4338,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=iron.exe,%Tmpl.Iron%\*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\*
 
 [Template_Iron_Separator]
 Tmpl.Title=-


### PR DESCRIPTION
So for whatever reason, SRWare Iron has gone from calling their program "iron.exe" to "chrome.exe"

There's still an iron.exe in the folder but it doesn't seem to be used.

This changes the force file template to force the install folder in Sandboxie instead. The alternative is to force "chrome.exe" in the sandbox, which will be confusing for people that use both Chrome and Iron.

"chrome.exe" is also used instead of "iron.exe" for every occurrence. 

Iron doesn't seem to have an updater, so I expect no issues with that. I installed it with Chocolatey.