### PR TITLE
Added GitHub Workflow for Cleaning Up Build Artifacts

### DIFF
--- a/.github/workflows/workflow_artifact_cleanup.yml
+++ b/.github/workflows/workflow_artifact_cleanup.yml
@@ -1,0 +1,14 @@
+name: 'Workflow Artifact Cleanup'
+on:
+    push:
+        workflow_dispatch:
+            branches: [ master ]
+
+jobs:
+  delete-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kolpav/purge-artifacts-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          expire-in: 0


### PR DESCRIPTION
This pull request adds a workflow which can be executed manually via the GitHub website to clean up workflow build artifacts. This is useful for working on fork of the Sandboxie repository on an account which has a limited shared storage quota.