### PR TITLE
Fix SandMan Settings UI showing inverse of actual value for AutoRunSoftCompat

### DIFF
--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -153,7 +153,7 @@ CSettingsWindow::CSettingsWindow(QWidget *parent)
 	connect(ui.btnDelCompat, SIGNAL(clicked(bool)), this, SLOT(OnDelCompat()));
 	m_CompatLoaded = 0;
 	m_CompatChanged = false;
-	ui.chkNoCompat->setChecked(theConf->GetBool("Options/AutoRunSoftCompat", true));
+	ui.chkNoCompat->setChecked(!theConf->GetBool("Options/AutoRunSoftCompat", true));
 
 	connect(ui.treeCompat, SIGNAL(itemClicked(QTreeWidgetItem*, int)), this, SLOT(OnTemplateClicked(QTreeWidgetItem*, int)));
 


### PR DESCRIPTION
Closes #1678

I am still in the multi-hour QT install so didn't actually test but this is basic enough.   in SandMan UI Settings the option variable was inverted for readability.  For comparability it is still stored the same way.

Setting the value from the ui does this correctly:
`theConf->SetValue("Options/AutoRunSoftCompat", !ui.chkNoCompat->isChecked());`
reading from the UI previously was not inverting the value:
`ui.chkNoCompat->setChecked(theConf->GetBool("Options/AutoRunSoftCompat", true));`

