### PR TITLE
Update FLT_FILE_NAME_INFORMATION usage to match docs

### DIFF
--- a/Sandboxie/core/drv/file_flt.c
+++ b/Sandboxie/core/drv/file_flt.c
@@ -414,8 +414,11 @@ _FX FLT_PREOP_CALLBACK_STATUS File_PreOperation(
 								Log_Msg_Process(MSG_1319, wcPid, (PWCHAR)pStr, proc->box->session_id, proc->pid);
                                 Mem_Free(pStr, len);
                             }
-                            FltReleaseFileNameInformation(pTargetFileNameInfo);
                         }   // if (FltGetFileNameInformation)
+
+                        if (pTargetFileNameInfo != NULL) {
+                            FltReleaseFileNameInformation(pTargetFileNameInfo);
+                        }
                     }   // if (proc)
                 }   // if (ulOwnerPid)
             }   // is this the print spooler process?


### PR DESCRIPTION
This is possible a performance issue I've noticed on my system, where the `FMfn tag` pool is using increasingly more memory.

It all seems be pointing to fltMgr.sys, which I guess is this `FltGetFileNameInformation` call.

The code-path seems to be querying `FltGetFileNameInformation`, and on the success path, it only released the filename when the spool folder work is allowed.

That meant this was effectively leaking a reference to `FLT_FILE_NAME_INFORMATION` for non-spooler work folders, because as the docs state:
> After a successful call to FltGetFileNameInformation, the caller is responsible for releasing the pointer returned in the FileNameInformation parameter when the pointer is no longer needed. The caller does this by calling FltReleaseFileNameInformation.

