### PR TITLE
Restore Waterfox phishing template

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -293,6 +293,8 @@ OpenFilePath=waterfox.exe,%Tmpl.Waterfox%\sessionstore.js*
 [Template_Waterfox_Phishing_DirectAccess]
 Tmpl.Title=#4337,Waterfox
 Tmpl.Class=WebBrowser
+OpenFilePath=waterfox.exe,%Tmpl.Waterfox%\blocklist.xml
+OpenFilePath=waterfox.exe,%Tmpl.Waterfox%\cert9.db
 OpenFilePath=waterfox.exe,%Local AppData%\Waterfox\Profiles\*\safebrowsing*
 
 [Template_Waterfox_Profile_DirectAccess]


### PR DESCRIPTION
Removing the lines was not correct (#1309). The file "cert9.db" is still used in the current version of Waterfox. The file "blocklist.xml" is probably still used by older versions.

The problem was not because these files supposedly no longer exist, but because the variable could not be expanded due to a typo (capitalized F).

**Wrong:**
OpenFilePath=waterfox.exe,%Tmpl.Water**F**ox%\blocklist.xml
OpenFilePath=waterfox.exe,%Tmpl.Water**F**ox%\cert9.db

**Correct:**
OpenFilePath=waterfox.exe,%Tmpl.Water**f**ox%\blocklist.xml
OpenFilePath=waterfox.exe,%Tmpl.Water**f**ox%\cert9.db