### PR TITLE
Update Mozilla paths

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -171,9 +171,9 @@ SpecialImage=browser,PuffinSecureBrowser.exe
 
 SoftwareUpdater=firefox.exe,*\mozilla firefox\updater.exe
 SoftwareUpdater=firefox.exe,*\mozilla firefox\updates\*updater.exe
-SoftwareUpdater=firefox.exe,*\mozilla\updates\*updater.exe
+SoftwareUpdater=firefox.exe,*\mozilla*\updates\*updater.exe
 
-SoftwareUpdater=thunderbird.exe,*\mozilla\updates\*updater.exe
+SoftwareUpdater=thunderbird.exe,*\mozilla*\updates\*updater.exe
 
 SoftwareUpdater=GoogleUpdate.exe,*\google\update\*chrome_installer.exe
 


### PR DESCRIPTION
This PR updates the "Mozilla" directory related to ProgramData for the new versions of Firefox 97.0 and Thunderbird 98.0 that append an ID to that folder.