### PR TITLE
Update Simplified Chinese translation

### DIFF
--- a/SandboxiePlus/SandMan/sandman_zh_CN.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_CN.ts
@@ -58,7 +58,7 @@
         <location filename="Windows/NewBoxWindow.cpp" line="30"/>
         <source>New Box</source>
         <translatorcomment>沙盒名称只能包含字母、数字和下划线，不应更改此处！</translatorcomment>
-        <translation type="unfinished">New Box</translation>
+        <translation>New Box</translation>
     </message>
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="38"/>
@@ -358,7 +358,7 @@
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="246"/>
         <source>Boxed Only</source>
-        <translation type="unfinished">仅沙盒内</translation>
+        <translation>仅沙盒内</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="248"/>

--- a/SandboxiePlus/SandMan/sandman_zh_CN.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_CN.ts
@@ -57,7 +57,8 @@
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="30"/>
         <source>New Box</source>
-        <translation>新沙盒</translation>
+        <translatorcomment>沙盒名称只能包含字母、数字和下划线，不应更改此处！</translatorcomment>
+        <translation type="unfinished">New Box</translation>
     </message>
     <message>
         <location filename="Windows/NewBoxWindow.cpp" line="38"/>
@@ -357,7 +358,7 @@
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="246"/>
         <source>Boxed Only</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">仅沙盒内</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAccess.cpp" line="248"/>
@@ -3708,7 +3709,7 @@ The process match level has a higher priority than the specificity and describes
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2169"/>
         <source>Allow use of nested job objects (experimental, works on Windows 8 and later)</source>
-        <translation>允许使用嵌套作业对象 (job object) （实验性；适用于 Windows 8 及更高版本）</translation>
+        <translation>允许使用嵌套作业对象 (job object) （实验性，适用于 Windows 8 及更高版本）</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2032"/>
@@ -3753,7 +3754,7 @@ The process match level has a higher priority than the specificity and describes
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2176"/>
         <source>Disable the use of RpcMgmtSetComTimeout by default (this may resolve compatibility issues)</source>
-        <translation type="unfinished"></translation>
+        <translation>默认禁用 RpcMgmtSetComTimeout (或许可以解决兼容性问题)</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2231"/>


### PR DESCRIPTION
1. Remove the translation of "New Box". (Because "新沙盒" cannot be used as a sandbox name)
2. Translate "Boxed Only" to "仅沙盒内". I'm not sure if a better description of this exists. The behavior of this option is that if the file already exists **in current sandbox**, the program can access it, otherwise not.
***
In addition, it seems that `qt_zh_CN.ts` in the latest release is missing some translations, please make sure the file is correct and up-to-date.

![image](https://user-images.githubusercontent.com/15691402/147517782-0a9a2ee7-d70d-4bbc-ba79-dc64960dc7a4.png)
