### PR TITLE
Create get_qttranslations.cmd to get translations files

### DIFF
--- a/Installer/copy_build.cmd
+++ b/Installer/copy_build.cmd
@@ -75,9 +75,9 @@ ECHO Copying SandMan translations
 mkdir %instPath%\translations\
 rem copy /y %~dp0..\SandboxiePlus\SandMan\sandman_*.qm %instPath%\translations\
 copy /y %~dp0..\SandboxiePlus\Build_SandMan_%archPath%\release\sandman_*.qm %instPath%\translations\
-copy /y %qtPath%\translations\qt_*.qm %instPath%\translations\
-copy /y %qtPath%\translations\qtbase_*.qm %instPath%\translations\
-copy /y %qtPath%\translations\qtmultimedia_*.qm %instPath%\translations\
+copy /y %~dp0\qttranslations\qm\qt_*.qm %instPath%\translations\
+copy /y %~dp0\qttranslations\qm\qtbase_*.qm %instPath%\translations\
+copy /y %~dp0\qttranslations\qm\qtmultimedia_*.qm %instPath%\translations\
 copy /y %qtPath%\translations\qtscript_*.qm %instPath%\translations\
 copy /y %qtPath%\translations\qtxmlpatterns_*.qm %instPath%\translations\
 

--- a/Installer/get_qttranslations.cmd
+++ b/Installer/get_qttranslations.cmd
@@ -1,0 +1,8 @@
+mkdir %~dp0qttranslations
+mkdir %~dp0qttranslations\ts
+mkdir %~dp0qttranslations\qm
+set fileName=qttranslations-everywhere-src-6.2.3.zip
+set downloadUrl=https://download.qt.io/archive/qt/6.2/6.2.3/submodules/%filename%
+curl -L %downloadUrl% -o %~dp0qttranslations\%filename%
+"C:\Program Files\7-Zip\7z.exe" e -i!*\translations\qt_*.ts -i!*\translations\qtbase_*.ts -i!*\translations\qtmultimedia_*.ts %~dp0qttranslations\%filename% -o%~dp0qttranslations\ts\
+for %%a in (%~dp0qttranslations\ts\*.ts) do (lrelease.exe -silent %%a -qm %~dp0qttranslations\qm\%%~na.qm)

--- a/Installer/merge_builds.cmd
+++ b/Installer/merge_builds.cmd
@@ -2,6 +2,8 @@
 
 call %~dp0get_openssl.cmd
 
+call %~dp0get_qttranslations.cmd
+
 call %~dp0copy_build.cmd x64
 
 call %~dp0copy_build.cmd x86


### PR DESCRIPTION
Issues: https://github.com/sandboxie-plus/Sandboxie/issues/1528
The translations files in QT 5.15.2 is incomplete, I tried to get them in QT 6.2.3. 
It worked for me, but I didn't (or couldn't) test the translations files for other languages. 