### PR TITLE
Disable Phishing templates in new sandboxes

### DIFF
--- a/Sandboxie/apps/control/AppPage.cpp
+++ b/Sandboxie/apps/control/AppPage.cpp
@@ -1529,8 +1529,8 @@ void CAppPage::UpdateTemplates3(CBox &box,
 void CAppPage::SetDefaultTemplates6(CBox &box)
 {
     box.EnableTemplate(L"AutoRecoverIgnore", TRUE);
-    box.EnableTemplate(L"Firefox_Phishing_DirectAccess", TRUE);
-    box.EnableTemplate(L"Chrome_Phishing_DirectAccess", TRUE);
+    //box.EnableTemplate(L"Firefox_Phishing_DirectAccess", TRUE);
+    //box.EnableTemplate(L"Chrome_Phishing_DirectAccess", TRUE);
     box.EnableTemplate(L"LingerPrograms", TRUE);
     SetDefaultTemplates7(box);
 }

--- a/SandboxiePlus/QSbieAPI/Sandboxie/SandBox.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/SandBox.cpp
@@ -67,8 +67,8 @@ CSandBox::CSandBox(const QString& BoxName, class CSbieAPI* pAPI) : CSbieIni(BoxN
 	{
 		// templates L6
 		InsertText("Template", "AutoRecoverIgnore");
-		InsertText("Template", "Firefox_Phishing_DirectAccess");
-		InsertText("Template", "Chrome_Phishing_DirectAccess");
+		//InsertText("Template", "Firefox_Phishing_DirectAccess");
+		//InsertText("Template", "Chrome_Phishing_DirectAccess");
 		InsertText("Template", "LingerPrograms");
 	}
 


### PR DESCRIPTION
They don't have to be applied automatically, because not everyone has these browsers installed on the system.