### PR TITLE
Fix Plus upgrade install in Windows 7

### DIFF
--- a/Installer/Sandboxie-Plus.iss
+++ b/Installer/Sandboxie-Plus.iss
@@ -237,6 +237,12 @@ begin
 
     UpdateStatus(OutputProgressPage, 'KmdUtil delete SbieDrv', 100);
     Exec(ExpandConstant('{app}\KmdUtil.exe'), 'delete SbieDrv', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExecRet);
+
+    // Query driver which can remove SbieDrv key if exist.
+    if RegKeyExists(HKLM, 'SYSTEM\CurrentControlSet\services\SbieDrv') then begin
+      UpdateStatus(OutputProgressPage, 'SC query SbieDrv', 100);
+      Exec(ExpandConstant('{sys}\sc.exe'), 'query SbieDrv', '', SW_HIDE, ewWaitUntilTerminated, ExecRet);
+    end;
   finally
 
     // Restore status text (uninstall). Hide Prepare progress page (install).


### PR DESCRIPTION
Windows 7 still has KmdUtil issues with the Plus installer while Windows 10 has been recently fixed.

Upgrade install from v0.9.5 to v0.9.6 was not a nice experience on Windows 7.

 * Upgrade install can cause *CreateService* error. Run Sandman without OS restart can cause the 1061 error.
 * Uninstall *services\SbieDrv* key remains.
 * Restart system removes the key.

Tried to remove *services\SbieDrv* key in the installer though makes no difference with errors.

Either restart the OS or run the command `sc query sbiedrv` removes the *services\SbieDrv* key. The command needs to run before the reinstall of the driver else an error condition may happen, in which an OS restart is needed.

The fix tested is to check if `HKLM\SYSTEM\CurrentControlSet\services\SbieDrv` exist, if it does, run `sc query sbiedrv`. This will run on Windows 7 and will not run on Windows 10. Not tested on Windows 8 or Windows 11. The command should be safe to run on any supported OS.

A better fix might be in KmdUtil source, though until solved there, this current fix can be used. Comments in [kmdutil.c] mentions the issue with the registry key possibly remaining.

>        // fallback to stopping through SCM, otherwise the
>        // driver registry key does not always disappear

The key may remain due to being in a undetermined state that `sc query sbiedrv` knows how to fix.

The Classic installer handles the KmdUtil errors though likes to do OS restarts. I prefer to avoid OS restarts if possible. i looked at [SandboxieVS.nsi], though nothing that could be considered as an improvement with handling the driver as compared with [Sandboxie-Plus.iss].

This fix helps the Plus installer run in Windows 7 similar to the experience in Windows 10.

 [kmdutil.c]: https://github.com/sandboxie-plus/Sandboxie/blob/084385e65d1b5a402eada12eb68630920db907cb/Sandboxie/install/kmdutil/kmdutil.c#L619
 [SandboxieVS.nsi]: https://github.com/sandboxie-plus/Sandboxie/blob/master/Sandboxie/install/SandboxieVS.nsi
 [Sandboxie-Plus.iss]: https://github.com/sandboxie-plus/Sandboxie/blob/master/Installer/Sandboxie-Plus.iss
