### PR TITLE
Refresh and update French translations

### DIFF
--- a/Sandboxie/msgs/Text-French-1036.txt
+++ b/Sandboxie/msgs/Text-French-1036.txt
@@ -21,7 +21,7 @@ SBIE1104 Ressources système insuffisantes pour démarrer
 .
 
 1105;evt;err;01
-SBIE1105 Système d'exploitation inconnu:  %2
+SBIE1105 Système d'exploitation inconnu :  %2
 .
 
 1106;evt;err;01
@@ -29,35 +29,35 @@ SBIE1106 erreur %2, détail %3
 .
 
 # 1107;evt;err;01
-# SBIE1107 Ne peut accéder au compte du système %2
+# SBIE1107 Impossible de accéder au compte du système %2
 # .
 
 1108;evt;err;01
-SBIE1108 Procédure %2 ne peut être analysée
+SBIE1108 La procédure %2 ne peut être analysée
 .
 
 1109;evt;err;01
-SBIE1109 Information de license invalide:  %2
+SBIE1109 Information de licence invalide :  %2
 .
 
 1110;evt;err;01
-SBIE1110 ne peut intercepter type %3, erreur %2
+SBIE1110 Impossible d'intercepter le type %3, erreur %2
 .
 
 1111;evt;err;01
-SBIE1111 System DLL %3 ne peut être chargé %2
+SBIE1111 La DLL système %3 ne peut être chargée %2
 .
 
 1112;evt;err;01
-SBIE1112 Procédure %2 ne peut être localisée
+SBIE1112 La procédure %2 ne peut être localisée
 .
 
 1113;evt;err;01
-SBIE1113 Ne peut trouver système Nt, raison %2
+SBIE1113 Impossible de trouver système Nt, raison %2
 .
 
 1114;evt;err;01
-SBIE1114 Ne peut trouver système Zw, raison %2
+SBIE1114 Impossible de trouver système Zw, raison %2
 .
 
 1116;evt;err;01
@@ -65,7 +65,7 @@ SBIE1116 Le pilote ne peut enregistrer la routine de notification du processus %
 .
 
 1119;evt;err;01
-SBIE1119 Ne peut créer le périphérique API %2
+SBIE1119 Impossible de créer le périphérique API %2
 .
 
 1120;evt;err;01
@@ -77,7 +77,7 @@ SBIE1121 Echec surveillance service %2
 .
 
 1122;evt;err;01
-SBIE1122 Erreur:  %2
+SBIE1122 Erreur :  %2
 .
 
 #----------------------------------------------------------------------------
@@ -87,15 +87,15 @@ SBIE1122 Erreur:  %2
 #----------------------------------------------------------------------------
 
 1151;evt;pop;err;01
-SBIE1151 Ne peut gérer l'instruction %2
+SBIE1151 Impossible de gérer l'instruction %2
 .
 
 1152;evt;pop;err;01
-SBIE1152 Echec allocation Trampoline %2
+SBIE1152 Echec de l'allocation trampoline %2
 .
 
 1153;evt;pop;err;01
-SBIE1153 Echec démarrage Sandboxie. Fermez tous les programmes et réinstallez Sandboxie  OU Redemarrer votre ordinateur.
+SBIE1153 Echec démarrage de Sandboxie. Fermez tous les programmes et réinstallez Sandboxie  OU  redémarrer votre ordinateur.
 .
 
 #----------------------------------------------------------------------------
@@ -109,11 +109,11 @@ SBIE1201 Mémoire insuffisante
 .
 
 1202;pop;err;01
-SBIE1202 Ne peut mettre à jour la license:  %2
+SBIE1202 Impossible de mettre à jour la licence :  %2
 .
 
 1203;pop;err;01
-SBIE1203 Ne peut construire la liste des chemins (erreur dans %2)
+SBIE1203 Impossible de construire la liste des chemins (erreur dans %2)
 .
 
 1204;pop;err;01
@@ -121,51 +121,55 @@ SBIE1204 Echec création Bac à sable pour %3 %2
 .
 
 1211;pop;err;01
-SBIE1211 Ne peut démarrer processus "sandboxé" %2
+SBIE1211 Impossible de démarrer processus "sandboxé" %2
 .
 
 1212;pop;err;01
-SBIE1212 Ne peut créer le répertoire '%3' %2
+SBIE1212 Impossible de créer le répertoire '%3' %2
 .
 
 1213;pop;err;01
-SBIE1213 Ne peut créer l'objet répertoire '%3' %2
+SBIE1213 Impossible de créer l'objet répertoire '%3' %2
 .
 
-1214;pop;err;01
-SBIE1214 Ne peut injecter SbieDll %2
-.
+# 1214;pop;err;01
+# SBIE1214 Impossible de injecter SbieDll %2
+# .
 
-1215;pop;err;01
-SBIE1215 Ne peut résoudre le chemin de l'image processus %2
-.
+# 1215;pop;err;01
+# SBIE1215 Impossible de résoudre le chemin de l'image processus %2
+# .
 
-1216;pop;err;01
-SBIE1216 Echec de la requête de sécurité ID %2
-.
+# 1216;pop;err;01
+# SBIE1216 Echec de la requête de sécurité ID %2
+# .
 
 # 1217;pop;err;01
-# SBIE1217 Ne peut trouver le processus parent
+# SBIE1217 Impossible de trouver le processus parent
 # .
 
 # 1221;pop;err;01
-# SBIE1221 Ne peut créer la tâche:  %2
+# SBIE1221 Impossible de créer la tâche :  %2
 # .
 
-1222;pop;err;01
-SBIE1222 Ne peut restreindre token:  %2
+1222;pop;err;02
+SBIE1222 Erreur avec le token de sécurité :  %2
 .
 
-1223;pop;err;01
-SBIE1223 Ne peut remplacer token:  %2
-.
+# 1223;pop;err;01
+# SBIE1223 Impossible de remplacer le token :  %2
+# .
 
-1224;pop;err;01
-SBIE1224 Ne peut interroger token:  %2
+# 1224;pop;err;01
+# SBIE1224 Impossible de interroger le token :  %2
+# .
+
+1231;pop;err;01
+SBIE1231 Echec de l'initialisation pour le processus %3 %2
 .
 
 1241;pop;err;01
-SBIE1241 Ne peut monter la Ruche Registre:  %2
+SBIE1241 Impossible de monter la ruche du registre :  %2
 .
 
 1242;pop;err;01
@@ -179,7 +183,7 @@ SBIE1242 Moniteur débordement cache
 #----------------------------------------------------------------------------
 
 1301;pop;inf;01
-SBIE1301 Le programme '%2' à démarré hors du Bac à sable
+SBIE1301 Le programme '%2' a démarré hors du Bac à sable
 .
 
 # 1302;pop;inf;01
@@ -190,48 +194,64 @@ SBIE1301 Le programme '%2' à démarré hors du Bac à sable
 SBIE1303 Un seul Bac à sable peut être activé à la fois
 .
 
-1304;pop;inf;01
-SBIE1304 Simulation clavier ou souris bloquée par processus '%2'
-.
+# 1304;pop;inf;01
+# SBIE1304 Simulation clavier ou souris bloquée par processus '%2'
+# .
 
 1306;pop;inf;01
 SBIE1306 Le pilote Sandboxie (SbieDrv) ne peut être déchargé actuellement
 .
 
 1307;pop;inf;02
-SBIE1307 Le programme ne peut accéder à Internet à cause des Restrictions - %2
+SBIE1307 Le programme ne peut accéder à Internet à cause des restrictions - %2
 .
 
 1308;pop;inf;02
-SBIE1308 Le programme ne peut démarrer à causes des Restrictions - %2
+SBIE1308 Le programme ne peut démarrer à causes des restrictions - %2
 .
 
 1309;pop;inf;01
-SBIE1309 Accés refusé pour changer mot de passe du compte
+SBIE1309 Accès refusé pour changer mot de passe du compte
 .
 
 1310;pop;inf;01
 SBIE1310 Les fonctionnalités étendues sont désactivées jusqu'à la réactivation de la licence
 .
 
-1311;pop;inf;01
-SBIE1311 Blocage de la demande de changement de l'arrière-plan du bureau par processus '%2'
-.
+#1311;pop;inf;01
+#SBIE1311 Blocage de la demande de changement de l'arrière-plan du bureau par processus '%2'
+#.
 
 1312;pop;inf;01
 SBIE1312 Blocage de la demande pour démarrer un programme 16 bit dans la sandbox
 .
 
 1313;pop;inf;01
-SBIE1313 Accès direct au disque est bloqué par le(s) processu(s) de %2
+SBIE1313 Accès direct au disque est bloqué par le(s) processus de %2
 .
 
 1314;pop;inf;01
 SBIE1314 Blocage de la demande pour modifier les paramètres du pare-feu/réseau par le processus '%2'
 .
 
-1315;pop;inf;01
-SBIE1315 Probablement en raison d'un conflit avec le logiciel: %2
+# 1315;pop;inf;01
+# SBIE1315 Probablement en raison d'un conflit avec le logiciel : %2
+# .
+
+316;pop;inf;01
+SBIE1316 Requête bloquée afin de générer un évènement d'appareil (Device) dans le Bac à sable
+.
+
+1319;pop;inf;01
+SBIE1319 Impression vers un fichier bloquée, %2 %3
+.
+
+1320;pop;wrn;01
+SBIE1320 Pour autoriser le Spouleur d'impression à écrire dans des fichiers en dehors du Bac à sable, veuillez double-cliquer sur ce message
+.
+
+1399;pop;inf;01
+%0
 .
 
 #----------------------------------------------------------------------------
@@ -245,23 +265,23 @@ SBIE1401 Fichier de configuration introuvable, utilisation réglages par défaut
 .
 
 1402;evt;pop;wrn;01
-SBIE1402 Erreur du fichier configuration à la ligne %3:  %2
+SBIE1402 Erreur du fichier configuration à la ligne %3 :  %2
 .
 
 1403;evt;pop;wrn;01
-SBIE1403 Erreur du fichier configuration à la ligne %2:  ligne trop longue
+SBIE1403 Erreur du fichier configuration à la ligne %2 :  ligne trop longue
 .
 
 1404;evt;pop;wrn;01
-SBIE1404 Erreur du fichier configuration à la ligne %2:  trop de lignes
+SBIE1404 Erreur du fichier configuration à la ligne %2 :  trop de lignes
 .
 
 1405;evt;pop;wrn;01
-SBIE1405 Erreur du fichier configuration à la ligne %2:  Erreur de syntaxe
+SBIE1405 Erreur du fichier configuration à la ligne %2 :  erreur de syntaxe
 .
 
 1406;evt;pop;err;01
-SBIE1406 Expansion manquante ou invalide pour %3:  %2
+SBIE1406 Expansion manquante ou invalide pour %3 :  %2
 .
 
 # 1407;evt;pop;err;01
@@ -269,15 +289,15 @@ SBIE1406 Expansion manquante ou invalide pour %3:  %2
 # .
 
 1408;pop;err;01
-SBIE1408 Nom d'utilisateur inconnu pour SID:  %2
+SBIE1408 Nom d'utilisateur inconnu pour le SID :  %2
 .
 
 1409;evt;pop;wrn;01
-SBIE1409 le fichier "templates.ini"ne peut-être ouvert
+SBIE1409 Le fichier "templates.ini" ne peut être ouvert
 .
 
 1410;evt;pop;wrn;01
-SBIE1410 le message suivant indique une erreur dans le fichier "templates.ini"
+SBIE1410 Le message suivant indique une erreur dans le fichier "templates.ini"
 .
 
 1411;evt;pop;wrn;01
@@ -285,7 +305,7 @@ SBIE1411 Sandbox %2 indique un modèle inconnu %3
 .
 
 1412;evt;pop;err;01
-SBIE1412 Dansle texte: %2
+SBIE1412 Dans le texte : %2
 .
 
 #----------------------------------------------------------------------------
@@ -311,7 +331,7 @@ SBIE2104 Echec à la fermeture de cette session Windows - %2
 .
 
 # 2105;pop;inf;01
-# SBIE2105 Service "sandboxé" démarré avec succès:  %2
+# SBIE2105 Service "sandboxé" démarré avec succès :  %2
 # .
 
 # 2106;pop;inf;01
@@ -323,19 +343,27 @@ SBIE2104 Echec à la fermeture de cette session Windows - %2
 # .
 
 2108;pop;inf;01
-SBIE2108 Simulation achèvement du programme '%2' réussi
+SBIE2108 Simulation de l'achèvement du programme '%2' réussi
 .
 
 2191;pop;inf;01
-SBIE2191 %2 ne devra pas pas être mis à jour pendant son fonctionnement dans sandboxie.
+SBIE2191 %2 ne devra pas être mis à jour pendant son fonctionnement dans Sandboxie.
 .
 
 2192;pop;inf;01
-SBIE2192 Pour mettre à jour le programme,son exécution doit se faire en dehors de sandboxie.
+SBIE2192 Pour mettre à jour le programme, son exécution doit se faire en dehors de Sandboxie.
 .
 
 2193;pop;inf;01
-SBIE2193 Assurez-vous d'avoir éffacer la sandbox après le processus de mise à jour.
+SBIE2193 Assurez-vous d'avoir effacé la sandbox après le processus de mise à jour.
+.
+
+2194;pop;inf;01
+SBIE2194 L'installateur de MSI a besoin que l'option %s soit placée dans l'ini, ce qui affaiblit cependant l'isolement.
+.
+
+2198;pop;inf;01
+%0
 .
 
 2199;pop;inf;01
@@ -357,15 +385,15 @@ SBIE2201 %2
 # .
 
 2203;pop;wrn;01
-SBIE2203 Echec de la communication avec le service Sandboxie:  %2
+SBIE2203 Echec de la communication avec le service Sandboxie :  %2
 .
 
 2204;pop;wrn;01
-SBIE2204 Ne peut démarrer le service "sandboxé" %2
+SBIE2204 Impossible de démarrer le service "sandboxé" %2
 .
 
 2205;pop;wrn;01
-SBIE2205 Service non éxécuté:  %2
+SBIE2205 Service non exécuté :  %2
 .
 
 2206;pop;wrn;01
@@ -373,23 +401,23 @@ SBIE2206 Echec du traitement AutoExec %2
 .
 
 2207;pop;wrn;01
-SBIE2207 Valeur Invalide réglage value for setting '%2', réglages par défaut
+SBIE2207 Valeur invalide du réglage '%2', utilisation du réglage par défaut
 .
 
 2208;pop;wrn;01
-SBIE2208 Ne peut enlever la Ruche Registre:  %2
+SBIE2208 Impossible de enlever la Ruche Registre :  %2
 .
 
 2209;pop;wrn;01
-SBIE2209 Ne peut traduire SID en nom utilisateur:  %2
+SBIE2209 Impossible de traduire SID en nom utilisateur :  %2
 .
 
 2210;pop;wrn;01
-SBIE2210 Ne peut démarrer l'Explorateur Windows pour:  %2
+SBIE2210 Impossible de démarrer l'Explorateur Windows pour :  %2
 .
 
 2211;pop;wrn;01
-SBIE2211 Echec au démarrage du service "sandboxé":  %2
+SBIE2211 Echec au démarrage du service "sandboxé" :  %2
 .
 
 2212;pop;wrn;01
@@ -397,19 +425,19 @@ SBIE2212 Le lecteur de courrier '%2' n'est pas configuré pour démarrer "sandbo
 .
 
 2213;pop;wrn;01
-SBIE2213 Les Identités Windows ne peuvent être stockées dans la sandbox
+SBIE2213 Les identités Windows ne peuvent être stockées dans la sandbox
 .
 
 2214;pop;wrn;01
-SBIE2214 Demande d'éxécution service '%2' refusée en raison de droits restreints
+SBIE2214 Demande d'exécution service '%2' refusée en raison de droits restreints
 .
 
 2217;pop;wrn;02
-SBIE2217 Demande d'éxécution comme "administrateur" a été refusée à cause des droits restreints
+SBIE2217 Demande d'exécution comme "administrateur" a été refusée à cause des droits restreints
 .
 
 2218;pop;wrn;01
-SBIE2218 echec pour l'obtention de droits plus élevés:  %2
+SBIE2218 Echec de l'obtention des droits plus élevés :  %2
 .
 
 2219;pop;wrn;01
@@ -417,19 +445,23 @@ SBIE2219 Une demande a été émise par le programme %2
 .
 
 2220;pop;wrn;01
-SBIE2220 Pour avoir les droits administrateurs, double-cliquer sur cette ligne du message
+SBIE2220 Pour avoir les droits administrateurs, double-cliquez sur cette ligne du message
 .
 
 2221;pop;wrn;01
-SBIE2221 Pour ajouter au programme un accès restreint à internet, double-cliquer sur cette ligne du message
+SBIE2221 Pour ajouter au programme un accès restreint à internet, double-cliquez sur cette ligne du message
 .
 
 2222;pop;wrn;01
-SBIE2222 Pour ajouter au programme des restrictions d'accès au démarrage et en exécution, double-cliquer sur cette ligne du message
+SBIE2222 Pour ajouter au programme des restrictions d'accès au démarrage et en exécution, double-cliquez sur cette ligne du message
 .
 
 2223;pop;wrn;01
-SBIE2223 Pour augmenter la taille limite des fichiers à copier, double-cliquer sur cette ligne du message
+SBIE2223 Pour augmenter la taille limite des fichiers à copier, double-cliquez sur cette ligne du message
+.
+
+2224;pop;wrn;01
+SBIE2224 Le programme du Bac à sable a planté : %2
 .
 
 #----------------------------------------------------------------------------
@@ -442,8 +474,12 @@ SBIE2223 Pour augmenter la taille limite des fichiers à copier, double-cliquer 
 SBIE2301 %2
 .
 
+2302;pop;err;01
+SBIE2302 Conflit dans la configuration de l'image du processus : %2
+.
+
 2303;pop;err;01
-SBIE2303 Ne peut surveiller %2
+SBIE2303 Impossible de surveiller %2
 .
 
 2304;pop;err;01
@@ -455,19 +491,19 @@ SBIE2305 Débordement mémoire
 .
 
 2306;pop;err;01
-SBIE2306 Ne peut localiser le répertoire utilisateur:  %2
+SBIE2306 Impossible de localiser le répertoire utilisateur :  %2
 .
 
 2307;pop;err;01
-SBIE2307 Ne peut mapper le lecteur %2
+SBIE2307 Impossible de mapper le lecteur %2
 .
 
 2308;pop;err;01
-SBIE2308 Ne peut créer l'objet répertoire:  %2
+SBIE2308 Impossible de créer l'objet répertoire :  %2
 .
 
 2309;pop;err;01
-SBIE2309 Ne peut désativer COM+/DCOM:  %2
+SBIE2309 Impossible de désactiver COM+/DCOM :  %2
 .
 
 2310;pop;err;01
@@ -475,82 +511,92 @@ SBIE2310 Le nom du cache approche du débordement (%2)
 .
 
 2311;pop;err;01
-SBIE2311 Ne peut désactiver la corbeille (BitBucket):  %2
+SBIE2311 Impossible de désactiver la corbeille (BitBucket) :  %2
 .
 
 2312;pop;err;01
-SBIE2312 Ne peut activer réglages BrowseNewProcess :  %2
+SBIE2312 Impossible d'activer les réglages BrowseNewProcess :  %2
 .
 
 2313;pop;err;01
-SBIE2313 Ne peut éxécuter %2
+SBIE2313 Impossible d'exécuter %2
 .
 
 2314;pop;err;01
-SBIE2314 Abandon processus %2
+SBIE2314 Abandon du processus %2
 .
 
-2315;pop;err;01
-SBIE2315 Ne peut réparer l'image éxécutable
-.
+# 2315;pop;err;01
+# SBIE2315 Impossible de réparer l'image exécutable
+# .
 
 2316;pop;err;01
 SBIE2316 Corruption mémoire
 .
 
 2317;pop;err;01
-SBIE2317 Ne peut initialiser la liste des chemins '%2'
+SBIE2317 Impossible d'initialiser la liste des chemins '%2'
 .
 
 2318;pop;err;01
-SBIE2318 Echec initialisation DLL '%2'
+SBIE2318 Echec d'initialisation DLL '%2'
 .
 
 # 2319;pop;err;01
-# SBIE2319 Echec contexte d'activation du processus "sandboxé" %2
+# SBIE2319 Echec d'activation du contexte du processus "sandboxé" %2
 # .
 
 # 2320;pop;err;01
-# SBIE2320 Ne peut désactiver l'Explorateur Windows comme processus:  %2
+# SBIE2320 Impossible de désactiver l'Explorateur Windows comme processus de bureau :  %2
 # .
 
 2321;pop;err;01
-SBIE2321 Ne peut gérer périphérique:  %2
+SBIE2321 Impossible de gérer les périphériques :  %2
 .
 
 2322;pop;err;01
-SBIE2322 Ne peut réécrire Sandboxie.ini:  %2
+SBIE2322 Impossible de réécrire Sandboxie.ini :  %2
 .
 
 2323;pop;err;01
-SBIE2323 Erreur de cryptage:  %2
+SBIE2323 Erreur de chiffrement :  %2
 .
 
 2326;pop;err;01
-SBIE2326 Ne peut préparer le Registre:  %2
+SBIE2326 Impossible de préparer le Registre :  %2
 .
 
 2327;pop;err;01
-SBIE2327 Erreur du serveur COM:  %2
+SBIE2327 Erreur du serveur COM :  %2
 .
 
 2331;pop;err;01
-SBIE2331 echec démarrage service:  %2
+SBIE2331 Echec du démarrage du service :  %2
 .
 
 2332;pop;err;01
-SBIE2332 Ne peut accéder au fichier "SbiePst.dat"
+SBIE2332 Impossible de accéder au fichier "SbiePst.dat"
 .
 
 # 2333;pop;err;01
-# SBIE2333 Des "DLL" incompatibles ont été trouvées:  %2
+# SBIE2333 Des "DLL" incompatibles ont été trouvées :  %2
 # .
 
-2334;pop;err;01
-SBIE2334 Ne peut charger les fichier "DLL":  %2
+#2334;pop;err;01
+#SBIE2334 Impossible de charger le fichier "DLL" :  %2
+#.
+
+2335;pop;err;01
+SBIE2335 Initialisation échouée pour le processus %2
 .
 
+2336;pop;err;01
+SBIE2336 Erreur dans le serveur graphique :  %2
+.
 
+2337;pop;err;01
+SBIE2337 Echec de démarrage du programme :  %2
+.
 
 #----------------------------------------------------------------------------
 # SbieSvc
@@ -561,7 +607,7 @@ SBIE9101 Ressources système insuffisantes
 .
 
 9153;evt;err;01
-SBIE9153 Ne peut démarrer le pilote (SbieDrv)
+SBIE9153 Impossible de démarrer le pilote (SbieDrv)
 .
 
 9154;evt;err;01
@@ -569,63 +615,54 @@ SBIE9154 Pilote (SbieDrv) et service (SbieSvc) sont de versions différentes
 .
 
 9156;evt;err;01
-SBIE9156 Initialisation driver incomplète
+SBIE9156 Initialisation du pilote incomplète
 .
 
-9201;evt;err;01
-SBIE9201 Erreur Token
-.
+9234;evt;err;01
+SBIE9234 Erreur de démarrage du service %2
 
-9202;evt;err;01
-SBIE9202 ErreurToken
-.
-
-9203;evt;err;01
-SBIE9203 erreur Token
-.
-
-9204;evt;err;01
-SBIE9204 Erreur descripteur de sécurité
-.
-
-9205;evt;err;01
-SBIE9205 Erreur descripteur de sécurité
-.
-
-9206;evt;err;01
-SBIE9206 Erreur descripteur de sécurité
-.
-
-9207;evt;err;01
-SBIE9207 Erreur descripteur de sécurité
-.
-
-9208;evt;err;01
-SBIE9208 Echec activation SeRestorePrivilege
-.
-
-9251;evt;err;01
-SBIE9251 Echec création évènement de Port
-.
-
-9252;evt;err;01
-SBIE9252 Echec création Port
-.
-
-9253;evt;err;01
-SBIE9253 Echec création Port thread
-.
-
-# 9302;evt;err;01
-# SBIE9302 Echec création section (device setup classes)
+# 9201;evt;err;01
+# SBIE9201 Erreur Token
 # .
 
-# 9304;evt;err;01
-# SBIE9304 Echec création section (device id list)
+# 9202;evt;err;01
+# SBIE9202 Erreur Token
 # .
 
-# 9305;evt;err;01
-# SBIE9305 Quitter programmes "sandboxés, s'il y en a
+# 9203;evt;err;01
+# SBIE9203 Erreur Token
+# .
+
+# 9204;evt;err;01
+# SBIE9204 Erreur de descripteur de sécurité
+# .
+
+# 9205;evt;err;01
+# SBIE9205 Erreur de descripteur de sécurité
+# .
+
+# 9206;evt;err;01
+# SBIE9206 Erreur de descripteur de sécurité
+# .
+
+# 9207;evt;err;01
+# SBIE9207 Erreur de descripteur de sécurité
+# .
+
+# 9208;evt;err;01
+# SBIE9208 Echec d'activation SeRestorePrivilege
+# .
+
+# 9251;evt;err;01
+# SBIE9251 Echec de création d'évènement de Port
+# .
+
+# 9252;evt;err;01
+# SBIE9252 Echec de création de Port
+# .
+
+# 9253;evt;err;01
+# SBIE9253 Echec de création du thread du Port
 # .
 
 #----------------------------------------------------------------------------
@@ -653,7 +690,7 @@ Cou&per
 .
 
 3051;txt;01
-Protection effacement activé pour le Bac à sable
+Protection contre l'effacement activée pour le Bac à sable
 .
 
 3052;txt;01
@@ -696,51 +733,52 @@ Bureau
 (explorer le dossier)
 .
 
+# should match the localized folder name for Programs in the Start Menu folder
 3114;txt;01
 Programmes
 .
 
 3202;txt;01
-Invalid command line parameter:  %2
+Paramètre de ligne de commande invalide : %2
 .
 
 3203;txt;01
-Usage: Start.exe <program name>
+Usage : Start.exe <nom du programme>
 .
 
 3204;txt;01
-Paramètre de boîte invalide:  %2
+Paramètre du bac invalide : %2
 .
 
 3205;txt;01
-Ne peut appeler le programme:
+Impossible d'appeler le programme :
 
 %2
 .
 
 3206;txt;01
-Code erreur système:
+Code erreur système :
 .
 
 # 3207;txt;01
-# Ne peut trouver l'éxécutable Internet Explorer
+# Impossible de trouver l'exécutable Internet Explorer
 # .
 
 # 3208;txt;01
-# Ne peut trouver l'éxécutable du navigateur Internet par défaut
+# Impossible de trouver l'exécutable du navigateur Internet par défaut
 # .
 
 3209;txt;01
-Ne peut trouver l'éxécutable du lecteur de courrier par défaut
+Impossible de trouver l'exécutable du lecteur de courrier par défaut
 .
 
 3210;txt;01
-Ne peut démarrer le programme Sandboxie Control
+Impossible de démarrer le programme Sandboxie Control
 .
 
-3211;txt;01
-Incohérence de version Sandboxie.  Essayez de réinstaller.
-.
+# 3211;txt;01
+# Incohérence de version Sandboxie.  Essayez de réinstaller.
+# .
 
 3212;txt;01
 Le driver Sandboxie (SbieDrv) n'est pas disponible pour les programmes Bac à sable.
@@ -748,11 +786,11 @@ Assurez-vous que le driver et le service Sandboxie (SbieSvc) sont correctement d
 .
 
 3213;txt;01
-Ne peut initialiser les services Sandboxie COM
+Impossible d'initialiser les services Sandboxie COM
 .
 
 3214;txt;01
-Effacement Bac à sable %2:  %0
+Effacement Bac à sable %2 :  %0
 .
 
 3215;txt;01
@@ -761,23 +799,23 @@ Fermez les programmes ou fenêtres pouvant bloquer l'accès.
 .
 
 3216;txt;01
-Ne peut localiser le dossier Bac à sable
+Impossible de localiser le dossier Bac à sable
 .
 
 3217;txt;01
-Ne peut ouvrir le dossier Bac à sable
+Impossible d'ouvrir le dossier Bac à sable
 .
 
 3218;txt;01
-Ne peut ouvrir le dossier contenant le dossier Bac à sable
+Impossible d'ouvrir le dossier contenant le dossier Bac à sable
 .
 
 3219;txt;01
-Ne peut déplacer le dossier Bac à sable
+Impossible de déplacer le dossier Bac à sable
 .
 
 3220;txt;01
-Erreur en renommant un long fichiers du Bac à sable.
+Erreur en renommant un long fichier du Bac à sable.
 Le Bac à sable ne peut être effacé.
 .
 
@@ -786,7 +824,7 @@ Veuillez fermer les programmes lancés dans le Bac à sable avant d'en effacer l
 .
 
 3222;txt;01
-Echec commande d'effacement:  %0
+Echec commande d'effacement :  %0
 .
 
 3231;txt;01
@@ -810,11 +848,11 @@ Cette limitation est supprimée dans la version payante de Sandboxie.
 .
 
 3236;txt;01
-En plus, la version payante permet d'éxécuter des programmes "sandboxés" automatiquement.
+En plus, la version payante permet d'exécuter des programmes "sandboxés" automatiquement.
 .
 
 3237;txt;01
-Pour plus d'informations ou pour acheter le programme, cliquez sur le lien suivant:
+Pour plus d'informations ou pour acheter le programme, cliquez sur le lien suivant :
 .
 
 3238;txt;01
@@ -830,16 +868,16 @@ Cliquez pour arrêter et fermer cette fenêtre
 .
 
 3241;txt;01
-Sandboxie demande des droits "administrateur"pour le programme qui s'éxecute dans la sandbox.
+Sandboxie demande des droits "administrateur" pour le programme qui s'exécute dans la sandbox.
 .
 
 3242;txt;01
 Pour refuser ou accepter la demande, activer la
-fenêtre User Account Control pop-up.
+fenêtre User Account Control.
 .
 
 3243;txt;01
-Remarque: le programme va continuer à s'exécuter dans Sandboxie,
+Remarque : le programme va continuer à s'exécuter dans Sandboxie,
 même après que des droits administrateurs aient été accordés.
 .
 
@@ -848,29 +886,29 @@ Démarrer en dehors de la sandbox
 .
 
 3252;txt;01
-Démarre le programme volontairement à l'extérieur du panneau de contrôle de sandboxie,
-même si le programme est forcé dans sandboxie,
+Démarre le programme volontairement à l'extérieur du panneau de contrôle de Sandboxie,
+même si le programme est forcé dans Sandboxie,
 ceci s'applique aussi à tous les programmes démarrés par ce programme.
 
 Vous pouvez aussi utiliser cette option en maintenant les touches "ctrl" et "shift"
-enfoncées quand vous cliquez sur la commande "executer sandboxé".
+enfoncées quand vous cliquez sur la commande "exécuter sandboxé".
 .
 
 3253;txt;01
-Es-tu sur de vouloir utiliser ce programme à l'extérieur de la sandbox?
+Etes-vous sûr de vouloir utiliser ce programme à l'extérieur de la sandbox ?
 .
 
 3254;txt;01
 Passer cette fenêtre en maintenant enfoncé la touche "ctrl"
-quand vous cliquez sur la commande "executer Sandboxé".
+quand vous cliquez sur la commande "exécuter Sandboxé".
 .
 
 3255;txt;01
-L'option est désactivée car des droits restreints sont activés dans cette sandbox.
+L'option est désactivée car des droits restreints sont activés dans cette sandbox
 .
 
 3256;txt;01
-L'option est désactivée car ce programme s'execute déjà avec les droits administrateurs
+L'option est désactivée car ce programme s'exécute déjà avec les droits administrateurs
 .
 
 #----------------------------------------------------------------------------
@@ -890,13 +928,13 @@ Version %2
 .
 
 3304;txt;01
-Incohérence de version de Sandboxie:
+Incohérence de version de Sandboxie :
 
-Sandboxie Control: Version %2
-Service (SbieSvc): Version %3
-Pilote (SbieDrv): Version %4
+Sandboxie Control : Version %2
+Service (SbieSvc) : Version %3
+Pilote (SbieDrv) : Version %4
 
-réinstallez Sandboxie pour résoudre le problème.
+Réinstallez Sandboxie pour résoudre le problème.
 
 Abandon.
 .
@@ -915,15 +953,15 @@ Programmes#*.EXE#Tous les fichiers#*.*##
 .
 
 3309;txt;01
-  -  Effacer Sandbox
+  -  Effacer la Bac à sable
 .
 
 3311;txt;01
-Echec à l'enregistrement de la configuration %3 en section %2:  %4
+Echec à l'enregistrement de la configuration %3 en section %2 :  %4
 .
 
 3312;txt;01
-Vous n'êtes pas autorisés à mettre à jour la configuration en section %2
+Vous n'êtes pas autorisé à mettre à jour la configuration en section %2
 .
 
 3313;txt;01
@@ -939,13 +977,13 @@ Une erreur est survenue en appliquant les réglages par défaut au Bac à sable 
 # .
 
 # 3322;txt;01
-# Votre session de connexion est en cours sous le contrôle de sandboxie.
+# Votre session de connexion est en cours sous le contrôle de Sandboxie.
 # Effacer le contenu de la sandbox, va annuler toutes les modifications effectuées pendant la session.
 # 
-# Compte utilisateur: %2
-# Sandbox: %3
+# Compte utilisateur : %2
+# Sandbox : %3
 # 
-# Etes-vous sur de vouloir effacer le contenu de la sandbox et de se déconnecter?
+# Etes-vous sur de vouloir effacer le contenu de la sandbox et de se déconnecter ?
 # .
 
 3351;txt;01
@@ -1005,11 +1043,11 @@ Désactiver les programmes &Forcés
 .
 
 3414;txt;01
-Exécuté comme Administrateur &UAC
+Exécuter comme Administrateur &UAC
 .
 
 3415;txt;01
-Cette &Fenêtre est-elle "Sandboxée"?
+Cette &Fenêtre est-elle "Sandboxée" ?
 .
 
 3416;txt;01
@@ -1037,7 +1075,11 @@ Cette &Fenêtre est-elle "Sandboxée"?
 .
 
 3425;txt;01
-Le journal de la partie récupération
+&Journal de récupération
+.
+
+3426;txt;01
+&Toujours au-dessus
 .
 
 3431;txt;01
@@ -1069,7 +1111,11 @@ Alertes &programme
 .
 
 3443;txt;01
-&Integration Windows Shell
+&Intégration Windows Shell
+.
+
+3501;txt;01
+Compatibilité avec les autres programmes
 .
 
 3444;txt;01
@@ -1078,6 +1124,10 @@ Délaisser &messages cachés
 
 3445;txt;02
 &Astuces
+.
+
+3502;txt;01
+Protection de la configuration
 .
 
 3446;txt;01
@@ -1094,6 +1144,10 @@ Re&charger la configuration
 
 3449;txt;01
 &Cacher toutes les astuces
+.
+
+3504;txt;01
+&Soutenir Sandboxie
 .
 
 3451;txt;01
@@ -1120,6 +1174,22 @@ Vérifier les &mises à jour
 &A propos de Sandboxie
 .
 
+3457;txt;01
+&Forum Sandboxie (Internet)
+.
+
+3458;txt;01
+Autoriser l'accès direct au cache de polices de Windows
+.
+
+3459;txt;01
+Autoriser l'accès direct au pilote qWave (Google Hangouts)
+.
+
+3460;txt;01
+Personnalisation de l'accrochage aux fonctions
+.
+
 3461;txt;01
 &Exécuter "sandboxé"
 .
@@ -1142,6 +1212,10 @@ Exécuter dans le &menu Démarrer
 
 3466;txt;01
 Exécuter l'Explorateur &Windows
+.
+
+3467;txt;01
+Passer à Sandboxie-Plus
 .
 
 3471;txt;01
@@ -1181,7 +1255,11 @@ Configuration P&rogramme
 .
 
 3483;txt;01
-Accès &ressources
+Accès aux &ressources
+.
+
+3484;txt;01
+Accès aux ressources
 .
 
 3485;txt;01
@@ -1220,18 +1298,6 @@ E&ffacer le dossier de la Récupération Rapide
 Créer un raccourci vers le bureau
 .
 
-3501;txt;01
-Compatibilité avec les autres programmes
-.
-
-3503;txt;01
-Protection expérimental (64-bit)
-.
-
-3502;txt;01
-Protection de la configuration
-.
-
 #----------------------------------------------------------------------------
 # Sandboxie Control Main Window
 #----------------------------------------------------------------------------
@@ -1251,14 +1317,14 @@ qu'après son rechargement.
 
 Généralement, la configuration sera rechargée
 automatiquement à la fermeture de la 
-fenêtre de l"éditeur de texte.
+fenêtre de l'éditeur de texte.
 
 Vous pouvez également forcer Sandboxie Control
 à recharger la configuration.
 .
 
 3513;txt;01
-La configuration de Sandboxie à été rechargée et
+La configuration de Sandboxie a été rechargée et
 s'appliquera au prochain programme lancé.
 
 Si un programme est déjà "sandboxé", 
@@ -1266,7 +1332,7 @@ la configuration ne lui sera pas appliquée.
 .
 
 3514;txt;01
-Un problème à bloqué la lecture du fichier de configuration.
+Un problème a bloqué la lecture du fichier de configuration.
 La configuration de Sandboxie n'a pas été modifiée.
 .
 
@@ -1327,7 +1393,7 @@ Entrer le nom du nouveau Bac à sable
 .
 
 3529;txt;01
-Etes-vous sûr de vouloir effacer le Bac à sable %2?
+Etes-vous sûr de vouloir effacer le Bac à sable %2 ?
 .
 
 3530;txt;01
@@ -1335,10 +1401,10 @@ Il n'a pas de processus à terminer.
 .
 
 3531;txt;01
-ATTENTION: Terminer le(s) processus ne permettra pas
+ATTENTION : terminer le(s) processus ne permettra pas
 aux données d'être sauvegardées.
 
-Etes-vous sûr de fermer le(s) processus?
+Etes-vous sûr de fermer le(s) processus ?
 .
 
 3532;txt;01
@@ -1358,7 +1424,7 @@ Vous pouvez ouvrir des programmes ou des documents du Bac à sable.
 Le programme ou le document sera pris en charge par Sandboxie.
 
 Toutefois, il est conseillé de manipuler le contenu du Bac à sable par le biais
-de l'Explorateur Windows.  Pour cela, vous devez utiliser la commande:
+de l'Explorateur Windows.  Pour cela, vous devez utiliser la commande :
 Sandbox -> Exécuter "sandboxé" -> Exécuter l'Explorateur Windows.
 .
 
@@ -1379,59 +1445,46 @@ L'attribut "ne pas montrer ce message" est appliqué à toutes les astuces.
 .
 
 3539;txt;01
-Sandbox '%2' a été créée, il y a %3 jour(s).
+La Sandbox '%2' a été créée, il y a %3 jour(s).
 
-Penser à effacer le contenu de la sandbox de temps en temps.
+Pensez à effacer le contenu de la sandbox de temps en temps.
 
-Pour configurer la suppresssion automatique, aller dans "sandboxie control","menu contextuel", "configuration sandbox" 
-"Delete","effacer invocation".
+Pour configurer la suppression automatique, aller dans "Sandboxie control", "menu contextuel", "configuration sandbox"
+"Delete", "effacer invocation".
 .
 
 3540;txt;01
-La configuration du fichier "The Sandboxie.ini ne peut être enregistrée 
-car il est protégé. Pour modifer ce fichier, il faut de rendre dans "lock configuration"
-et il faut désactivé "la protection par mot de passe".
+La configuration du fichier "Sandboxie.ini" ne peut être éditée car elle est
+protégée par mot de passe. Pour la modifier, merci de vous rendre
+dans "lock configuration" et désactiver la protection par mot de passe.
 .
 
 3541;txt;01
 Public
 .
 
-3542;txt;01
-Le mode "Experimental Protection" renforce la protection
-offerte par la version 64-bit, cela apporte le même niveau de protection que la version 32-bit.
+# 3542;txt;01
+# Le mode "Experimental Protection" renforce la protection
+# offerte par la version 64-bit, cela apporte le même niveau de protection que la version 32-bit.
+#
+# IMPORTANT :  "Experimental Protection" utilise des fonctionnalités du kernel de Windows,
+# les fonctionnalités mises à jour de Windows peuvent interférer avec ce mode
+# et peuvent rendre votre système instable.
+#
+# SON UTILISATION EST DANGEREUSE.
+#
+# Pour activer ce mode, veuillez redémarrer votre pc.
+# .
 
-IMPORTANT:  "Experimental Protection" utilise des fonctionnalités du kernel de windows,
-les futures mise à jour de windows peuvent interférer avec ce mode 
-et peut rendre votre système instable.
-
-SON UTILISATION EST DANGEREUSE.
-
-Pour activer ce mode, il faut maintenant redémarrer son pc.
-.
-
-3543;txt;01
-Pour désactiver ce mode, il faut maintenant redémarrer son pc.
-
-Il faut noter que le paramètre des droits restreints
-seront activés dans tous les sandbox.
-.
-
-3551;txt;01
-(Tous les programmes, sauf %2)
-.
-
-3552;txt;01
-Inverser la selection courante
-.
-
-3599;txt;01
-Tu peux désactiver le forcage d'un programme en maintenant enfoncé la touche "ctrl"
-et "shift" et "la flèche du bas" quand, tu cliques sur "executer sandboxé" pour ce programme.
-.
+# 3543;txt;01
+# Pour désactiver ce mode, veuillez redémarrer votre pc.
+#
+# Notez que le paramètre des droits restreints
+# sera activé dans toutes les Sandboxes.
+# .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: About/Welcome
+# Sandboxie Control Dialogs : About/Welcome
 #----------------------------------------------------------------------------
 
 3601;txt;01
@@ -1461,7 +1514,7 @@ A propos de Sandboxie
 # .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Update
+# Sandboxie Control Dialogs : Update
 #----------------------------------------------------------------------------
 
 3621;txt;01
@@ -1469,7 +1522,7 @@ Vérifier les mises à jour
 .
 
 3622;txt;01
-Se connecter au site de Sandboxie pour vérifier si une nouvelle version est disponible?
+Se connecter au site de Sandboxie pour vérifier si une nouvelle version est disponible ?
 .
 
 3623;txt;01
@@ -1489,7 +1542,7 @@ Dorénavant, vérifier les mises à jour automatiquement
 .
 
 3627;txt;01
-Charte de confiance: Vos coordonnées ne seront jamais transmises par Sandboxie.
+Charte de confiance : vos coordonnées ne seront jamais transmises par Sandboxie.
 .
 
 3628;txt;01
@@ -1505,9 +1558,9 @@ Sandboxie %2 est disponible au téléchargement.
 .
 
 3631;txt;01
-télécharger maintenant?
+Télécharger maintenant ?
 
-Note:  Le téléchargement prends quelques minutes.
+Note :  le téléchargement prend quelques minutes.
 Vous serez prévenu dès qu'il sera terminé.
 .
 
@@ -1517,16 +1570,16 @@ avec les droits d'Administrateur et recommencez.
 .
 
 3633;txt;01
-Sandboxie %2 à été téléchargé à cet endroit:
+Sandboxie %2 a été téléchargé à cet endroit :
 
 %3
 
-Cliquez OK pour commencer l'installation. Si des programmes
+Cliquez sur OK pour commencer l'installation. Si des programmes
 fonctionnent "sandboxés", ils seront fermés.
 .
 
 3634;txt;01
-Echec de la mise à jour: une erreur est survenue lors de la communicationavec le site de Sandboxie.
+Echec de la mise à jour : une erreur est survenue lors de la communication avec le site de Sandboxie.
 .
 
 3635;txt;01
@@ -1534,7 +1587,7 @@ Télécharger la nouvelle version
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Run Browser
+# Sandboxie Control Dialogs : Run Browser
 #----------------------------------------------------------------------------
 
 3641;txt;01
@@ -1554,7 +1607,7 @@ Sélectionnez l'opportunité d'ouvrir l'adresse Web suivante dans un navigateur 
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Message Dialog
+# Sandboxie Control Dialogs : Message Dialog
 #----------------------------------------------------------------------------
 
 3645;txt;01
@@ -1567,14 +1620,14 @@ Messages de Sandboxie
 
 3647;txt;01
 Cacher un message et il n'apparaîtra plus dans le futur.
-Cacher le message ne resoudra pas le problème
+Cacher le message ne résoudra pas le problème
 pour lequel il a été affiché.
 
-Etes-vous certain de ne plus recevoir l'avertissement %2?
+Etes-vous certain de ne plus recevoir l'avertissement %2 ?
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Disable Forced Programs
+# Sandboxie Control Dialogs : Disable Forced Programs
 #----------------------------------------------------------------------------
 
 3651;txt;01
@@ -1590,11 +1643,16 @@ secondes
 .
 
 3654;txt;01
-En cliquant OK, le mécanisme de forçage des programmes sera temporairement désactivé pendant le nombre de secondes spécifiées ou jusqu'à ce que vous resélectionniez cette fonction.
+En cliquant sur OK, le mécanisme de forçage des programmes sera temporairement désactivé durant le temps spécifié ou jusqu'à ce que vous re-sélectionniez cette fonction.
+.
+
+3599;txt;01
+Vous pouvez désactiver le forçage d'un programme en maintenant enfoncé la touche "ctrl",
+"shift" et "la flèche du bas" quand vous cliquez sur "exécuter sandboxé" pour ce programme.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Resource Access Monitor
+# Sandboxie Control Dialogs : Resource Access Monitor
 #----------------------------------------------------------------------------
 
 3655;txt;01
@@ -1610,15 +1668,15 @@ Copier le contenu vers le Presse-papier et fermer la fenêtre
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Is Window Sandboxed
+# Sandboxie Control Dialogs : Is Window Sandboxed
 #----------------------------------------------------------------------------
 
 3661;txt;01
-Cette fenêtre est-elle "sandboxée"?
+Cette fenêtre est-elle "sandboxée" ?
 .
 
 3662;txt;01
-Glissez l'outil Cible sur une fenêtre et relachez le bouton pour savoir si cette fenêtre est "sandboxée".
+Glissez l'outil Cible sur une fenêtre et relâchez le bouton pour savoir si cette fenêtre est "sandboxée".
 
 Pressez Echap pour annuler.
 .
@@ -1632,7 +1690,7 @@ La fenêtre sélectionnée ne fait partie d'aucune application "sandboxée".
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Create New Sandbox
+# Sandboxie Control Dialogs : Create New Sandbox
 #----------------------------------------------------------------------------
 
 3665;txt;01
@@ -1644,11 +1702,11 @@ Entrer le nom pour le nouveau Bac à sable.
 .
 
 3667;txt;01
-Erreur: Nom invalide. N'utilisez que des lettres et des chiffres. Les espaces et autres caractères spéciaux ne sont pas supportés. Le nom ne doit pas dépasser 32 caractères.
+Erreur : nom invalide. N'utilisez que des lettres et des chiffres. Les espaces et autres caractères spéciaux ne sont pas supportés. Le nom ne doit pas dépasser 32 caractères.
 .
 
 3668;txt;01
-Erreur: Nom déjà utilisé par un Bac à sable. Entrez un nouveau nom.
+Erreur : nom déjà utilisé par un Bac à sable. Entrez un nouveau nom.
 .
 
 3669;txt;01
@@ -1656,11 +1714,11 @@ Copier les paramètres du bac à sable existant
 .
 
 4665;txt;01
-Erreur: Doublon du nom entré pour la sandbox. Le nom est déjà utilisé par une sandbox cachée. Utiliser la commande "Révéler la sandbox cachée" du menu de la sandbox.
+Erreur : doublon du nom entré pour la sandbox. Le nom est déjà utilisé par une sandbox cachée. Utilisez la commande "Révéler la sandbox cachée" du menu de la sandbox.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Set Container Folder
+# Sandboxie Control Dialogs : Set Container Folder
 #----------------------------------------------------------------------------
 
 3671;txt;01
@@ -1676,11 +1734,11 @@ Pour une compatibilité maximale avec d'autres logiciels, il est recommandé de 
 .
 
 3674;txt;01
-Toutefois, vous pouvez aussi utiliser la zone de modification ci-dessous pour remplacer l'emplacement par défaut:
+Toutefois, vous pouvez aussi utiliser la zone de modification ci-dessous pour remplacer l'emplacement par défaut :
 .
 
 3675;txt;01
-Note:  Il est conseillé de supprimer le contenu de tous les Bacs à sable avant de changer le dossier conteneur.
+Note :  il est conseillé de supprimer le contenu de tous les Bacs à sable avant de changer le dossier conteneur.
 .
 
 3676;txt;01
@@ -1688,7 +1746,7 @@ Lecteur %2
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Alerts
+# Sandboxie Control Dialogs : Alerts
 #----------------------------------------------------------------------------
 
 3681;txt;01
@@ -1700,11 +1758,11 @@ Lorsqu'un des programmes suivants est lancé en dehors du Bac à sable, Sandboxi
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control Dialogs: Shell Integration
+# Sandboxie Control Dialogs : Shell Integration
 #----------------------------------------------------------------------------
 
 3685;txt;01
-Integration Windows Shell
+Intégration Windows Shell
 .
 
 3686;txt;01
@@ -1732,7 +1790,7 @@ Raccourci dans la Barre de lancement rapide pour Exécuter le Navigateur Interne
 .
 
 3692;txt;01
-Cliquez pour ajouter plus de raccourcis sur le bureau:
+Cliquez pour ajouter plus de raccourcis sur le bureau :
 .
 
 3693;txt;01
@@ -1740,7 +1798,7 @@ Cliquez pour ajouter plus de raccourcis sur le bureau:
 .
 
 3694;txt;01
-Actions "Exécuter sanboxé"
+Actions "Exécuter sandboxé"
 .
 
 3695;txt;01
@@ -1772,7 +1830,7 @@ Ouvrir %2 dans la sandbox %3
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Delete Sandbox / Quick Recovery / Immediate Recovery
+# Sandboxie Control :  Delete Sandbox / Quick Recovery / Immédiate Recovery
 #----------------------------------------------------------------------------
 
 3711;txt;01
@@ -1849,19 +1907,19 @@ qui peuvent être récupérés à partir du dossier.
 .
 
 3728;txt;01
-Aucun fichier ont sélectionné pour le recouvrement.
+Aucun fichier n'a été sélectionné pour le recouvrement.
 .
 
 3729;txt;01
-Echec de récupération.  L'objet suivant ne peut être déplacé hors du Bac à sable:
+Echec de récupération.  L'objet suivant ne peut être déplacé hors du Bac à sable :
 .
 
 3730;txt;01
-Ce Bac à sable est vide. Il n'y a rien a effacer.
+Ce Bac à sable est vide. Il n'y a rien à effacer.
 .
 
 3731;txt;01
-Des programmes "sandboxés" n'ont pu être arrêté. Le Bac à sable ne sera pas supprimé.
+Des programmes "sandboxés" n'ont pu être arrêtés. Le Bac à sable ne sera pas supprimé.
 .
 
 3732;txt;01
@@ -1874,7 +1932,7 @@ Sélectionner un autre dossier de destination.
 .
 
 3734;txt;01
-Pour avoir plus d'option, il faut effectuer un clic-droit sur la liste des dossiers
+Pour avoir plus d'option, effectuez un clic-droit sur la liste des dossiers
 .
 
 3735;txt;02
@@ -1890,7 +1948,7 @@ Remplacer tous les fichiers sans demandes supplémentaires
 .
 
 3981;txt;01
-&Ouvrir le dossier dans l'explorateur de windows en dehors du bac à sable
+&Ouvrir le dossier dans l'explorateur de Windows en dehors du bac à sable
 .
 
 3982;txt;01
@@ -1902,15 +1960,15 @@ Retirer tous les dossiers de la liste
 .
 
 3986;txt;01
-journal de la partie récupération
+Journal de récupération
 .
 
 3987;txt;01
-Les fichiers suivants ont étés récemment récupérés et enlevés des bac à sable.
+Les fichiers suivants ont étés récemment récupérés et enlevés des Bacs à sable.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Program Settings
+# Sandboxie Control :  Program Settings
 #----------------------------------------------------------------------------
 
 3741;txt;01
@@ -1918,11 +1976,11 @@ Paramètres programme
 .
 
 3742;txt;01
-Bac à sable:
+Bac à sable :
 .
 
 3743;txt;01
-Programme:
+Programme :
 .
 
 3744;txt;01
@@ -1938,7 +1996,7 @@ Démarrage programme
 .
 
 3752;txt;01
-Chaque fois que ce programme démarre à l'extérieur du Bac à sable:
+Chaque fois que ce programme démarre à l'extérieur du Bac à sable :
 .
 
 3753;txt;01
@@ -1966,11 +2024,11 @@ Restrictions Internet
 .
 
 3762;txt;01
-Tout programme qui s'exécute dans ce Bac à sable peut se connecter à l'Internet..
+Tout programme qui s'exécute dans ce Bac à sable peut se connecter à l'Internet...
 .
 
 3763;txt;01
-Programmes qui peuvent se connecter à Internet dans ce Bac à sable:
+Programmes qui peuvent se connecter à Internet dans ce Bac à sable :
 .
 
 3764;txt;01
@@ -1986,7 +2044,7 @@ Tous les programmes peuvent démarrer dans ce Bac à sable.
 .
 
 3767;txt;01
-Programmes qui peuvent être lancés dans ce Bac à sable:
+Programmes qui peuvent être lancés dans ce Bac à sable :
 .
 
 3768;txt;01
@@ -2009,15 +2067,15 @@ du programme.
 .
 
 3772;txt;02
-Etes-vous sûr vous voulez mettre %2 en programme forcé?
+Etes-vous sûr vous voulez mettre %2 en programme forcé ?
 .
 
 3773;txt;02
-Etes-vous sûr vous voulez mettre %2 en programme forcé?
+Etes-vous sûr vous voulez mettre %2 en programme forcé ?
 .
 
 # 3774;txt;02
-# Etes-vous sûr vous voulez mettre %2 en utilisateur forcé?
+# Etes-vous sûr vous voulez mettre %2 en utilisateur forcé ?
 # .
 
 3775;txt;02
@@ -2025,7 +2083,7 @@ Vous avez fait un changement qui peut ne pas être facile à défaire.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings
+# Sandboxie Control :  Sandbox Settings
 #----------------------------------------------------------------------------
 
 3801;txt;01
@@ -2049,7 +2107,7 @@ Tous les programmes
 .
 
 3806;txt;02
-La liste ci-dessous s'applique à:
+La liste ci-dessous s'applique à :
 .
 
 3807;txt;01
@@ -2064,8 +2122,16 @@ Ajouter nom de ressource
 Editer nom de ressource
 .
 
+3551;txt;01
+(Tous les programmes, sauf %2)
+.
+
+3552;txt;01
+Inverser la sélection courante
+.
+
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Appearance
+# Sandboxie Control :  Sandbox Settings :  Appearance
 #----------------------------------------------------------------------------
 
 3811;txt;01
@@ -2073,7 +2139,7 @@ Apparence
 .
 
 3812;txt;01
-Les programmes éxécutés sous la supervision de Sandboxie auront [#] dans le titre de la fenêtre.
+Les programmes exécutés sous la supervision de Sandboxie auront [#] dans le titre de la fenêtre.
 .
 
 3813;txt;01
@@ -2105,7 +2171,7 @@ Afficher bordures quand le curseur de la souris est dans le titre de la fenêtre
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Recovery
+# Sandboxie Control :  Sandbox Settings :  Recovery
 #----------------------------------------------------------------------------
 
 # 3821;txt;01
@@ -2137,7 +2203,7 @@ Activer la Récupération Immédiate
 .
 
 3834;txt;01
-Les dossiers suivants et Types de fichiers (Extentions) seront exclus de la Récupération Immédiate.
+Les dossiers suivants et types de fichiers (extension) seront exclus de la Récupération Immédiate.
 .
 
 3835;txt;01
@@ -2145,15 +2211,15 @@ Ajouter &Type
 .
 
 3836;txt;01
-Sélectionner un dossier à exclure de la Récupération Immediate.
+Sélectionner un dossier à exclure de la Récupération Immédiate.
 .
 
 3837;txt;01
-Entrez un Type de fichier (Extension) à exclure de la Récupération Immediate
+Entrez un Type de fichier (Extension) à exclure de la Récupération Immédiate
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Delete
+# Sandboxie Control :  Sandbox Settings :  Delete
 #----------------------------------------------------------------------------
 
 # 3841;txt;01
@@ -2201,16 +2267,16 @@ Pour la suppression automatique et manuelle, la commande suivante sera utilisée
 .
 
 3854;txt;01
-Si vous changez ce réglage, ajoutez le texte "%%SANDBOX%%" (avec les guillemets). Lorsque la commande sera éxécutée, le texte sera remplacé par l'emplacement du dossier "Bac à sable.
+Si vous changez ce réglage, ajoutez le texte "%%SANDBOX%%" (avec les guillemets). Lorsque la commande sera exécutée, le texte sera remplacé par l'emplacement du dossier Bac à sable.
 .
 
 3855;txt;01
-Ou sélectionnez un préréglage commande effacer:
+Ou sélectionnez un préréglage commande effacer :
 .
 
 3856;txt;01
 La commande d'effacement ne spécifie pas "%%SANDBOX%%" (avec les guillemets).
-Etes-vous sûr d'accepter cette commande d'effacement?
+Etes-vous sûr d'accepter cette commande d'effacement ?
 .
 
 3857;txt;01
@@ -2240,7 +2306,7 @@ Enter un nom pour le groupe
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Forced Folders/Programs
+# Sandboxie Control :  Sandbox Settings :  Forced Folders/Programs
 #----------------------------------------------------------------------------
 
 # 3861;txt;01
@@ -2256,7 +2322,7 @@ Dossiers forcés
 .
 
 3863;txt;01
-Si un programme démarre non "sandboxé" d'un des dossiers suivants, il sera forcé de s'éxécuter dans ce Bac à sable. Ceci n'est pas valable si le programme est éxécuté dans un autre Bac à sable.
+Si un programme démarre non "sandboxé" d'un des dossiers suivants, il sera forcé de s'exécuter dans ce Bac à sable. Ceci n'est pas valable si le programme est exécuté dans un autre Bac à sable.
 .
 
 3864;txt;01
@@ -2280,7 +2346,7 @@ Programmes forcés
 .
 
 3873;txt;01
-Si un des programmes suivants démarre non "sondboxé", il sera forcé de démarrer dans ce Bac à sable. Ceci ne s'applique pas si un programme doit explicitement démarrer dans un autre Bac à sable.
+Si un des programmes suivants démarre non "sandboxé", il sera forcé de démarrer dans ce Bac à sable. Ceci ne s'applique pas si un programme doit explicitement démarrer dans un autre Bac à sable.
 .
 
 # 3962;txt;01
@@ -2293,7 +2359,7 @@ Si un des programmes suivants démarre non "sondboxé", il sera forcé de démar
 
 # 3964;txt;01
 # Pour effacer une sandbox associée à un compte d'utilisateur forcé,
-# Il faut se connecter comme utilisateur et utiliser "Sandboxie Control"pour effacer la sandbox.
+# Connectez-vous comme utilisateur et utiliser "Sandboxie Control" pour effacer la sandbox.
 # .
 
 # 3965;txt;01
@@ -2301,7 +2367,7 @@ Si un des programmes suivants démarre non "sondboxé", il sera forcé de démar
 # .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Linger/Leader Programs
+# Sandboxie Control :  Sandbox Settings :  Linger/Leader Programs
 #----------------------------------------------------------------------------
 
 # 3881;txt;01
@@ -2317,7 +2383,7 @@ Programmes persistants
 .
 
 3883;txt;01
-Les programmes suivants seront automatiquement terminés s'ils continuent de s'éxécuter dans ce Bac à sable après
+Les programmes suivants seront automatiquement terminés s'ils continuent de s'exécuter dans ce Bac à sable après
 que les autres programmes soient fermés.
 .
 
@@ -2330,11 +2396,11 @@ Programmes leaders
 .
 
 3893;txt;01
-Les programmes suivants sont considérés essentiels dans ce Bac à sable. Terminer ces programmes causera la fermeture des autres programmes s'éxécutant dans ce Bac à sable.
+Les programmes suivants sont considérés essentiels dans ce Bac à sable. Terminer ces programmes causera la fermeture des autres programmes s'exécutant dans ce Bac à sable.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  File Migration
+# Sandboxie Control :  Sandbox Settings :  File Migration
 #----------------------------------------------------------------------------
 
 3901;txt;01
@@ -2376,7 +2442,7 @@ La modification de cette limite peut se faire aussi en ouvrant la fenêtre des p
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Internet/Start Restrictions
+# Sandboxie Control :  Sandbox Settings :  Internet/Start Restrictions
 #----------------------------------------------------------------------------
 
 # 3911;txt;01
@@ -2384,7 +2450,7 @@ La modification de cette limite peut se faire aussi en ouvrant la fenêtre des p
 # .
 
 3911;txt;02
-Restrictions:
+Restrictions :
 .
 
 3912;txt;01
@@ -2396,7 +2462,7 @@ Les programmes suivants seront les seuls de ce Bac à sable à pouvoir accéder 
 .
 
 3914;txt;01
-Quand cette option est activée, les programmes qui sont installés (ou téléchargés) dans ce Bac à sable n'auront jamais àccès à Internet, même s'ils correspondent aux noms définis ci-dessus.
+Quand cette option est activée, les programmes qui sont installés (ou téléchargés) dans ce Bac à sable n'auront jamais accès à Internet, même s'ils correspondent aux noms définis ci-dessus.
 .
 
 3915;txt;01
@@ -2422,7 +2488,7 @@ Aucun programme ne peut accéder à Internet
 3920;txt;01
 Les Restrictions d'accès à internet sont activées dans le bac à sable '%2', et évite à ce programme d'accéder à internet.
 
-Cliquer sur OK pour ajouter le programme '%3' aux restrictions d'accès à internet dans le bac à sable '%2'.
+Cliquez sur OK pour ajouter le programme '%3' aux restrictions d'accès à internet dans le bac à sable '%2'.
 
 Pour gérer les restrictions d’accès à internet, ouvrir la fenêtre des paramètres du bac à sable et parcourir le groupe des paramètres de Restriction.
 .
@@ -2436,75 +2502,75 @@ Démarrage/Exécuter accès
 .
 
 3923;txt;01
-Les programmes suivants seront les seuls dans ce Bac à sable à pouvoir démarrer et s'éxécuter.
+Les programmes suivants seront les seuls dans ce Bac à sable à pouvoir démarrer et s'exécuter.
 .
 
 3924;txt;01
-Lorsque cette option est activée, les programmes qui sont installés (ou téléchargés) dans ce Bac à sable ne seront jamais autorisés à démarrer ou s'éxécuter, même s'ils correspondent aux noms définis ci-dessus.
+Lorsque cette option est activée, les programmes qui sont installés (ou téléchargés) dans ce Bac à sable ne seront jamais autorisés à démarrer ou s'exécuter, même s'ils correspondent aux noms définis ci-dessus.
 .
 
 3928;txt;01
-Tous les programmes peuvent démarrer et s'éxécuter
+Tous les programmes peuvent démarrer et s'exécuter
 .
 
 3930;txt;01
 Les Restrictions d'accès à démarrer/exécuter sont activées dans le bac à sable '%2', et évite à ce programme de démarrer ou de s’exécuter.
 
-Cliquer sur OK pour ajouter le programme '%3' aux restrictions d'accès à Démarrer/exécuter dans le bac à sable '%2'.
+Cliquez sur OK pour ajouter le programme '%3' aux restrictions d'accès à Démarrer/exécuter dans le bac à sable '%2'.
 
 Pour gérer les restrictions d'accès à démarrer/exécuter, ouvrir la fenêtre des paramètres du bac à sable et parcourir le groupe des paramètres de Restriction.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Low Level Access / Hardware Access
+# Sandboxie Control :  Sandbox Settings :  Low Level Access / Hardware Access
 #----------------------------------------------------------------------------
 
 # 3931;txt;01
 # Restrictions::Accès Bas-niveau
 # .
 
-3932;txt;01
-Accès Bas-niveau
-.
+# 3932;txt;01
+# Accès Bas-niveau
+# .
 
-3933;txt;01
-Les paramètres suivants déterminent essentiellement la protection offerte par Sandboxie. Activer un ou tous ces réglages n'est pas recommandé.
-.
+# 3933;txt;01
+# Les paramètres suivants déterminent essentiellement la protection offerte par Sandboxie. Activer un ou tous ces réglages n'est pas recommandé.
+# .
 
-3934;txt;01
-Autoriser les programmes de ce Bac à sable à charger les pilotes noyaux dans le système d'exploitation.
-.
+# 3934;txt;01
+# Autoriser les programmes de ce Bac à sable à charger les pilotes noyaux dans le système d'exploitation.
+# .
 
-3935;txt;01
-Autoriser les programmes de ce Bac à sable à charger l'application surveillée (Win32) dans d'autres programmes.
-.
+# 3935;txt;01
+# Autoriser les programmes de ce Bac à sable à charger l'application surveillée (Win32) dans d'autres programmes.
+# .
 
-3936;txt;01
-Autoriser les programmes de ce Bac à simuler l'entrée du clavier et de la souris.
-.
+# 3936;txt;01
+# Autoriser les programmes de ce Bac à simuler l'entrée du clavier et de la souris.
+# .
 
-3937;txt;01
-Autoriser les programmes de cette sandbox à modifier l'arrière-plan du bureau et d'autres parametres systèmes.
-.
+# 3937;txt;01
+# Autoriser les programmes de cette sandbox à modifier l'arrière-plan du bureau et d'autres paramètres systèmes.
+# .
 
-3938;txt;01
-Autoriser les programmes de cette sandbox à gérer la configuration des périphériques materiels.
-.
+# 3938;txt;01
+# Autoriser les programmes de cette sandbox à gérer la configuration des périphériques matériels.
+# .
 
-3952;txt;01
-Accés materiel
-.
+# 3952;txt;01
+# Accès matériel
+# .
 
-3953;txt;01
-Autoriser les programmes de cette sandbox à modifer le mot de passe du compte utilisateur
-.
+# 3953;txt;01
+# Autoriser les programmes de cette sandbox à modifier le mot de passe du compte utilisateur
+# .
 
-3954;txt;01
-Autoriser les programmes à modifier les paramètres du réseau et du pare-feu
-.
+# 3954;txt;01
+# Autoriser les programmes à modifier les paramètres du réseau et du pare-feu
+# .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Drop Rights
+# Sandboxie Control :  Sandbox Settings :  Drop Rights
 #----------------------------------------------------------------------------
 
 # 3941;txt;01
@@ -2516,7 +2582,7 @@ Droits restreints
 .
 
 3943;txt;01
-Sandboxie a désactivé seulement quelques droits en matière de sécurité des programmes qu' il supervise afin de garantir l'isolement.
+Sandboxie a désactivé seulement quelques droits en matière de sécurité des programmes qu'il supervise afin de garantir l'isolement.
 .
 
 3944;txt;01
@@ -2527,24 +2593,64 @@ Toutefois, si vous utilisez un compte Administratif ou Super Utilisateur, Sandbo
 Restreindre les droits des groupes Administrateurs et Super Utilisateurs
 .
 
-3946;txt;01
-Il est conseillé de garder ce paramètre activé pour compenser le fait que certaines fonctions ne sont pas disponibles dans la version 64 bit
-.
+# 3946;txt;01
+# Il est conseillé de garder ce paramètre activé pour compenser le fait que certaines fonctions ne sont pas disponibles dans la version 64 bit
+# .
 
-3947;txt;01
-Pour activer la protection renforcée sur 64-bit, Il faut utiliser le mode "Experimental Protection" en allant dans le menu de configuration.
-.
+# 3947;txt;01
+# Pour activer la protection renforcée sur 64-bit, utilisez le mode "Experimental Protection" en allant dans le menu de configuration.
+# .
 
 3949;txt;01
 Le paramètre droits restreints est activé dans le bac à sable '%2', elle empêche l'utilisation des droits administrateur.
 
-Cliquer sur OK pour désactiver les droits restreints dans le bac à sable '%2', et autoriser l'utilisation des droits administrateur dans le bac à sable.
+Cliquez sur OK pour désactiver les droits restreints dans le bac à sable '%2', et autoriser l'utilisation des droits administrateur dans le bac à sable.
 
 Vous pouvez toujours modifier les droits restreints en passant par la fenêtre de configuration du bac à sable et en parcourant le groupe des paramètres des restrictions.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  Resource Access
+# Sandboxie Control:  Sandbox Settings:  Print Spooler
+#----------------------------------------------------------------------------
+
+3950;txt;01
+Spouleur d'impression
+.
+
+3951;txt;01
+Le Spouleur d'impression de Windows fonctionne en dehors de la supervision de Sandboxie.  Une application sandboxée qui demande au Spouleur d'impression d'imprimer dans un fichier sera bloquée car ce fichier sera écrit en dehors du bac à sable.
+.
+
+3952;txt;01
+Si vous souhaitez autoriser le Spouleur d'impression à imprimer dans un fichier, vous pouvez activer ce paramètre. Il est recommandé d'activer cette option uniquement en cas de besoin.
+.
+
+3953;txt;01
+Autoriser le Spouleur d'impression de Windows à imprimer vers un fichier.
+.
+
+#----------------------------------------------------------------------------
+# Sandboxie Control:  Sandbox Settings:  Network Files
+#----------------------------------------------------------------------------
+
+3955;txt;01
+Fichiers en réseau
+.
+
+3956;txt;01
+Les dossiers et fichiers en réseau sont normalement visibles aux applications dans les Bacs à sable.
+.
+
+3957;txt;01
+Si vous souhaitez empêcher les applications des Bacs à sable d'accéder aux fichiers et aux dossiers sur votre réseau, vous pouvez activer ce paramètre. Il est possible d'autoriser l'accès à des fichiers et dossiers spécifiques en les ajoutant via Accès aux ressources -> Ajouter un fichier ou dossier.
+.
+
+3958;txt;01
+Bloquer les fichiers et dossiers du réseau, sauf s'ils sont spécifiquement autorisés.
+.
+
+#---------------------------------------------------------------------------
+# Sandboxie Control :  Sandbox Settings :  Resource Access
 #----------------------------------------------------------------------------
 
 4001;txt;01
@@ -2556,12 +2662,12 @@ Accès direct au fichier (OpenFilePath)
 .
 
 4003;txt;01
-Les fichiers et dossiers suivants seront directement accessibles aux programmes s'éxécutant dans ce Bac à sable, sans effets de "sandboxage".
+Les fichiers et dossiers suivants seront directement accessibles aux programmes s'exécutant dans ce Bac à sable, sans effets de "sandboxage".
 .
 
 4004;txt;01
 Cela ne s'applique pas aux programmes installés ou téléchargés dans le Bac à sable.
-Voir aussi:  Réglage Accès total.
+Voir aussi :  Réglage Accès total.
 .
 
 4011;txt;01
@@ -2573,7 +2679,7 @@ Accès total au fichier (OpenPipePath)
 .
 
 4013;txt;01
-Les fichiers et dossiers suivants seront directement accessibles aux programmes s'éxécutant dans ce Bac à sable, sans effets de "sandboxage".
+Les fichiers et dossiers suivants seront directement accessibles aux programmes s'exécutant dans ce Bac à sable, sans effets de "sandboxage".
 .
 
 4014;txt;01
@@ -2589,7 +2695,7 @@ Accès bloqué au fichier (ClosedFilePath)
 .
 
 4023;txt;01
-Les dossiers et fichiers suivants seront inaccessibles à tous les programmes s'éxécutant dans ce Bac à sable.
+Les dossiers et fichiers suivants seront inaccessibles à tous les programmes s'exécutant dans ce Bac à sable.
 .
 
 4024;txt;01
@@ -2597,8 +2703,8 @@ Si un fichier ou un dossier figure dans la liste Accès autorisés mais aussi da
 .
 
 4025;txt;01
-Le partage des fichiers Windows peut être utilisé pour contourner les paramètres d'acces aux fichiers bloqués.
-Par consequent,une option a été ajoutée pour bloquer l'accés au service de partage des fichiers de windows.
+Le partage des fichiers Windows peut être utilisé pour contourner les paramètres d'accès aux fichiers bloqués.
+Par conséquent, une option a été ajoutée pour bloquer l'accès au service de partage des fichiers de Windows.
 .
 
 4031;txt;01
@@ -2610,7 +2716,7 @@ Accès lecture seule au fichier (ReadFilePath)
 .
 
 4033;txt;01
-Les dossiers et fichiers suivants ne seront pas modifiable par les programmes s'éxécutant dans ce Bac à sable.
+Les dossiers et fichiers suivants ne seront pas modifiables par les programmes s'exécutant dans ce Bac à sable.
 .
 
 4111;txt;01
@@ -2622,7 +2728,7 @@ Accès du fichier en écriture seule (chemin du fichier en écriture)
 .
 
 4113;txt;01
-Les dossiers suivants seront en apparence vide pour les programmes en cours, mais ces programmes pourront créer des nouveaux fichiers dans cette sandbox.
+Les dossiers suivants seront en apparence vides pour les programmes en cours, mais ces programmes pourront créer des nouveaux fichiers dans cette sandbox.
 .
 
 4041;txt;01
@@ -2634,7 +2740,7 @@ Accès direct au Registre (OpenKeyPath)
 .
 
 4043;txt;01
-Les clés de Registre suivantes seront directement accessibles aux programmes s'éxécutant dans ce Bac à sable, sans effets de "sandboxage".
+Les clés de Registre suivantes seront directement accessibles aux programmes s'exécutant dans ce Bac à sable, sans effets de "sandboxage".
 .
 
 4044;txt;01
@@ -2650,11 +2756,11 @@ Accès bloqué au Registre (ClosedKeyPath)
 .
 
 4053;txt;01
-Les clés de Registre suivantes ne seront pas accessibles aux programmes s'éxécutant dans ce Bac à sable.
+Les clés de Registre suivantes ne seront pas accessibles aux programmes s'exécutant dans ce Bac à sable.
 .
 
 4054;txt;01
-Si une clé Registre figure dans la liste Accès autorisés mais aussi dans la liste Accès bloqués, le paramètre'Accès bloqué sera prioritaire.
+Si une clé Registre figure dans la liste Accès autorisés mais aussi dans la liste Accès bloqués, le paramètre Accès bloqué sera prioritaire.
 .
 
 4061;txt;01
@@ -2666,7 +2772,7 @@ Accès Registre en Lecture seule (ReadKeyPath)
 .
 
 4063;txt;01
-Les clés de Registre suivantes ne seront pas modifiables aux programmes s'éxécutant dans ce Bac à sable.
+Les clés de Registre suivantes ne seront pas modifiables aux programmes s'exécutant dans ce Bac à sable.
 .
 
 4121;txt;01
@@ -2678,7 +2784,7 @@ Accès du registre en écriture seule (WriteKeyPath)
 .
 
 4123;txt;01
-Les clés du registre suivantes seront en apparence vide pour les programmes en cours, mais ces programmes pourront écrire des nouvelles données dans cette sandbox.
+Les clés du registre suivantes seront en apparence vides pour les programmes en cours, mais ces programmes pourront écrire des nouvelles données dans cette sandbox.
 .
 
 4071;txt;01
@@ -2690,7 +2796,7 @@ Accès direct IPC (OpenIpcPath)
 .
 
 4073;txt;01
-Les objets NT IPC suivants seront directement accessibles aux programmes s'éxécutant dans ce Bac à sable, sans effets de "sandboxage".
+Les objets NT IPC suivants seront directement accessibles aux programmes s'exécutant dans ce Bac à sable, sans effets de "sandboxage".
 .
 
 4074;txt;01
@@ -2706,7 +2812,7 @@ Accès bloqué IPC  (ClosedIpcPath)
 .
 
 4083;txt;01
-Les objets NT IPC suivants ne seront pas accessibles aux programmes s'éxécutant dans ce Bac à sable.
+Les objets NT IPC suivants ne seront pas accessibles aux programmes s'exécutant dans ce Bac à sable.
 .
 
 4084;txt;01
@@ -2722,7 +2828,7 @@ Accès fenêtre (OpenWinClass)
 .
 
 4093;txt;01
-Les programmes "sandboxés" ne peuvent pas communiquer avec les fenêtres qui appartiennent à des programmes s'éxécutant à l'extérieur du Bac à sable, à moins que la fenêtre n'ait été créée avec l'une des classes de la fenêtre suivante.
+Les programmes "sandboxés" ne peuvent pas communiquer avec les fenêtres qui appartiennent à des programmes s'exécutant à l'extérieur du Bac à sable, à moins que la fenêtre n'ait été créée avec l'une des classes de fenêtre suivantes.
 .
 
 4101;txt;01
@@ -2734,7 +2840,15 @@ Accès COM (OpenClsid)
 .
 
 4103;txt;01
-Les programmes "sandboxés" ne peuvent pas communiquer avec les objets COM qui appartiennent à des programmes s'éxécutant à l'extérieur du Bac à sable, à moins qu'ils correspondent à l'un des identifiants de la classe IDs suivante.
+Les programmes "sandboxés" ne peuvent pas communiquer avec les objets COM qui appartiennent à des programmes s'exécutant à l'extérieur du Bac à sable, à moins qu'ils correspondent à l'un des identifiants de la classe suivants.
+.
+
+4104;txt;01
+Accès aux ressources::Accès réseaux
+.
+
+4105;txt;01
+Accès réseaux (pare-feu)
 .
 
 #----------------------------------------------------------------------------
@@ -2766,7 +2880,7 @@ Divers
 .
 
 4207;txt;01
-Ameliorer l'utilisation de sandboxie avec d'autres applications en les selectionnant dans la liste suivante.
+Améliorer l'utilisation de Sandboxie avec d'autres applications en les sélectionnant dans la liste suivante.
 .
 
 4209;txt;01
@@ -2778,30 +2892,30 @@ Déterminer les emplacements des dossiers utilisés par vos autres applications.
 .
 
 4211;txt;01
-Selection du dossier pour
+Sélection du dossier pour
 .
 
 4212;txt;01
-Emplacement par défaut:
+Emplacement par défaut :
 .
 
 4213;txt;01
-Autre emplacement:
+Autre emplacement :
 .
 
 4214;txt;02
 Un autre emplacement pour '%2'
-Devra contenir le fichier suivant:
+Devra contenir le fichier suivant :
 
 %3
 
-L'emplacement selectionné ne contient pas ce fichier.
+L'emplacement sélectionné ne contient pas ce fichier.
 
 Choisir un dossier qui contient ce fichier.
 .
 
 4215;txt;01
-Selectionner le dossier utilisé par %2.
+Sélectionner le dossier utilisé par %2.
 .
 
 4216;txt;01
@@ -2809,7 +2923,7 @@ Les paramètres ci-dessous règle la configuration de l'application '%2'.
 .
 
 4217;txt;01
-Déterminer ou coller les paramètres, cliquer sur ok pour créér une nouvelle configuration
+Déterminer où coller les paramètres, cliquez sur ok pour créer une nouvelle configuration
 pour l'application locale.
 .
 
@@ -2823,7 +2937,7 @@ Vos configurations des applications locales.
 
 4220;txt;01
 Le code entré contient une ou plusieurs erreurs.
-Ne peut créér la configuration de l'application.
+Impossible de créer la configuration de l'application.
 .
 
 4221;txt;01
@@ -2831,8 +2945,8 @@ Pour déterminer les emplacements de tes dossiers pour tes applications, voir la
 .
 
 4222;txt;02
-Ce paramètre ne peut être supprimé ou modifé
-car c'est une partie de la configuration de l'application:
+Ce paramètre ne peut être supprimé ou modifié
+car c'est une partie de la configuration de l'application :
 
 %2
 
@@ -2841,8 +2955,8 @@ voir les pages "applications" dans les paramètres de la sandbox.
 .
 
 4223;txt;01
-La configuration de l'application Local'%2' est maintenant enlevée dans toutes les sandbox.
-Aimerais-tu effacer cette configuration de cette application?
+La configuration de l'application locale '%2' est maintenant enlevée de toutes les sandboxes.
+Voulez-vous entièrement effacer la configuration de cette application ?
 .
 
 4224;txt;01
@@ -2850,7 +2964,7 @@ PDF/Imprimer
 .
 
 4226;txt;02
-Securité/Privé
+Sécurité/Privé
 .
 
 4228;txt;01
@@ -2858,7 +2972,55 @@ Utilitaires de bureau
 .
 
 4230;txt;01
-Gestionnaires de telechargement
+Gestionnaires de téléchargement
+.
+
+4288;txt;01
+Toutes les applications
+.
+
+4289;txt;01
+Liste de toutes les configurations des applications, triée par ordre alphabétique. La liste ne contient pas les configurations de vos applications locales (non-officiel).
+.
+
+4291;txt;01
+Les exclusions par défaut pour la récupération immédiate
+.
+
+4292;txt;01
+La liste par défaut des programmes persistants
+.
+
+4293;txt;01
+La liste par défaut des ports tcp/udp bloqués
+.
+
+4294;txt;01
+Autoriser à mettre à jour les "jump lists" (menus flèches dans le menu démarrer) dans la barre des tâches de Windows 7.
+.
+
+4295;txt;01
+Exclusions par défaut des préréglages de migration de fichier
+.
+
+4296;txt;01
+Bindings par défaut des ports RPC
+.
+
+4297;txt;01
+Ouvrir les ports RPC pour le Bluetooth
+.
+
+4298;txt;01
+Ouvrir les ports RPC pour les cartes à puce
+.
+
+4299;txt;01
+Ouvrir les ports RCP pour Simple Service Discovery Protocol (SSDP, UPnP)
+.
+
+4300;txt;01
+Ouvrir des ports RPC additionnels
 .
 
 #----------------------------------------------------------------------------
@@ -2874,7 +3036,7 @@ Sandboxie a trouvé les applications suivantes sur ton système.
 .
 
 4253;txt;01
-Cliquer sur OK et appliquer les paramètres de configuration
+Cliquez sur OK et appliquer les paramètres de configuration
 qui vont améliorer la compatibilité avec ces applications.
 .
 
@@ -2884,7 +3046,7 @@ et nouvelles.
 .
 
 4255;txt;01
-Dans l'avenir,ne pas vérifier la compatibilité du logiciel
+A l'avenir, ne pas vérifier la compatibilité du logiciel
 .
 
 4256;txt;01
@@ -2898,27 +3060,27 @@ Enlever &anciens réglages
 .
 
 4258;txt;01
-Les paramètres de compatibilité suivants ne sont plus en cours d'utilisation:
+Les paramètres de compatibilité suivants ne sont plus en cours d'utilisation :
 
 %2
 
-Cliquer sur OK pour rejeter ces paramètres de compatibilité.
+Cliquez sur OK pour rejeter ces paramètres de compatibilité.
 .
 
 4451;txt;01
 Sandboxie a détecté des conflits avec l'application ci-dessous dans votre système.
-Cela peut perturber le bon fonctionnement de sandboxie.
+Cela peut perturber le bon fonctionnement de Sandboxie.
 
 %2
 
 La consultation de la page "conflits connus" vous permettra
 de résoudre le problème.
 
-Voulez-vous ouvrir la page "conflits connus", maintenant?
+Voulez-vous ouvrir la page "conflits connus", maintenant ?
 .
 
 4452;txt;01
-&conflits connus
+&Conflits connus
 .
 
 #----------------------------------------------------------------------------
@@ -2931,11 +3093,11 @@ Protection de la configuration
 
 4262;txt;01
 Sandboxie peut protéger l'ensemble des modifications non autorisées,
-Il suffit d'activer ou de désactiver les modes de protections.
+il suffit d'activer ou de désactiver les modes de protections.
 .
 
 4263;txt;01
-Seul les comptes d'utilisateurs en mode administrateur peuvent effectuer des changements.
+Seuls les comptes d'utilisateurs en mode administrateur peuvent effectuer des changements.
 .
 
 4264;txt;01
@@ -2943,7 +3105,7 @@ Seul les comptes d'utilisateurs en mode administrateur peuvent effectuer des cha
 .
 
 4265;txt;01
-&Mot de passe oublié quand la fenetre "sandboxie Control" devient caché
+Oublier le &mot de passe quand la fenêtre "Sandboxie Control" est cachée
 .
 
 4266;txt;01
@@ -2951,16 +3113,16 @@ Seul les comptes d'utilisateurs en mode administrateur peuvent effectuer des cha
 .
 
 4267;txt;01
-Seul les comptes d'utilisateurs en mode administrateur peuvent utiliser la commande "desactiver les programmes forcés"
+Seuls les comptes d'utilisateurs en mode administrateur peuvent utiliser la commande "désactiver les programmes forcés"
 .
 
 4269;txt;01
-Il faut lire la page de la documentation de sandboxie
-concernant la protection de la configuration. Voulez-vous la lire?
+Merci de prendre le temps de lire la page de la documentation de Sandboxie
+concernant la protection de la configuration. Voulez-vous la lire ?
 .
 
 4271;txt;01
-La configuration de sandboxie est protégé par un mot de passe. Entrez ce mot de passe, maintenant.
+La configuration de Sandboxie est protégée par un mot de passe. Veuillez entrer ce mot de passe.
 .
 
 4272;txt;01
@@ -2972,8 +3134,12 @@ Entrer le même mot de passe pour le confirmer.
 .
 
 4274;txt;01
-Mot de passe erroné.  Recommencer?
+Mot de passe erroné.  Recommencer ?
 .
+
+#----------------------------------------------------------------------------
+# Program Selector
+#----------------------------------------------------------------------------
 
 4281;txt;01
 Définir un nom de programme
@@ -2996,36 +3162,11 @@ Groupes de programme
 .
 
 4286;txt;01
-Selectionner ou &entrer un programme:
+Sélectionner ou &entrer un programme :
 .
 
 4287;txt;01
 Ouvrir/ Sélectionner &Fichier
-.
-
-4288;txt;01
-Toutes les applications
-.
-
-4289;txt;01
-Liste de touTes les configurations des applications, triée par ordre alphabétique.
-La liste ne contient pas les configurations de vos applications locales (non-officiel).
-.
-
-4291;txt;01
-Les exclusions par défaut pour la récupération immédiate
-.
-
-4292;txt;01
-La liste par défaut des programmes persistants
-.
-
-4293;txt;01
-La liste par défaut des ports tcp/udp bloqués
-.
-
-4294;txt;01
-Autoriser à mettre à jour les "jump lists" dans la barre des tâches de windows seven.
 .
 
 #----------------------------------------------------------------------------
@@ -3049,7 +3190,7 @@ Pour compenser la perte de protection, veuillez consulter la page paramètres de
 .
 
 4305;txt;03
-Lecteur d'écran:  %2
+Lecteur d'écran :  %2
 .
 
 #----------------------------------------------------------------------------
@@ -3061,11 +3202,11 @@ Navigateur Internet
 .
 
 4322;txt;01
-Les exclusions suivantes permettent au Navigateur Internet s'éxécutant dans ce Bac à sable, d'apporter des modifications à l'extérieur du Bac à sable, donc un petit échange de mesure de sécurité et de confidentialité pour plus de commodité.
+Les exclusions suivantes permettent au Navigateur Internet s'exécutant dans ce Bac à sable d'apporter des modifications à l'extérieur du Bac à sable, donc un petit échange de mesure de sécurité et de confidentialité pour plus de commodité.
 .
 
 4323;txt;01
-Forcer %2 à s'executer dans cette sandbox
+Forcer %2 à s'exécuter dans cette sandbox
 .
 
 4324;txt;02
@@ -3073,7 +3214,7 @@ Autoriser l'accès direct de %2 à la synchronisation des données.
 .
 
 4325;txt;02
-Permet un accés direct aux %2 flux
+Permet un accès direct aux %2 flux
 .
 
 4326;txt;02
@@ -3085,15 +3226,15 @@ Ajout les favoris de Internet Explorer à la récupération des dossiers immédi
 .
 
 4328;txt;01
-Permet un accés direct aux %2 cookies
+Permet un accès direct aux %2 cookies
 .
 
 4329;txt;01
-Sauvegarde en dehors de la sandbox: Historique de recherche
+Sauvegarde en dehors de la sandbox : Historique de recherche
 .
 
 4330;txt;01
-Sauvegarde en dehors de la sandbox: informations sur les comptes hotmail et messenger
+Sauvegarde en dehors de la sandbox : informations sur les comptes hotmail et messenger
 .
 
 4331;txt;01
@@ -3113,11 +3254,15 @@ Permet un accès direct au %2 dossier du profil
 .
 
 4339;txt;02
-Permet un accès direct aux %2 preferences
+Permet un accès direct aux %2 préférences
 .
 
 4340;txt;01
 Autoriser l'accès direct à la gestion des sessions de %2
+.
+
+4341;txt;01
+Autoriser l'accès direct aux Notes de %2
 .
 
 4356;txt;02
@@ -3137,11 +3282,35 @@ Lecteur de courrier
 .
 
 4392;txt;01
-Les exclusions suivantes permettent au Lecteurs de courrier s'éxécutant dans ce Bac à sable pour accéder à des fichiers à l'extérieur de ce Bac à sable.
+Les exclusions suivantes permettent aux lecteurs de messagerie s'exécutant dans ce Bac à sable d'accéder à des fichiers à l'extérieur de ce Bac à sable.
+.
+
+4393;txt;01
+Lecteurs multimédias
+.
+
+4394;txt;01
+Les exclusions suivantes permettent aux lecteurs multimédias tournant dans ce Bac à sable d'accéder aux fichiers hors du bac.
+.
+
+4395;txt;01
+Autoriser l'accès direct au dossier Photo/Images à %2 pour simplifier la capture d'écran.
+.
+
+4396;txt;01
+Clients de torrent
+.
+
+4397;txt;01
+Les exclusions suivantes permettent aux clients de torrent tournant dans ce Bac à sable d'accéder aux fichiers hors du bac.
+.
+
+4398;txt;01
+Autoriser l'accès direct au dossier Musique à %2 pour simplifier la gestion de la bibliothèque musicale.
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Sandbox Settings:  User Accounts
+# Sandboxie Control :  Sandbox Settings :  User Accounts
 #----------------------------------------------------------------------------
 
 5101;txt;01
@@ -3150,11 +3319,11 @@ Comptes des utilisateurs
 
 5102;txt;01
 Ajouter des comptes et des groupes d'utilisateurs sur la liste suivante pour limiter l'utilisation de la sandbox à ces comptes seuls.
-Si la liste est vide, la sandbox peut-être utilisée pour tous les comptes des utilisateurs.
+Si la liste est vide, la sandbox peut être utilisée pour tous les comptes des utilisateurs.
 .
 
 5103;txt;01
-Remarque: la configuration des programmes et des dossiers forcés pour une sandbox ne sont pas applicables aux comptes des utilisateurs qui ne peuvent pas utiliser la sandbox.
+Remarque : la configuration des programmes et des dossiers forcés pour une sandbox ne sont pas applicables aux comptes des utilisateurs qui ne peuvent pas utiliser la sandbox.
 .
 
 # 5105;txt;01
@@ -3170,7 +3339,7 @@ du menu de la sandbox
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Reveal Hidden Sandbox
+# Sandboxie Control :  Reveal Hidden Sandbox
 #----------------------------------------------------------------------------
 
 5122;txt;01
@@ -3178,7 +3347,7 @@ Votre compte utilisateur est exclu de toutes les sandboxes listées ci-dessous.
 .
 
 5123;txt;01
-Les comptes des utilisateurs suivants ont maintenant la permission d'utiliser la sandbox selectionnée.
+Les comptes des utilisateurs suivants ont maintenant la permission d'utiliser la sandbox sélectionnée.
 .
 
 5124;txt;01
@@ -3186,11 +3355,11 @@ Cliquer sur le bouton "OK" pour ajouter votre compte d'utilisateur '%2' à la sa
 .
 
 #----------------------------------------------------------------------------
-# Sandboxie Control:  Set Layout and Groups
+# Sandboxie Control :  Set Layout and Groups
 #----------------------------------------------------------------------------
 
 5142;txt;01
-Regrouper les sandboxes et personnaliser l'ordre dans lequel, celles-ci sont listées. Utiliser "le clic-droit"sur la sandboxe pour gérer sa position dans l'arborescence ci-dessous.
+Regrouper les sandboxes et personnaliser l'ordre dans lequel, celles-ci sont listées. Utiliser "le clic-droit" sur la sandbox pour gérer sa position dans l'arborescence ci-dessous.
 .
 
 5143;txt;01
@@ -3230,6 +3399,58 @@ Insérer un &Groupe
 .
 
 #----------------------------------------------------------------------------
+# Plus Tips
+#----------------------------------------------------------------------------
+
+6001;txt;01
+L'interface utilisateur classique de Sandboxie (SbieCtrl.exe) a des capacités
+de surveillance des ressources et des événements très limitées.
+
+Pour un dépannage optimal, il est fortement conseillé
+d'installer la nouvelle interface utilisateur, Sandboxie-Plus (SandMan.exe),
+qui offre d'excellentes capacités de suivi et de surveillance.
+
+Voulez-vous télécharger Sandboxie-Plus ?
+.
+
+6002;txt;01
+Visitez <a ID="whats_new">sandboxie-plus.com</a> pour découvrir les nouvelles fonctionnalités de Sandboxie-Plus
+ou cliquez directement <a ID="upgrade">ici</a> pour télécharger le dernier installateur de Sandboxie-Plus.
+.
+
+6003;txt;01
+L'ancienne interface utilisateur de Sandboxie classic ne prend pas en charge la fonctionnalité de pare-feu réseau.
+
+Vous pouvez cependant configurer la fonctionnalité prise en charge par les composants de base en utilisant le fichier ini, les règles sont structurées comme suit :
+NetworkAccess=iexplorer.exe,Allow; Port=80,443; Address=192.168.0.1-192.168.100.255; Protocol=TCP
+
+Si vous préférez utiliser une interface utilisateur pour contrôler ces options, veuillez passer à Sandboxie-Plus, qui offre un support complet de toutes les nouvelles fonctionnalités.
+.
+
+6004;pop;err;01
+La configuration de la boîte sélectionnée n'est pas autorisée.
+.
+
+6005;txt;01
+Note : sans privilèges administrateurs, les installateurs ne pourront pas démarrer dans le Bac à sable. Sandboxie-Plus offre une option pour que de nombreux installateurs réussissent sans ces privilèges. Vous pouvez également activer cette option manuellement dans la version classique, en ajoutant "FakeAdminRights=y" à la section ini du bac à sable.
+.
+
+6006;txt;01
+L'ancienne interface utilisateur de Sandboxie classic ne prend en charge que quelques options de restriction.
+
+Des options supplémentaires comme "ClosePrintSpooler=y", "OpenClipboard=n", "BlockNetParam=n" et bien d'autres peuvent être définies dans la section ini du bac.
+L'interface utilisateur moderne (SandMan.exe) offre également plus d'options de personnalisation pour le démarrage/exécution et les restrictions d'accès à Internet.
+
+Si vous préférez utiliser une interface utilisateur pour contrôler ces options, veuillez passer à Sandboxie-Plus, qui offre un support complet de toutes les nouvelles fonctionnalités.
+.
+
+6007;txt;01
+Sandboxie Plus renforce la confidentialité en passant d'un mode liste noire (accès en lecture à l'ensemble du disque sauf si une règle spécifique d’un dossier l’empêche) à un mode liste blanche (les programmes "sandboxés" ne sont autorisés à lire que les emplacements génériques du système et l'accès en lecture à la plupart des données de l'utilisateur doit être explicitement accordé).
+
+L'interface utilisateur de Sandboxie classic ne prend pas en charge ce mode de fonctionnement. Bien qu'il soit possible de le configurer à l'aide du fichier ini, il est recommandé d'utiliser l'interface moderne Sandboxie-Plus (SandMan.exe) si vous souhaitez utiliser des Bacs à sable à confidentialité renforcée.
+.
+
+#----------------------------------------------------------------------------
 # Getting Started Wizard
 #----------------------------------------------------------------------------
 
@@ -3238,35 +3459,35 @@ Tutoriel de prise en main - Sandboxie
 .
 
 7851;txt;01
-Démarrer avec sandboxie
+Démarrer avec Sandboxie
 .
 
 7852;txt;01
-Bienvenue dans sandboxie !
+Bienvenue dans Sandboxie !
 
-Sandboxie execute vos programmes dans un environnement isolé qui les empêchent de modifer de façon permanente d'autres programmes et des données dans votre pc.
+Sandboxie exécute vos programmes dans un environnement isolé qui les empêchent de modifier de façon permanente d'autres programmes et des données dans votre pc.
 
-Ce tutoriel explique brièvement les principes de base pour utiliser sandboxie.
+Ce tutoriel explique brièvement les principes de base pour utiliser Sandboxie.
 .
 
 7853;txt;01
-Note: Ce tutoriel est conçu pour une utilisation avec la sandbox par défaut, DefaultBox.
+Note : ce tutoriel est conçu pour une utilisation avec la sandbox par défaut, DefaultBox.
 .
 
 7854;txt;01
-Comment Sandboxie fonctionne (Illustration)
+Comment Sandboxie fonctionne (illustration)
 .
 
 7855;txt;01
-Démarrer votre navigateur web sous sandboxie
+Démarrez votre navigateur web sous Sandboxie
 .
 
 7856;txt;01
-Trouver le raccourci sur votre bureau et effectuer un double-clic sur le raccourci pour démarrer votre navigateur web dans la sandbox par défaut, DefaultBox.
+Trouvez le raccourci sur votre bureau et effectuez un double-clic sur le raccourci pour démarrer votre navigateur web dans la sandbox par défaut, DefaultBox.
 .
 
 7857;txt;01
-Cliquer ici pour cacher cette fenêtre et montrer le bureau
+Cliquez ici pour cacher cette fenêtre et montrer le bureau
 .
 
 7858;txt;01
@@ -3274,71 +3495,73 @@ Votre navigateur est en cours d'exécution à l'intérieur de la sandbox
 .
 
 7859;txt;01
-Les programmes dans la sandbox peuvent seulement modifer les contenus de cette sandbox.
+Les programmes dans la sandbox peuvent seulement modifier les contenus de cette sandbox.
 
 Lorsque vous enregistrez ou téléchargez des fichiers, ils vont dans le bac à sable. Si vous enregistrez un fichier sur votre bureau, des documents ou des dossiers de Téléchargements, Sandboxie propose de déplacer le fichier à l'extérieur du bac à sable.
 
-Essayez dès maintenant: télécharger un fichier de votre navigateur vers votre dossier de bureau (dans le bac à sable), et de récupérer le fichier sur votre bureau réel.
+Essayez dès maintenant : téléchargez un fichier de votre navigateur vers votre dossier de bureau (dans le bac à sable) et récupérez le fichier sur votre bureau réel.
 .
 
 7860;txt;01
-Effacer les contenus de votre sandboxe
+Effacez les contenus de votre sandbox
 .
 
 7861;txt;01
-vous pouvez imaginer que la sandbox est comme un morceau de papier transparent placé entre le programme et votre pc. Effacer les contenus de la sandbox, c'est comme jeter un morceau de papier utilisé et le remplacer par un propre
+Vous pouvez imaginer que la sandbox est comme un morceau de papier transparent placé entre le programme et votre pc. Effacer les contenus de la sandbox, c'est comme jeter un morceau de papier utilisé et le remplacer par un propre
 .
 
 7862;txt;01
-Essayez dès maintenant: Supprimer les contenus de votre sandbox "DefaultBox". Trouver l'icône jaune Sandboxie dans le coin de votre écran en surbrillance, puis cliquez sur:
+Essayez dès maintenant : supprimer les contenus de votre sandbox "DefaultBox". Trouvez l'icône jaune Sandboxie dans le coin de votre écran en surbrillance, puis cliquez sur :
 .
 
 7863;txt;01
-Cliquer sur l'icône jaune de sandboxie,
+Cliquez droit sur l'icône jaune de Sandboxie,
 
-Alors sélectionner "DefaultBox", et selectionner "effacer les contenus".
+sélectionnez "DefaultBox", et sélectionnez "effacer les contenus".
 .
 
 7864;txt;01
-Prêt à l'emploi!
+Prêt à l'emploi !
 .
 
 7865;txt;01
 Merci d'avoir pris le temps de regarder ce tutoriel. Vous pouvez visiter le site web de Sandboxie pour plus de tutoriels et d'astuces.
 
-La configuration par défaut dans sandboxie fournit une protection complète, mais vous pouvez passer en revue les commandes de configuration de la sandboxe dans le menu "bac à sable" à l'intérieur de la fenêtre du programme "sandboxie control".
+La configuration par défaut dans Sandboxie fournit une protection complète, mais vous pouvez passer en revue les commandes de configuration de la sandbox dans le menu "bac à sable" à l'intérieur de la fenêtre du programme "Sandboxie control".
 .
 
-7866;txt;01
-Pour les systèmes en 64 bits, vous devrez activer "Experimental Protection". Voir le menu "configurer" dans "Sandboxie Control".
-.
+# 7866;txt;01
+# Pour les systèmes en 64 bits, vous devrez activer "Experimental Protection". Voir le menu "configurer" dans "Sandboxie Control".
+# .
 
 #----------------------------------------------------------------------------
-# License Manager
+# licence Manager
 #----------------------------------------------------------------------------
 
 7901;txt;01
-Sandboxie License Manager
+Sandboxie licence Manager
 .
 
 7902;txt;01
-code système %2
+Code système %2
 .
 
 7903;txt;01
 Dans l'avenir, activer la licence sans demander.
 .
 
+#----------------------------------------------------------------------------
+
 7921;txt;01
-Sandboxie est enregistrée et la licence est activée.
+Sandboxie est enregistré et la licence est activée.
 .
 
 7922;txt;01
-Sandboxie is enregistrée mais la licence doit être réactivée maintenant.
+Sandboxie est enregistré mais la licence doit être réactivée.
 .
 
 7923;txt;01
-Copie non enregistrée. Enregistrer aujourd'hui!
+Copie non enregistrée. Enregistrez-la aujourd'hui !
 .
 
 7924;txt;01
@@ -3346,47 +3569,51 @@ La licence de Sandboxie devra être réactivée dans %2 jours.
 .
 
 7925;txt;01
-la licence de Sandboxie est activé maintenant.
+La licence de Sandboxie est activée.
 .
 
 7926;txt;01
-La date d'expiration de la clé du Produit est %2.
+La date d'expiration de votre clé du produit est %2.
 .
 
 7927;txt;01
-Ta clé de produit n'a pas de date d'expiration.
+Votre clé de produit n'a pas de date d'expiration.
 .
 
+#----------------------------------------------------------------------------
+
 7931;txt;01
-Ta copie de Sandboxie est enregistrée avec une clé d'enregistrement obsolète.
+Votre copie de Sandboxie est enregistrée avec une clé d'enregistrement obsolète.
 .
 
 7932;txt;01
-Il faut laisser le "License Manager"se connecter au serveur et mettre à jour votre clé d'enregistrement.
+Merci de laisser le "licence Manager" se connecter au serveur afin de mettre à jour votre clé d'enregistrement.
 Cette opération est gratuite.
 .
 
 7933;txt;01
-Ta clé d'enregistrement n'est pas reconnue par le serveur de licence.
+Votre clé d'enregistrement n'est pas reconnue par le serveur de licence.
 .
 
 7934;txt;01
-Si vous avez utilisé une cle d'enregistrement valide, pour lequel vous avez payé ou qui vous a été fourni comme cadeau 
-ou comme une sorte de promotion, veuillez envoyer un mail à:
+Si vous avez utilisé une clef d'enregistrement valide, pour laquelle vous avez payé ou qui vous a été fourni comme cadeau
+ou comme une sorte de promotion, veuillez envoyer un mail à :
 .
 
 7935;txt;01
-Ta nouvelle clé de produit est:
+Votre nouvelle clé de produit est :
 .
 
 7936;txt;01
-Il faut penser à garder sa clé de produit dans un endroit sur pour la retouver en cas de besoin.
-Utiliser le bouton ci-dessous pour copier ta clé de produit, tu peux ensuite le coller dans un document et l'imprimer.
+Pensez à garder votre clé de produit dans un endroit sûr pour la retrouver en cas de besoin.
+Utilisez le bouton ci-dessous pour copier votre clé de produit, vous pourrez ensuite la coller dans un document et l'imprimer.
 .
 
 7937;txt;01
 &Mise à jour de la clé d'enregistrement pour la clé du produit 
 .
+
+#----------------------------------------------------------------------------
 
 7941;txt;01
 L'enregistrement de Sandboxie se fait par un site de paiement tierce-partie.  Commencer le processus d'enregistrement en suivant le lien suivant.
@@ -3398,7 +3625,7 @@ cliquer sur le bouton pour activer votre licence.
 .
 
 7943;txt;01
-Voulez-vous entrer une nouvelle clé de produit, maintenant?
+Voulez-vous entrer une nouvelle clé de produit ?
 .
 
 7944;txt;01
@@ -3410,26 +3637,30 @@ Votre copie de Sandboxie est maintenant enregistrée.
 .
 
 7946;txt;01
-Merci de votre support à Sandboxie!
+Merci de votre support à Sandboxie !
 .
 
+#----------------------------------------------------------------------------
+
 7951;txt;01
-Do you wish to activate the license now?
+Voulez-vous activer la licence dès à présent ?
 .
 
 7952;txt;01
-Please visit the Sandboxie web site at the link below to order a new Product Key.
+Veuillez visiter le site web de Sandboxie via le lien ci-dessous pour commander une nouvelle clef de produit.
 .
 
 7961;txt;01
-Clear License &Information
+Effacer les informations de la licence.
 .
 
 7962;txt;01
-Are you sure you wish to clear the license information in Sandboxie?
+Etes-vous sûr de vouloir effacer les informations de la licence de Sandboxie ?
 
-Tu peux activer ta licence à n'importe quel moment, il suffit d'entrer une clé de produit.
+Vous pourrez activer votre licence à n'importe quel moment, il suffira d'entrer une clé de produit.
 .
+
+#----------------------------------------------------------------------------
 
 7971;txt;01
 Ce n'est pas une clé de produit valide.
@@ -3448,16 +3679,16 @@ Réponse invalide du serveur qui fournit la licence.
 .
 
 7975;txt;01
-L'activation du produit a échoué:
+L'activation du produit a échoué :
 .
 
 7976;txt;01
-Voulez-vous faire un autre essai?
+Voulez-vous faire un autre essai ?
 .
 
 7977;txt;01
 Si vous avez besoin d'activer votre Sandboxie sur un ordinateur et que vous ne possédez pas d'accès à internet,
-il faut aller voir "the Sandboxie Licensing FAQ"pour avoir des informations sur l'activation hors-ligne.
+rendez-vous sur "the Sandboxie Licensing FAQ" pour avoir des informations sur l'activation hors-ligne.
 .
 
 7978;txt;01
@@ -3465,7 +3696,7 @@ La date actuelle (%2) est plus récente que la date fournie par le serveur de li
 .
 
 7982;txt;01
-Le serveur de licence n'a pas donner de raison pour expliquer l'echec de l'activation.
+Le serveur de licence n'a pas donné de raison pour expliquer l'échec de l'activation.
 .
 
 7983;txt;01
@@ -3473,7 +3704,7 @@ La clé de produit n'est pas reconnue par le serveur de licence.
 .
 
 7984;txt;01
-La clé de produit ne peut plus être utiliser au-delà de sa date d'expiration dU %2.
+La clé de produit ne peut plus être utilisée au-delà de sa date d'expiration du %2.
 .
 
 7985;txt;01
@@ -3481,11 +3712,11 @@ La clé de produit a été activée sur trop d'ordinateurs.
 .
 
 7986;txt;01
-Clé de produit annulé car elle a été rendue public sur internet.
+Clé de produit annulée car elle a été rendue publique sur internet.
 .
 
 7987;txt;01
-Clé de produit annulé car la commande a été remboursée.
+Clé de produit annulée car la commande a été remboursée.
 .
 
 #----------------------------------------------------------------------------
@@ -3505,19 +3736,19 @@ Démarrer
 .
 
 8004;ins;01
-Vous avez une installation existante de Sandboxie dans le dossier suivant:
+Vous avez une installation existante de Sandboxie dans le dossier suivant :
 .
 
 8005;ins;01
-Veuillez sélectionner comment procéder:
+Veuillez sélectionner la démarche à suivre :
 .
 
 8006;ins;01
-Ecraser (mise à niveau) l'installation éxistante
+Ecraser (mise à niveau) l'installation existante
 .
 
 8007;ins;01
-Désinstaller (Supprimer) l'installation éxistante et ses réglages
+Désinstaller (supprimer) l'installation existante et ses réglages
 .
 
 8008;ins;01
@@ -3529,7 +3760,7 @@ Avant de désinstaller, utilisez Sandboxie Control pour effacer le contenu du Ba
 .
 
 8010;ins;01
-Installation Pilote
+Installation du Pilote
 .
 
 8011;ins;01
@@ -3537,7 +3768,7 @@ Veuillez relire les informations ci-dessous.
 .
 
 8012;ins;01
-Cliquez sur suivant pour installer et activer le pilote Sandboxie au niveau Système. Ce pilote est le noyau de l'application Sandboxie.
+Cliquez sur suivant pour installer et activer le pilote Sandboxie au niveau Système. Ce pilote est le cœur de l'application Sandboxie.
 .
 
 8013;ins;01
@@ -3545,7 +3776,7 @@ Vous devrez peut-être désactiver temporairement tout système de protection qu
 .
 
 8014;ins;02
-Si cette étape échoue et que votre ordinateur se bloque ou redémarre, redémarrer votre pc en mode sans échec,
+Si cette étape échoue et que votre ordinateur se bloque ou redémarre, redémarrez votre pc en mode sans échec,
 vous pourrez ré-exécuter le programme d'installation pour supprimer Sandboxie.
 .
 
@@ -3570,7 +3801,7 @@ Exécuter dans le menu Démarrer.lnk
 .
 
 8024;ins;01
-Choisissez un programme du menu Démarrer pour s'éxécuter sous le contrôle de Sandboxie
+Choisissez un programme du menu Démarrer pour s'exécuter sous le contrôle de Sandboxie
 .
 
 8025;ins;01
@@ -3610,7 +3841,7 @@ Désinstaller Sandboxie
 .
 
 8041;ins;01
-Sandboxie ne peut être installé que sur les versions suivantes de Microsoft Windows:
+Sandboxie ne peut être installé que sur les versions suivantes de Microsoft Windows :
 .
 
 8042;ins;01
@@ -3639,7 +3870,7 @@ Cliquez sur Annuler pour arrêter l'installation.
 .
 
 8052;ins;01
-Ne peut créer ou mettre à jour le fichier programme Sandboxie.
+Impossible de créer ou mettre à jour le fichier programme Sandboxie.
 
 Veuillez vous assurer que Sandboxie Control n'est pas démarré,
 et qu'aucun programme 'sandboxés' ne soit en cours d'exécution.
@@ -3650,15 +3881,15 @@ Sinon, cliquez sur Annuler pour arrêter l'installation.
 .
 
 8053;ins;01
-*** KmdUtil  a échoué.l'Installation ou la désinstallation ne peut être effectuée avec succès. ***
+*** KmdUtil  a échoué. L'installation ou la désinstallation ne peut être effectuée avec succès. ***
 .
 
 8054;ins;01
-VOULEZ-vous sauvegarder la configuration de votre fichier sandboxie.ini?
+Voulez-vous sauvegarder la configuration de votre fichier Sandboxie.ini ?
 
-Selectionner 'oui' pour garder les paramètres de configuration dans le fichier sandboxie.ini.
+Sélectionner 'oui' pour garder les paramètres de configuration dans le fichier Sandboxie.ini.
 
-Selectionner 'non' pour effacer le fichier Sandboxie.ini et perdre tes paramètres de configuration.
+Sélectionner 'non' pour effacer le fichier Sandboxie.ini et perdre tes paramètres de configuration.
 .
 
 #----------------------------------------------------------------------------
@@ -3666,16 +3897,16 @@ Selectionner 'non' pour effacer le fichier Sandboxie.ini et perdre tes paramètr
 #----------------------------------------------------------------------------
 
 8101;txt;01
-Ne peut installer le pilote à cet instant.
+Impossible d'installer le pilote à cet instant.
 
 Veuillez redémarrer votre ordinateur,
 puis relancer la procédure d'installation.
 
-défaut de la fonction: %2
+Fonction en échec : %2
 .
 
 8102;txt;01
-Ne peut arrêter le service à ce point.
+Impossible d'arrêter le service à ce point.
 Le service '%2'  est occupé.
 
 Cliquez OK pour recommencer.
@@ -3694,6 +3925,6 @@ Ceci est la troisième et dernière tentative.
 .
 
 8106;txt;02
-Les programmes suivants doivent être fermées pour que l'installation puisse continuer.
+Les programmes suivants doivent être fermés pour que l'installation puisse continuer.
 Cliquez sur OK pour fermer ces programmes et pour continuer. Cliquez sur Annuler pour interrompre l'installation.
 .

--- a/SandboxiePlus/SandMan/sandman_fr.ts
+++ b/SandboxiePlus/SandMan/sandman_fr.ts
@@ -6,12 +6,12 @@
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="25"/>
         <source>%1 - Files</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - Fichiers</translation>
     </message>
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="129"/>
         <source>Create Shortcut</source>
-        <translation type="unfinished">Créer un raccourci</translation>
+        <translation>Créer un raccourci</translation>
     </message>
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="135"/>
@@ -21,17 +21,17 @@
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="137"/>
         <source>Recover to Same Folder</source>
-        <translation type="unfinished"></translation>
+        <translation>Récupérer vers le même dossier</translation>
     </message>
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="197"/>
         <source>Select Directory</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner le dossier</translation>
     </message>
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="247"/>
         <source>Create Shortcut to sandbox %1</source>
-        <translation type="unfinished">Créer un raccourci vers le bac à sable %1</translation>
+        <translation>Créer un raccourci vers le bac à sable %1</translation>
     </message>
 </context>
 <context>
@@ -64,32 +64,32 @@
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="38"/>
         <source>Hardened Sandbox with Data Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable renforcé avec protection des données</translation>
     </message>
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="39"/>
         <source>Security Hardened Sandbox</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable à sécurité renforcé</translation>
     </message>
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="40"/>
         <source>Sandbox with Data Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable avec protection des données</translation>
     </message>
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="41"/>
         <source>Standard Isolation Sandbox (Default)</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable à isolation standard (défaut)</translation>
     </message>
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="43"/>
         <source>Application Compartment with Data Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Compartimentation des applications avec protection des données</translation>
     </message>
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="44"/>
         <source>Application Compartment (NO Isolation)</source>
-        <translation type="unfinished"></translation>
+        <translation>Compartimentation des applications (SANS isolation)</translation>
     </message>
     <message>
         <source>Hardened</source>
@@ -153,22 +153,22 @@
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="240"/>
         <source>Normal</source>
-        <translation type="unfinished">Normal</translation>
+        <translation>Normal</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="241"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Autorisé</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="242"/>
         <source>Open for All</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Autorisé pour tous</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="246"/>
         <source>Boxed Only</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Dans le bac uniquement</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="248"/>
@@ -322,32 +322,32 @@
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="21"/>
         <source>Hardened Sandbox with Data Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable renforcé avec protection de données</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="22"/>
         <source>Security Hardened Sandbox</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable à sécurité renforcée</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="23"/>
         <source>Sandbox with Data Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable avec protection de donnée</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="24"/>
         <source>Standard Isolation Sandbox (Default)</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable à isolation standard (défaut)</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="26"/>
         <source>Application Compartment with Data Protection</source>
-        <translation type="unfinished"></translation>
+        <translation>Compartimentation d&apos;application avec protection de données</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="27"/>
         <source>Application Compartment (NO Isolation)</source>
-        <translation type="unfinished"></translation>
+        <translation>Compartimentation d&apos;application (SANS isolation)</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="90"/>
@@ -363,7 +363,7 @@
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="252"/>
         <source>Select color</source>
-        <translation type="unfinished"></translation>
+        <translation>Sélectionner une couleur</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="263"/>
@@ -767,7 +767,7 @@
     <message>
         <location filename="Windows/PopUpWindow.cpp" line="160"/>
         <source>Do you want to allow the print spooler to write outside the sandbox for %1 (%2)?</source>
-        <translation>Souhaitez-vous autoriser le spouleur d&apos;impression à écrire en dehors de la sandbox pour %1 (%2)&#xa0;?</translation>
+        <translation>Souhaitez-vous autoriser le spouleur d&apos;impression à écrire en dehors du bac à sable pour %1 (%2)&#xa0;?</translation>
     </message>
     <message>
         <location filename="Windows/PopUpWindow.cpp" line="253"/>
@@ -839,22 +839,22 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="97"/>
         <source>Remember target selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Se souvenir de l&apos;emplacement</translation>
     </message>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="121"/>
         <source>Original location</source>
-        <translation type="unfinished"></translation>
+        <translation>Emplacement d&apos;origine</translation>
     </message>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="122"/>
         <source>Browse for location</source>
-        <translation type="unfinished"></translation>
+        <translation>Naviguer vers un emplacement</translation>
     </message>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="123"/>
         <source>Clear folder list</source>
-        <translation type="unfinished">Effacer la liste des dossiers</translation>
+        <translation>Effacer la liste des dossiers</translation>
     </message>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="157"/>
@@ -866,12 +866,12 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="231"/>
         <source>Close until all programs stop in this box</source>
-        <translation type="unfinished"></translation>
+        <translation>Fermer tant qu&apos;un programme tourne dans le bac à sable</translation>
     </message>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="251"/>
         <source>There are %1 new files available to recover.</source>
-        <translation type="unfinished"></translation>
+        <translation>Il y a %1 fichier(s) disponible(s) pour une récupération.</translation>
     </message>
     <message>
         <location filename="Windows/RecoveryWindow.cpp" line="461"/>
@@ -884,22 +884,22 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="SandMan.cpp" line="2406"/>
         <source>Waiting for folder: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Attente du dossier : %1</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="2407"/>
         <source>Deleting folder: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Suppression du dossier : %1</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="2408"/>
         <source>Merging folders: %1 &amp;gt;&amp;gt; %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Fusion des dossiers : %1 &amp;gt;&amp;gt; %2</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="2409"/>
         <source>Finishing Snapshot Merge...</source>
-        <translation type="unfinished"></translation>
+        <translation>Finalisation de la fusion des instantanés...</translation>
     </message>
 </context>
 <context>
@@ -921,12 +921,12 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="SbiePlusAPI.cpp" line="188"/>
         <source>Application Compartment</source>
-        <translation type="unfinished"></translation>
+        <translation>Compartimentation d&apos;application</translation>
     </message>
     <message>
         <location filename="SbiePlusAPI.cpp" line="190"/>
         <source>NOT SECURE</source>
-        <translation type="unfinished"></translation>
+        <translation>NON SÉCURISÉ</translation>
     </message>
     <message>
         <location filename="SbiePlusAPI.cpp" line="192"/>
@@ -941,7 +941,7 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="SbiePlusAPI.cpp" line="197"/>
         <source>Privacy Enhanced</source>
-        <translation type="unfinished"></translation>
+        <translation>Confidentialité renforcée</translation>
     </message>
     <message>
         <location filename="SbiePlusAPI.cpp" line="200"/>
@@ -1037,7 +1037,7 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="SandMan.cpp" line="373"/>
         <source>Create Box Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Créer un groupe de bac</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="375"/>
@@ -1141,7 +1141,7 @@ Chemin complet&#xa0;: %4</translation>
         <location filename="SandMan.cpp" line="409"/>
         <source>Always on Top</source>
         <translatorcomment>( ͡° ͜ʖ ͡°)</translatorcomment>
-        <translation>Toujours au dessus</translation>
+        <translation>Toujours au-dessus</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="415"/>
@@ -1151,7 +1151,7 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="SandMan.cpp" line="417"/>
         <source>Show All Sessions</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher toutes les sessions</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="422"/>
@@ -1255,7 +1255,7 @@ Chemin complet&#xa0;: %4</translation>
     <message>
         <location filename="SandMan.cpp" line="497"/>
         <source>&lt;a href=&quot;https://sandboxie-plus.com/go.php?to=patreon&quot;&gt;Support Sandboxie-Plus on Patreon&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;a href=&quot;https://sandboxie-plus.com/go.php?to=patreon&quot;&gt;Soutenez Sandboxie Plus sur Patreon&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="528"/>
@@ -1284,24 +1284,26 @@ Voulez-vous faire le nettoyage&#xa0;?</translation>
     <message>
         <location filename="SandMan.cpp" line="590"/>
         <source>This box provides enhanced security isolation, it is suitable to test untrusted software.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce bac apporte une isolation sécuritaire renforcée et convient au test de logiciels non fiables.</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="594"/>
         <source>This box provides standard isolation, it is suitable to run your software to enhance security.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce bac apporte une isolation standard et convient à l&apos;exécution de vos logiciels avec une sécurité accrue.</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="598"/>
         <source>This box does not enforce isolation, it is intended to be used as an application compartment for software virtualization only.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce bac n&apos;impose pas d&apos;isolation, il est prévu pour être utilisé comme un compartimenteur d&apos;applications pour la virtualisation des logiciels uniquement.</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="603"/>
         <source>
 
 This box prevents access to all user data locations, except explicitly granted in the Resource Access options.</source>
-        <translation type="unfinished"></translation>
+        <translation>
+
+Ce bac empêche l&apos;accès à tous les emplacements des données utilisateur, à l&apos;exception de ceux spécifiquement autorisés dans les options d&apos;accès aux ressources.</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="660"/>
@@ -1358,7 +1360,7 @@ This box prevents access to all user data locations, except explicitly granted i
     <message>
         <location filename="SandMan.cpp" line="909"/>
         <source>Sbie+ Version: %1 (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Version de Sbie+ : %1 (%2)</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="910"/>
@@ -1382,7 +1384,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SandMan.cpp" line="979"/>
         <source>The supporter certificate is expired</source>
-        <translation type="unfinished"></translation>
+        <translation>Le certificat de supporter est expiré</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="985"/>
@@ -1397,7 +1399,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SandMan.cpp" line="1112"/>
         <source>The program %1 started in box %2 will be terminated in 5 minutes because the box was configured to use features exclusively available to project supporters.&lt;br /&gt;&lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-get-cert&quot;&gt;Become a project supporter&lt;/a&gt;, and receive a &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;supporter certificate&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Le programme %1 lancé dans le bac à sable %2 sera terminé dans 5 minutes car le bac a été configuré pour utiliser des fonctionnalités exclusivement disponibles pour les supporters du projet.&lt;br /&gt;&lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-get-cert&quot;&gt;Devenez un supporter du projet&lt;/a&gt;, et recevez un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;certificat de supporter&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="1135"/>
@@ -1412,7 +1414,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SandMan.cpp" line="1163"/>
         <source>The selected feature set is only available to project supporters. Processes started in a box with this feature set enabled without a supporter certificate will be terminated after 5 minutes.&lt;br /&gt;&lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-get-cert&quot;&gt;Become a project supporter&lt;/a&gt;, and receive a &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;supporter certificate&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>La fonctionnalité sélectionnée n&apos;est disponible que pour les supporters du projet. Les processus lancés dans un bac à sable avec cette fonctionnalité activée sans certificat de supporter seront terminés après 5 minutes.&lt;br /&gt;&lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-get-cert&quot;&gt;Devenez un supporter du projet&lt;/a&gt;, et recevez un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;certificat de supporter&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="1260"/>
@@ -1499,32 +1501,32 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SandMan.cpp" line="1792"/>
         <source>Error Status: 0x%1 (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Code erreur : 0x%1 (%2)</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="1793"/>
         <source>Unknown</source>
-        <translation type="unfinished">Inconnu</translation>
+        <translation>Inconnu</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="1826"/>
         <source>Unknown Error Status: 0x%1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Code erreur inconnu : 0x%1</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="2264"/>
         <source>This copy of Sandboxie+ is certified for: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Cette copie de Sanboxie+ est certifiée pour : %1</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="2266"/>
         <source>Sandboxie+ is free for personal and non-commercial use.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sandboxie+ est gratuit pour un usage personnel et non commercial.</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="2269"/>
         <source>Sandboxie-Plus is an open source continuation of Sandboxie.&lt;br /&gt;Visit &lt;a href=&quot;https://sandboxie-plus.com&quot;&gt;sandboxie-plus.com&lt;/a&gt; for more information.&lt;br /&gt;&lt;br /&gt;%3&lt;br /&gt;&lt;br /&gt;Driver version: %1&lt;br /&gt;Features: %2&lt;br /&gt;&lt;br /&gt;Icons from &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Sandboxie-Plus est la poursuite open source de Sandboxie.&lt;br /&gt;Visitez &lt;a href=&quot;https://sandboxie-plus.com&quot;&gt;sandboxie-plus.com&lt;/a&gt; pour plus d&apos;informations.&lt;br /&gt;&lt;br /&gt;%3&lt;br /&gt;&lt;br /&gt;Version du pilote : %1&lt;br /&gt;Fonctionnalités : %2&lt;br /&gt;&lt;br /&gt;Icônes provenant de &lt;a href=&quot;https://icons8.com&quot;&gt;icons8.com&lt;/a&gt;</translation>
     </message>
     <message>
         <source>Error Status: %1</source>
@@ -1656,7 +1658,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SandMan.cpp" line="1820"/>
         <source>Failed to remove old RegHive</source>
-        <translation>Impossible de supprimer l&apos;ancien base de données</translation>
+        <translation>Impossible de supprimer l&apos;ancienne base de données</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="1821"/>
@@ -1800,7 +1802,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="main.cpp" line="76"/>
         <source>Sandboxie Manager can not be run sandboxed!</source>
-        <translation type="unfinished"></translation>
+        <translation>Le programme de gestion de Sandboxie ne peut être démarré dans un bac !</translation>
     </message>
 </context>
 <context>
@@ -1992,7 +1994,8 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SbiePlusAPI.cpp" line="497"/>
         <source>Thunderbird</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Nom de logiciel</translatorcomment>
+        <translation>Thunderbird</translation>
     </message>
     <message>
         <location filename="SbiePlusAPI.cpp" line="506"/>
@@ -2002,7 +2005,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SbiePlusAPI.cpp" line="512"/>
         <source>Forced </source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Forcé </translation>
     </message>
     <message>
         <location filename="SbiePlusAPI.cpp" line="510"/>
@@ -2012,7 +2015,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="SbiePlusAPI.cpp" line="516"/>
         <source> in session %1</source>
-        <translation type="unfinished"></translation>
+        <translation> dans la session %1</translation>
     </message>
     <message>
         <location filename="SbiePlusAPI.cpp" line="525"/>
@@ -2261,87 +2264,87 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Views/SbieView.cpp" line="75"/>
         <source>Create Box Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Créer un groupe de bac</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="76"/>
         <source>Rename Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Renommer le groupe</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="86"/>
         <source>Command Prompt</source>
-        <translation type="unfinished"></translation>
+        <translation>Interpréteur de commandes</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="87"/>
         <source>Boxed Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Outils dans le bac à sable</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="88"/>
         <source>Command Prompt (as Admin)</source>
-        <translation type="unfinished"></translation>
+        <translation>Interpréteur de commandes (en tant qu&apos;administrateur)</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="90"/>
         <source>Command Prompt (32-bit)</source>
-        <translation type="unfinished"></translation>
+        <translation>Interpréteur de commandes (32 bits)</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="95"/>
         <source>Execute Autorun Entries</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Executer les entrées d&apos;Autorun</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="100"/>
         <source>Browse Content</source>
-        <translation type="unfinished"></translation>
+        <translation>Naviguer dans le contenu</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="101"/>
         <source>Box Content</source>
-        <translation type="unfinished"></translation>
+        <translation>Contenu du bac</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="105"/>
         <source>Open Registry</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir le registre</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="129"/>
         <source>Duplicate Sandbox</source>
-        <translation type="unfinished"></translation>
+        <translation>Dupliquer le bac à sable</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="132"/>
         <source>Move Box/Group</source>
-        <translation type="unfinished"></translation>
+        <translation>Déplacer le bac/groupe</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="133"/>
         <source>Move Up</source>
-        <translation type="unfinished">Monter</translation>
+        <translation>Monter</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="138"/>
         <source>Move Down</source>
-        <translation type="unfinished">Descendre</translation>
+        <translation>Descendre</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="578"/>
         <source>Please enter a new name for the Group.</source>
-        <translation type="unfinished"></translation>
+        <translation>Veuillez entrer un nouveau nom pour le groupe.</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="582"/>
         <source>This Group name is already in use.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le nom de groupe est déjà utilisé.</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="625"/>
         <source>Move entries by (negative values move up, positive values move down):</source>
-        <translation type="unfinished"></translation>
+        <translation>Déplacer les entrées de (un nombre négatif fait monter, un positif descendre) :</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="659"/>
@@ -2364,12 +2367,12 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Views/SbieView.cpp" line="883"/>
         <source>Please enter a new name for the duplicated Sandbox.</source>
-        <translation type="unfinished"></translation>
+        <translation>Veuillez entrer un nouveau nom pour le bac à sable dupliqué.</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="883"/>
         <source>%1 Copy</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - Copie</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="920"/>
@@ -2405,7 +2408,7 @@ Non choisira&#xa0;: %2</translation>
         <location filename="Views/SbieView.cpp" line="984"/>
         <location filename="Views/SbieView.cpp" line="1060"/>
         <source>Terminate without asking</source>
-        <translation type="unfinished"></translation>
+        <translation>Terminer sans demander</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="1024"/>
@@ -2416,12 +2419,12 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Views/SbieView.cpp" line="1059"/>
         <source>Do you want to %1 %2?</source>
-        <translation type="unfinished"></translation>
+        <translation>Voulez-vous %1 %2 ?</translation>
     </message>
     <message>
         <location filename="Views/SbieView.cpp" line="1059"/>
         <source>the selected processes</source>
-        <translation type="unfinished"></translation>
+        <translation>les processus sélectionnés</translation>
     </message>
     <message>
         <source>Do you want to %1 the selected process(es)?</source>
@@ -2472,17 +2475,17 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="106"/>
         <source>Don&apos;t show any icon</source>
-        <translation type="unfinished"></translation>
+        <translation>Ne pas afficher d&apos;icône</translation>
     </message>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="107"/>
         <source>Show Plus icon</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher l&apos;icône Plus</translation>
     </message>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="108"/>
         <source>Show Classic icon</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher l&apos;icône Classique</translation>
     </message>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="110"/>
@@ -2503,7 +2506,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="488"/>
         <source>This certificate is unfortunately expired.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce certificat est malheureusement expiré.</translation>
     </message>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="494"/>
@@ -2660,17 +2663,17 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Views/TraceView.cpp" line="83"/>
         <source>Type:</source>
-        <translation type="unfinished"></translation>
+        <translation>Type :</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="94"/>
         <source>Status:</source>
-        <translation type="unfinished"></translation>
+        <translation>État :</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="97"/>
         <source>Open</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Autorisé</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="98"/>
@@ -2680,37 +2683,37 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Views/TraceView.cpp" line="99"/>
         <source>Trace</source>
-        <translation type="unfinished"></translation>
+        <translation>Trace</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="100"/>
         <source>Other</source>
-        <translation type="unfinished"></translation>
+        <translation>Autre</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="105"/>
         <source>Show All Boxes</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher tous les bacs</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="111"/>
         <source>Save to file</source>
-        <translation type="unfinished"></translation>
+        <translation>Enregistrer dans un fichier</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="340"/>
         <source>Save trace log to file</source>
-        <translation type="unfinished"></translation>
+        <translation>Enregistrer le journal dans un fichier</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="346"/>
         <source>Failed to open log file for writing</source>
-        <translation type="unfinished"></translation>
+        <translation>Echec de l&apos;ouverture du fichier de journal en écriture</translation>
     </message>
     <message>
         <location filename="Views/TraceView.cpp" line="362"/>
         <source>Unknown</source>
-        <translation type="unfinished">Inconnu</translation>
+        <translation>Inconnu</translation>
     </message>
     <message>
         <source>Filter selected box only</source>
@@ -2733,7 +2736,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Forms/FileBrowserWindow.ui" line="32"/>
         <source>SandboxiePlus - Snapshots</source>
-        <translation type="unfinished">SandboxiePlus - Instantanés</translation>
+        <translation>SandboxiePlus - Instantanés</translation>
     </message>
 </context>
 <context>
@@ -2746,17 +2749,17 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Forms/NewBoxWindow.ui" line="54"/>
         <source>Box Type Preset:</source>
-        <translation type="unfinished"></translation>
+        <translation>Préréglage du type de bac :</translation>
     </message>
     <message>
         <location filename="Forms/NewBoxWindow.ui" line="77"/>
         <source>A sandbox isolates your host system from processes running within the box, it prevents them from making permanent changes to other programs and data in your computer. The level of isolation impacts your security as well as the compatibility with applications, hence there will be a different level of isolation depending on the selected Box Type. Sandboxie can also protect your personal data from being accessed by processes running under its supervision.</source>
-        <translation type="unfinished"></translation>
+        <translation>Un bac à sable isole votre système des processus qui tournent dans le bac. Cela permet d&apos;éviter qu&apos;ils puissent modifier de manière permanente vos programmes ou les données de votre ordinateur. Le niveau d&apos;isolation impacte votre sécurité mais aussi la compatibilité avec les applications, c&apos;est pourquoi il y a différents niveaux d&apos;isolation en fonction du type de bac à sable. Sandboxie peut aussi empêcher l&apos;accès à vos données personnelles aux processus tournant sous sa supervision.</translation>
     </message>
     <message>
         <location filename="Forms/NewBoxWindow.ui" line="94"/>
         <source>Box info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informations du bac</translation>
     </message>
     <message>
         <source>Select restriction/isolation template:</source>
@@ -2819,7 +2822,7 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="545"/>
         <source>Drop rights from Administrators and Power Users groups</source>
-        <translation>Abandonner les droits des groupes Administrateurs et Power Users</translation>
+        <translation>Retirer les droits des groupes Administrateurs et Power Users</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="131"/>
@@ -3110,37 +3113,37 @@ Non choisira&#xa0;: %2</translation>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="101"/>
         <source>General Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuration générale</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="111"/>
         <source>Box Type Preset:</source>
-        <translation type="unfinished"></translation>
+        <translation>Préréglage du type de bac :</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="151"/>
         <source>Box info</source>
-        <translation type="unfinished"></translation>
+        <translation>Informations du bac</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="226"/>
         <source>&lt;b&gt;More Box Types&lt;/b&gt; are exclusively available to &lt;u&gt;project supporters&lt;/u&gt;, the Privacy Enhanced boxes &lt;b&gt;&lt;font color=&apos;red&apos;&gt;protect user data from illicit access&lt;/font&gt;&lt;/b&gt; by the sandboxed programs.&lt;br /&gt;If you are not yet a supporter, then please consider &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-get-cert&quot;&gt;supporting the project&lt;/a&gt;, to receive a &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;supporter certificate&lt;/a&gt;.&lt;br /&gt;You can test the other box types by creating new sandboxes of those types, however processes in these will be auto terminated after 5 minutes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Les &lt;b&gt;types de bac à sable avancés&lt;/b&gt; sont réservés aux &lt;u&gt;supporters du projet&lt;/u&gt;. Les bacs de confidentialité renforcée &lt;b&gt;&lt;font color=&apos;red&apos;&gt;protègent les données utilisateurs contre des accès illicites&lt;/font&gt;&lt;/b&gt; des programmes du bac.&lt;br /&gt; Si vous n&apos;êtes pas encore un supporter, considérez de &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-get-cert&quot;&gt;soutenir le projet&lt;/a&gt;, pour recevoir un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;certificat de supporter&lt;/a&gt;.&lt;br /&gt; Vous pouvez tester les autres type de bac à sable en en créant, cependant les processus de ces bacs seront automatiquement arrêtés après 5 minutes.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="413"/>
         <source>Admin Rights</source>
-        <translation type="unfinished"></translation>
+        <translation>Droits administrateur</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="570"/>
         <source>Open Windows Credentials Store (user mode)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Ouvrir le magasin d&apos;identifiants Windows (mode utilisateur)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="721"/>
         <source>Prevent change to network and firewall parameters (user mode)</source>
-        <translation type="unfinished"></translation>
+        <translation>Empêche les changements aux réseaux et règles du pare-feu (mode utilisateur)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="965"/>
@@ -3327,14 +3330,16 @@ Si des processus directeurs sont définis, tous les autres sont traités comme d
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1536"/>
         <source>Resource Access Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Règles d&apos;accès aux ressources</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1575"/>
         <source>Configure which processes can access what resources. Double click on an entry to edit it.
 &apos;Open&apos; File and Key access only applies to program binaries located outside the sandbox.
 You can use &apos;Open for All&apos; instead to make it apply to all programs, or change this behaviour in the Policies tab.</source>
-        <translation type="unfinished"></translation>
+        <translation>Configurer quels processus peuvent accéder à quelles ressources. Double-cliquez sur une entrée pour la modifier.
+L&apos;accès « Autorisé » aux fichiers et aux clés ne s&apos;applique qu&apos;aux programmes binaires situés en dehors du bac à sable.
+Pour l&apos;accès aux fichiers, vous pouvez utiliser « Autorisé pour tous » pour qu&apos;il s&apos;applique à tous les programmes.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1707"/>
@@ -3447,18 +3452,19 @@ Pour l&apos;accès aux fichiers, vous pouvez utiliser «&#xa0;Toujours direct&#x
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2117"/>
         <source>Drop critical privileges from processes running with a SYSTEM token</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>SYSTEM conservé pour éviter de confondre avec autre chose lié à l&apos;OS</translatorcomment>
+        <translation>Retirer les privilèges critiques des processus tournant avec un jeton Système (SYSTEM)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2131"/>
         <location filename="Forms/OptionsWindow.ui" line="2152"/>
         <source>(Security Critical)</source>
-        <translation type="unfinished"></translation>
+        <translation>(Sécurité critique)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2138"/>
         <source>Protect sandboxed SYSTEM processes from unprivileged processes</source>
-        <translation type="unfinished"></translation>
+        <translation>Protéger les processus Système (SYSTEM) du bac des processus non privilégiés</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2169"/>
@@ -3473,63 +3479,64 @@ Pour l&apos;accès aux fichiers, vous pouvez utiliser «&#xa0;Toujours direct&#x
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1371"/>
         <source>Network Firewall Rules</source>
-        <translation type="unfinished"></translation>
+        <translation>Règles du pare-feu</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1717"/>
         <source>Resource Access Policies</source>
-        <translation type="unfinished"></translation>
+        <translation>Politiques d&apos;accès aux ressources</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1750"/>
         <source>The rule specificity is a measure to how well a given rule matches a particular path, simply put the specificity is the length of characters from the begin of the path up to and including the last matching non-wildcard substring. A rule which matches only file types like &quot;*.tmp&quot; would have the highest specificity as it would always match the entire file path. 
 The process match level has a higher priority than the specificity and describes how a rule applies to a given process. Rules applying by process name or group have the strongest match level, followed by the match by negation (i.e. rules applying to all processes but the given one), while the lowest match levels have global matches, i.e. rules that apply to any process.</source>
-        <translation type="unfinished"></translation>
+        <translation>La spécificité de la règle est une mesure de l&apos;efficacité avec laquelle une règle donnée correspond à un chemin d&apos;accès particulier. En d&apos;autres termes, la spécificité est la longueur en caractère depuis le début du chemin d&apos;accès jusqu&apos;à la dernière sous-chaîne non générique (wildcard) correspondante. Une règle qui ne correspondrait qu&apos;à des types de fichiers tels que &quot;*.tmp&quot; aurait la spécificité la plus élevée, car elle correspondrait toujours à l&apos;intégralité du chemin d&apos;accès au fichier.
+Le niveau de correspondance du processus a une priorité plus élevée que la spécificité et décrit comment une règle s&apos;applique à un processus donné. Les règles s&apos;appliquant par nom ou groupe de processus ont le niveau de correspondance le plus fort, suivi par la correspondance par négation (c&apos;est-à-dire les règles s&apos;appliquant à tous les processus sauf celui donné), tandis que les niveaux de correspondance les plus bas sont des correspondances globales, c&apos;est-à-dire des règles qui s&apos;appliquent à n&apos;importe quel processus.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1774"/>
         <source>Prioritize rules based on their Specificity and Process Match Level</source>
-        <translation type="unfinished"></translation>
+        <translation>Hiérarchiser les règles en fonction de leur spécificité et du niveau de correspondance des processus</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1781"/>
         <source>Privacy Mode, block file and registry access to all locations except the generic system ones</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode confidentialité : bloque tous les accès aux emplacements de fichiers et de registre à l&apos;exception des génériques du système</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1795"/>
         <source>Access Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Mode d&apos;accès</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1802"/>
         <source>When the Privacy Mode is enabled, sandboxed processes will be only able to read C:\Windows\*, C:\Program Files\*, and parts of the HKLM registry, all other locations will need explicit access to be readable and/or writable. In this mode, Rule Specificity is always enabled.</source>
-        <translation type="unfinished"></translation>
+        <translation>Lorsque le mode Confidentialité est activé, les processus du bac ne peuvent lire que C:\Windows\*, C:\Program Files\* et certaines parties de la ruche HKLM. Tous les autres emplacements nécessitent un accès explicite pour pouvoir être lus et/ou écrits. Dans ce mode, la spécificité des règles est toujours activée.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1819"/>
         <source>Rule Policies</source>
-        <translation type="unfinished"></translation>
+        <translation>Politiques des règles</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1826"/>
         <source>Apply Close...=!&lt;program&gt;,... rules also to all binaries located in the sandboxed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Appliquer les directives Close...=!&lt;program&gt; à tous les binaires situés dans le bac à sable.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1833"/>
         <source>Apply File and Key Open directives only to binaries located outside the sandbox.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Appliquer les directives Open (autoriser) pour les fichiers (File) et les clefs (Key) seulement aux binaires situés en dehors du bac à sable.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2004"/>
         <source>Start the sandboxed RpcSs as a SYSTEM process (not recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation>Démarrer le processus RpcSs du bac en tant que Système (non recommandé)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2011"/>
         <source>Allow only privileged processes to access the Service Control Manager</source>
-        <translation type="unfinished">Limiter l&apos;accès au gestionnaire de contrôle des services émulés aux processus privilégiés</translation>
+        <translation>Limiter l&apos;accès au gestionnaire des services aux processus privilégiés</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2032"/>
@@ -3539,17 +3546,17 @@ The process match level has a higher priority than the specificity and describes
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2059"/>
         <source>Open access to COM infrastructure (not recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ouvrir l&apos;accès à l&apos;infrastructure COM (non recommandé)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2086"/>
         <source>Add sandboxed processes to job objects (recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajouter les processus du bac à des objets de traitement (job objects) (recommandé)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2103"/>
         <source>COM isolation</source>
-        <translation type="unfinished"></translation>
+        <translation>Isolation COM</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2110"/>
@@ -3569,23 +3576,23 @@ The process match level has a higher priority than the specificity and describes
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2187"/>
         <source>Security Isolation through the usage of a heavily restricted process token is Sandboxie&apos;s primary means of enforcing sandbox restrictions, when this is disabled the box is operated in the application compartment mode, i.e. it’s no longer providing reliable security, just simple application compartmentalization.</source>
-        <translation type="unfinished"></translation>
+        <translation>L&apos;isolation de sécurité par l&apos;utilisation d&apos;un jeton de processus fortement restreint est le principal moyen utilisé par Sandboxie pour appliquer les restrictions du bac à sable. Lorsque cette fonction est désactivée, le bac fonctionne en mode compartiment d&apos;application, c&apos;est-à-dire qu&apos;il ne fournit plus de sécurité fiable, mais seulement une simple compartimentation d&apos;application.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2204"/>
         <source>Allow sandboxed programs to manage Hardware/Devices</source>
         <oldsource>Allow sandboxed programs to managing Hardware/Devices</oldsource>
-        <translation type="unfinished">Autoriser les programmes en bac à sable à gérer le matériel ou les périphériques</translation>
+        <translation>Autoriser les programmes en bac à sable à gérer le matériel ou les périphériques</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2224"/>
         <source>Disable Security Isolation (experimental)</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactiver l&apos;isolation de sécurité (expérimental)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2231"/>
         <source>Various advanced isolation features can break compatibility with some applications. If you are using this sandbox &lt;b&gt;NOT for Security&lt;/b&gt; but for simple application portability, by changing these options you can restore compatibility by sacrificing some security.</source>
-        <translation type="unfinished"></translation>
+        <translation>De multiples fonctionnalités avancées d&apos;isolation cassent la compatibilité avec certaines applications. Si vous n&apos;utilisez ce bac à sable que pour de la &lt;b&gt;NON sécurité&lt;/b&gt;, c&apos;est à dire uniquement pour de la portabilité, changer ces options permettra de restaurer de la compatibilité en sacrifiant de la sécurité.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2254"/>
@@ -3600,22 +3607,22 @@ The process match level has a higher priority than the specificity and describes
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2271"/>
         <source>Security Isolation &amp; Filtering</source>
-        <translation type="unfinished"></translation>
+        <translation>Isolation et filtrage de sécurité</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2278"/>
         <source>Disable Security Filtering (not recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation>Désactiver le filtrage de sécurité (non recommandé)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2285"/>
         <source>Security Filtering used by Sandboxie to enforce filesystem and registry access restrictions, as well as to restrict process access.</source>
-        <translation type="unfinished"></translation>
+        <translation>Le filtrage de sécurité est utilisé par Sandboxie pour imposer les restrictions d&apos;accès au système de fichier, au registre ou aux processus.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2295"/>
         <source>The below options can be used safely when you don&apos;t grant admin rights.</source>
-        <translation type="unfinished"></translation>
+        <translation>Les options ci-dessous peuvent être utilisées sans risque si vous n&apos;accordez pas les droits administrateur.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2315"/>
@@ -3737,7 +3744,7 @@ au lieu de «&#xa0;*&#xa0;».</translation>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2591"/>
         <source>Ntdll syscall Trace (creates a lot of output)</source>
-        <translation>Traçage de appels systèmes Ntdll (crée beaucoup de sortie)</translation>
+        <translation>Traçage des appels systèmes Ntdll (crée beaucoup de sortie)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2598"/>
@@ -3912,7 +3919,7 @@ Veuillez noter que ces valeurs sont actuellement spécifiques à l&apos;utilisat
     <message>
         <location filename="Windows/OptionsWindow.cpp" line="42"/>
         <source>Group: %1</source>
-        <translation type="unfinished">Groupe&#xa0;: %1</translation>
+        <translation>Groupe : %1</translation>
     </message>
 </context>
 <context>
@@ -3980,7 +3987,7 @@ Veuillez noter que ces valeurs sont actuellement spécifiques à l&apos;utilisat
     <message>
         <location filename="Forms/RecoveryWindow.ui" line="117"/>
         <source>Recover target:</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Cible :</translation>
     </message>
     <message>
         <location filename="Forms/RecoveryWindow.ui" line="153"/>
@@ -4019,7 +4026,7 @@ Veuillez noter que ces valeurs sont actuellement spécifiques à l&apos;utilisat
     <message>
         <location filename="Forms/SelectBoxWindow.ui" line="51"/>
         <source>Sandbox</source>
-        <translation type="unfinished"></translation>
+        <translation>Bac à sable</translation>
     </message>
     <message>
         <location filename="Forms/SelectBoxWindow.ui" line="66"/>
@@ -4221,17 +4228,18 @@ Veuillez noter que ces valeurs sont actuellement spécifiques à l&apos;utilisat
     <message>
         <location filename="Forms/SettingsWindow.ui" line="144"/>
         <source>Show recoverable files as notifications</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher les fichiers récupérables en tant que notification</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="204"/>
         <source>Show Icon in Systray:</source>
-        <translation type="unfinished"></translation>
+        <translation>Afficher dans la zone de notification :</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="411"/>
         <source>Activate Kernel Mode Object Filtering (experimental)</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Nom anglais conservé pour trouver sur internet ce que c&apos;est</translatorcomment>
+        <translation>Activer le filtrage d&apos;objet au niveau noyau (Kernel Mode Object Filtering)</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="493"/>
@@ -4317,7 +4325,7 @@ Veuillez noter que ces valeurs sont actuellement spécifiques à l&apos;utilisat
     <message>
         <location filename="Forms/SettingsWindow.ui" line="757"/>
         <source>Keeping Sandboxie up to date with the rolling releases of Windows and compatible with all web browsers is a never-ending endeavor. Please consider supporting this work with a donation.&lt;br /&gt;You can support the development with a &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=donate&quot;&gt;PayPal donation&lt;/a&gt;, working also with credit cards.&lt;br /&gt;Or you can provide continuous support with a &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=patreon&quot;&gt;Patreon subscription&lt;/a&gt;.</source>
-        <translation>Maintenir Sandboxie à jour avec les versions continues de Windows et compatible avec tous les navigateurs Web est une effort sans fin. Veuillez envisager de soutenir ce travail par un don.&lt;br /&gt;Vous pouvez soutenir le développement avec un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=donate&quot;&gt;don PayPal&lt;/a&gt;, fonctionnant également avec des cartes de crédit.&lt;br /&gt;Ou vous pouvez fournir un soutien continu avec un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=patreon&quot;&gt;abonnement à Patreon&lt;/a&gt;.</translation>
+        <translation>Maintenir Sandboxie à jour avec les versions continues de Windows et compatible avec tous les navigateurs Web est un effort sans fin. Veuillez envisager de soutenir ce travail par un don.&lt;br /&gt;Vous pouvez soutenir le développement avec un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=donate&quot;&gt;don PayPal&lt;/a&gt;, fonctionnant également avec des cartes de crédit.&lt;br /&gt;Ou vous pouvez fournir un soutien récurrent avec un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=patreon&quot;&gt;abonnement à Patreon&lt;/a&gt;.</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="789"/>
@@ -4332,12 +4340,12 @@ Veuillez noter que ces valeurs sont actuellement spécifiques à l&apos;utilisat
     <message>
         <location filename="Forms/SettingsWindow.ui" line="810"/>
         <source>Supporters of the Sandboxie-Plus project receive a &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;supporter certificate&lt;/a&gt;. It&apos;s like a license key but for awesome people using open source software. :-)</source>
-        <translation type="unfinished"></translation>
+        <translation>Les supporters du projet Sandboxie Plus reçoivent un &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=sbie-cert&quot;&gt;certificat de supporter&lt;/a&gt;. C&apos;est comme une clef de licence mais pour de superbes personnes utilisant des logiciels open source. :-)</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="827"/>
         <source>This supporter certificate has expired, please get an updated certificate.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ce certificat de supporter a expiré, veuillez obtenir un certificat à jour.</translation>
     </message>
     <message>
         <source>Supporters of the Sandboxie-Plus project receive a &lt;a href=&quot;https://sandboxie-plus.com/go.php?to=certificate&quot;&gt;supporter certificate&lt;/a&gt;. It&apos;s like a license key but for awesome people using free software. :-)</source>

--- a/SandboxiePlus/SandMan/sandman_fr.ts
+++ b/SandboxiePlus/SandMan/sandman_fr.ts
@@ -16,7 +16,7 @@
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="135"/>
         <source>Recover to Any Folder</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Récupérer vers un autre dossier</translation>
     </message>
     <message>
         <location filename="Windows/FileBrowserWindow.cpp" line="137"/>


### PR DESCRIPTION
French translation update to the current state.
Little refactor of Text-French-1036.txt in order to be like the English one and be easilly diffable.

Note: it would be a good idea to do a cleanup in the translation files for all languages (there are a lot of commented texts and some maybe not used anymore texts ass well, i.e. 7933;txt;01)