### PR TITLE
Fixes the Waterfox phishing template

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -287,8 +287,6 @@ OpenFilePath=waterfox.exe,%Tmpl.Waterfox%\sessionstore.js*
 [Template_Waterfox_Phishing_DirectAccess]
 Tmpl.Title=#4337,Waterfox
 Tmpl.Class=WebBrowser
-OpenFilePath=waterfox.exe,%Tmpl.WaterFox%\blocklist.xml
-OpenFilePath=waterfox.exe,%Tmpl.WaterFox%\cert9.db
 OpenFilePath=waterfox.exe,%Local AppData%\Waterfox\Profiles\*\safebrowsing*
 
 [Template_Waterfox_Profile_DirectAccess]


### PR DESCRIPTION
Waterfox has now stopped using two files in the phishing template. The result? Enabling Waterfox access to the phishing directory means Sandboxie refuses to start Waterfox, citing an invalid template. This fixes that.