### PR TITLE
Replace default hotkey with Shift+Pause

### DIFF
--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -1024,7 +1024,7 @@ void CSandMan::SetupHotKeys()
 	m_pHotkeyManager->unregisterAllHotkeys();
 
 	if (theConf->GetBool("Options/EnablePanicKey", false))
-		m_pHotkeyManager->registerHotkey(theConf->GetString("Options/PanicKeySequence", "Ctrl+Alt+Cancel"), HK_PANIC);
+		m_pHotkeyManager->registerHotkey(theConf->GetString("Options/PanicKeySequence", "Shift+Pause"), HK_PANIC);
 }
 
 void CSandMan::OnHotKey(size_t id)

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -217,7 +217,7 @@ void CSettingsWindow::LoadSettings()
 	ui.chkNotifyRecovery->setChecked(!theConf->GetBool("Options/InstantRecovery", true));
 
 	ui.chkPanic->setChecked(theConf->GetBool("Options/EnablePanicKey", false));
-	ui.keyPanic->setKeySequence(QKeySequence(theConf->GetString("Options/PanicKeySequence", "Ctrl+Alt+Cancel")));
+	ui.keyPanic->setKeySequence(QKeySequence(theConf->GetString("Options/PanicKeySequence", "Shift+Pause")));
 
 	ui.chkWatchConfig->setChecked(theConf->GetBool("Options/WatchIni", true));
 


### PR DESCRIPTION
This is only related to Plus UI. If you set `Ctrl+Alt+Pause` hotkey on Options -> Global Settings -> General Config, this will be incorrectly displayed  as `Ctrl+Alt+Cancel`

Further reasons for changing the current hotkey (which terminates all boxed processes) were provided [here](https://github.com/sandboxie-plus/Sandboxie/pull/1337#issuecomment-952063294).

In a few words: the `Cancel` reference related to the default hotkey is automatically translated on the Plus UI as it was a Cancel button for dialogs. This conflict (partially due to how [Qt interpretes the key codes](https://github.com/sandboxie-plus/Sandboxie/pull/1337#issuecomment-952142434)) would be fixed by replacing the default `Ctrl+Alt+Cancel` with `Shift+Pause` or other alternatives I proposed [here](https://github.com/sandboxie-plus/Sandboxie/pull/1337#issuecomment-953220971).
