### PR TITLE
Fix SetCursorPos and ClipCursor ignoring DPI awareness

### DIFF
--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -123,6 +123,11 @@ typedef int (*P_ReleaseDC)(
 
 static P_GetUserObjectInformationW __sys_GetUserObjectInformationW = NULL;
 
+#ifndef _DPI_AWARENESS_CONTEXTS_
+struct DPI_AWARENESS_CONTEXT__ { int unused; };
+typedef DPI_AWARENESS_CONTEXT__ *DPI_AWARENESS_CONTEXT;
+#endif
+
 typedef DPI_AWARENESS_CONTEXT (WINAPI *P_GetThreadDpiAwarenessContext)(
     VOID);
 
@@ -322,7 +327,7 @@ _FX BOOL Gui_ClipCursor(const RECT *lpRect)
         memzero(&req.rect, sizeof(req.rect));
         Gui_ClipCursorActive = FALSE;
     }
-    req.dpi_awareness_ctx = __sys_GetThreadDpiAwarenessContext ? __sys_GetThreadDpiAwarenessContext() : NULL;
+    req.dpi_awareness_ctx = __sys_GetThreadDpiAwarenessContext ? (LONG64)(LONG_PTR)__sys_GetThreadDpiAwarenessContext() : 0;
 
     rpl = Gui_CallProxy(&req, sizeof(req), sizeof(ULONG));
     if (rpl) {
@@ -474,7 +479,7 @@ _FX BOOL Gui_SetCursorPos(int x, int y)
     req.error = GetLastError();
     req.x = x;
     req.y = y;
-    req.dpi_awareness_ctx = __sys_GetThreadDpiAwarenessContext ? __sys_GetThreadDpiAwarenessContext() : NULL;
+    req.dpi_awareness_ctx = __sys_GetThreadDpiAwarenessContext ? (LONG64)(LONG_PTR)__sys_GetThreadDpiAwarenessContext() : 0;
     rpl = Gui_CallProxyEx(&req, sizeof(req), sizeof(ULONG), TRUE);
     if (rpl) {
         retval = rpl->retval;

--- a/Sandboxie/core/svc/GuiServer.cpp
+++ b/Sandboxie/core/svc/GuiServer.cpp
@@ -85,6 +85,10 @@ typedef struct _WND_HOOK {
 
 static HWND DDE_Request_ProxyWnd = NULL;
 
+#ifndef _DPI_AWARENESS_CONTEXTS_
+struct DPI_AWARENESS_CONTEXT__ { int unused; };
+typedef DPI_AWARENESS_CONTEXT__ *DPI_AWARENESS_CONTEXT;
+#endif
 typedef DPI_AWARENESS_CONTEXT (WINAPI *P_SetThreadDpiAwarenessContext)(
     DPI_AWARENESS_CONTEXT dpiContext);
 
@@ -3051,7 +3055,7 @@ ULONG GuiServer::ClipCursorSlave(SlaveArgs *args)
         rect = &req->rect;
 
     DPI_AWARENESS_CONTEXT old_trd_dpi_ctx = __sys_SetThreadDpiAwarenessContext
-        ? __sys_SetThreadDpiAwarenessContext(req->dpi_awareness_ctx)
+        ? __sys_SetThreadDpiAwarenessContext((DPI_AWARENESS_CONTEXT)(LONG_PTR)req->dpi_awareness_ctx)
         : NULL;
 
     ClipCursor(rect); //if (! ) // as this seems to randomly fail, don't issue errors
@@ -3355,7 +3359,7 @@ ULONG GuiServer::SetCursorPosSlave(SlaveArgs *args)
         return STATUS_INFO_LENGTH_MISMATCH;
 
     DPI_AWARENESS_CONTEXT old_trd_dpi_ctx = __sys_SetThreadDpiAwarenessContext
-        ? __sys_SetThreadDpiAwarenessContext(req->dpi_awareness_ctx)
+        ? __sys_SetThreadDpiAwarenessContext((DPI_AWARENESS_CONTEXT)(LONG_PTR)req->dpi_awareness_ctx)
         : NULL;
 
     SetLastError(req->error);

--- a/Sandboxie/core/svc/GuiServer.cpp
+++ b/Sandboxie/core/svc/GuiServer.cpp
@@ -85,6 +85,10 @@ typedef struct _WND_HOOK {
 
 static HWND DDE_Request_ProxyWnd = NULL;
 
+typedef DPI_AWARENESS_CONTEXT (WINAPI *P_SetThreadDpiAwarenessContext)(
+    DPI_AWARENESS_CONTEXT dpiContext);
+
+static P_SetThreadDpiAwarenessContext __sys_SetThreadDpiAwarenessContext = NULL;
 
 //---------------------------------------------------------------------------
 // Constructor
@@ -113,6 +117,9 @@ GuiServer::GuiServer()
 	else*/
 	GetVersionExW(&osvi); // since windows 10 this one is lying
     m_nOSVersion = osvi.dwMajorVersion * 10 + osvi.dwMinorVersion;
+
+    __sys_SetThreadDpiAwarenessContext = (P_SetThreadDpiAwarenessContext)GetProcAddress(
+        GetModuleHandle(L"user32.dll"), "SetThreadDpiAwarenessContext");
 }
 
 
@@ -3043,8 +3050,16 @@ ULONG GuiServer::ClipCursorSlave(SlaveArgs *args)
     if (req->have_rect)
         rect = &req->rect;
 
+    DPI_AWARENESS_CONTEXT old_trd_dpi_ctx = __sys_SetThreadDpiAwarenessContext
+        ? __sys_SetThreadDpiAwarenessContext(req->dpi_awareness_ctx)
+        : NULL;
+
     ClipCursor(rect); //if (! ) // as this seems to randomly fail, don't issue errors
     //    return STATUS_ACCESS_DENIED; // todo: add reply and return ret value
+
+    if (__sys_SetThreadDpiAwarenessContext) {
+        __sys_SetThreadDpiAwarenessContext(old_trd_dpi_ctx);
+    }
 
     return STATUS_SUCCESS;
 }
@@ -3339,10 +3354,18 @@ ULONG GuiServer::SetCursorPosSlave(SlaveArgs *args)
     if (args->req_len != sizeof(GUI_SET_CURSOR_POS_REQ))
         return STATUS_INFO_LENGTH_MISMATCH;
 
+    DPI_AWARENESS_CONTEXT old_trd_dpi_ctx = __sys_SetThreadDpiAwarenessContext
+        ? __sys_SetThreadDpiAwarenessContext(req->dpi_awareness_ctx)
+        : NULL;
+
     SetLastError(req->error);
 
     rpl->retval = (ULONG)SetCursorPos(req->x, req->y);
     rpl->error = GetLastError();
+
+    if (__sys_SetThreadDpiAwarenessContext) {
+        __sys_SetThreadDpiAwarenessContext(old_trd_dpi_ctx);
+    }
 
     args->rpl_len = sizeof(GUI_SET_CURSOR_POS_RPL);
     return STATUS_SUCCESS;

--- a/Sandboxie/core/svc/GuiWire.h
+++ b/Sandboxie/core/svc/GuiWire.h
@@ -66,11 +66,6 @@ enum {
     GUI_MAX_REQUEST_CODE
 };
 
-#ifndef _DPI_AWARENESS_CONTEXTS_
-struct DPI_AWARENESS_CONTEXT__ { int unused; };
-typedef DPI_AWARENESS_CONTEXT__ *DPI_AWARENESS_CONTEXT;
-#endif
-
 
 //---------------------------------------------------------------------------
 // Initialize New Process
@@ -550,7 +545,7 @@ struct tagGUI_CLIP_CURSOR_REQ
     ULONG msgid;
     BOOLEAN have_rect;
     RECT rect;
-    DPI_AWARENESS_CONTEXT dpi_awareness_ctx;
+    LONG64 dpi_awareness_ctx;
 };
 
 typedef struct tagGUI_CLIP_CURSOR_REQ GUI_CLIP_CURSOR_REQ;
@@ -652,7 +647,7 @@ struct tagGUI_SET_CURSOR_POS_REQ
     ULONG error;
     LONG x;
     LONG y;
-    DPI_AWARENESS_CONTEXT dpi_awareness_ctx;
+    LONG64 dpi_awareness_ctx;
 };
 
 struct tagGUI_SET_CURSOR_POS_RPL

--- a/Sandboxie/core/svc/GuiWire.h
+++ b/Sandboxie/core/svc/GuiWire.h
@@ -66,6 +66,11 @@ enum {
     GUI_MAX_REQUEST_CODE
 };
 
+#ifndef _DPI_AWARENESS_CONTEXTS_
+struct DPI_AWARENESS_CONTEXT__ { int unused; };
+typedef DPI_AWARENESS_CONTEXT__ *DPI_AWARENESS_CONTEXT;
+#endif
+
 
 //---------------------------------------------------------------------------
 // Initialize New Process
@@ -545,6 +550,7 @@ struct tagGUI_CLIP_CURSOR_REQ
     ULONG msgid;
     BOOLEAN have_rect;
     RECT rect;
+    DPI_AWARENESS_CONTEXT dpi_awareness_ctx;
 };
 
 typedef struct tagGUI_CLIP_CURSOR_REQ GUI_CLIP_CURSOR_REQ;
@@ -646,6 +652,7 @@ struct tagGUI_SET_CURSOR_POS_REQ
     ULONG error;
     LONG x;
     LONG y;
+    DPI_AWARENESS_CONTEXT dpi_awareness_ctx;
 };
 
 struct tagGUI_SET_CURSOR_POS_RPL


### PR DESCRIPTION
This fixes the issue of `SetCursorPos` coordinates being scaled incorrectly when high-DPI display scaling is active. (#1369)

The `DPI_AWARENESS_CONTEXT` of the calling thread is passed to GuiServer, which is applied there before calling the actual WinAPI. The original `DPI_AWARENESS_CONTEXT` of the GuiServer thread is then restored immediately to prevent affecting other functions.

The same fix has been applied to `ClipCursor`, ~~but I do not have a way to test it~~. `SendInput` doesn't seem to be affect by the looks of it. I have not checked the other APIs.