### PR TITLE
[Reminder] Fix isolation flaw with IOCTLs on non-hardened sandboxes

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -167,10 +167,6 @@ ClosedClsid={4991D34B-80A1-4291-83B6-3328366B9097}
 ClosedClsid={C2F03A33-21F5-47FA-B4BB-156362A2F239}
 
 [Template_ThirdPartyIsolation]
-# close VMNet0 virtual network
-ClosedFilePath=\Device\VMnetUserif
-
-
 #
 # Internet Explorer
 #


### PR DESCRIPTION
I think compare with the change affect out of the Sandboxie, VMNet0(Bridging network) could't work is even worse.

---

Reply n. 1 on 3 Jan 2022: https://github.com/sandboxie-plus/Sandboxie/issues/1102#issuecomment-1004026992

> It is a general flaw in sbies security architecture to allow Device IO Control access to random devices at \Device* this issue will be remedied in a later release.
> for the issue at hand the result will be same as ClosedFilePath=\Device\VMnetUserif
> hence if one wants to access that device OpenFilePath=\Device\VMnetUserif will have to be added
> resulting in the initial issue at hand, device is open sandboxed apps can talk to it device driver modifies outside OS.
> 
> It is possible to add a driver level control code filter for this device, but as its not a part of windows and will be closed by default, its not something I would want to spend my time on,
> i add a fix for one device driver and the world stays full of millions other device drviers that a good portion of will also allow to compromise the system still.
> 
> If this is something extremely important for someone, them one can become a patron at one of the 3 highest tears, then I would look into that custom solution for this particular use case.

Reply n. 2 on 7 Apr 2022: https://github.com/sandboxie-plus/Sandboxie/issues/1102#issuecomment-1091668084

> In one of the future builds a new hardened box mode will be introduced that prevents access to not opened device endpoints that will be the fix.
> The user must choose if he wants to allow a particular sandbox access to this device or not. Its not reasonable to implement custom filtering for that endpoint.
> If that means that then a sand boxed process can alter that tools configuration so be it.
> Until then you can use ClosedFilePath=!vmware.exe,\Device\VMnetUserif or alike to allow only vmware.exe to access that endpoint but prevent all other processes from doing the same.