### PR TITLE
Minor classic installer fixes

### DIFF
--- a/Sandboxie/install/SandboxieVS.nsi
+++ b/Sandboxie/install/SandboxieVS.nsi
@@ -821,7 +821,7 @@ FunctionEnd
 
 Function DownloadStatPng
 ;
-;	Pop $0	; Get the parameter (file name to download)
+	Pop $0	; Get the parameter (file name to download)
 ;	${If} ${RunningX64}
 ;	SetRegView 64
 ;	${EndIf}

--- a/Sandboxie/install/SandboxieVS.nsi
+++ b/Sandboxie/install/SandboxieVS.nsi
@@ -1091,11 +1091,9 @@ WriteOk:
     ;
     
     StrCmp $BundledInstall "Y" SkipCopyInstaller
-    
-    System::Call 'Kernel32::GetModuleFileNameA(i 0, t .r0, i 1024) i r1'
-    ; $0 --> Installer Filename
-    
-    CopyFiles "$0" "$WINDIR\Installer\${OUTFILE_${_BUILDARCH}}"
+
+    CreateDirectory "$WINDIR\Installer"
+    CopyFiles /SILENT "$EXEPATH" "$WINDIR\Installer\${OUTFILE_${_BUILDARCH}}"
 
 SkipCopyInstaller:
    

--- a/Sandboxie/install/SandboxieVS.nsi
+++ b/Sandboxie/install/SandboxieVS.nsi
@@ -324,14 +324,15 @@ StrCpy $1 "https://www.sandboxie.com/support"
 !else
 	StrCpy $2 "vcredist_x86.exe"
 !endif
-	
-NSISdl::download /TIMEOUT=30000 $1/$2 $TEMP\$2
+
+InitPluginsDir
+inetc::get /SILENT /CONNECTTIMEOUT=5000 /RECEIVETIMEOUT=5000  $1/$2 $PLUGINSDIR\$2 /END
 Pop $R0 ;Get the return value
-  StrCmp $R0 "success" +3
+  StrCmp $R0 "OK" +3
     MessageBox MB_RETRYCANCEL|MB_ICONSTOP "Download failed for: $1/$2.$\nError: $R0.$\nRerun the install when problem corrected." IDRETRY -3
     Quit
 
-ExecWait '"$TEMP\$2" /passive' $0
+ExecWait '"$PLUGINSDIR\$2" /passive' $0
 StrCmp $0 "0" +3
 	MessageBox MB_OK|MB_ICONSTOP "Installation of VCRedist failed: $0.$\nRerun the install when problem corrected."
 	Quit


### PR DESCRIPTION
- No need for System::Call when there is a constant for it.
- Use InetC for downloads.
- Don't use root of %temp% to avoid conflicts and DLL hell.