### PR TITLE
Disable SBIE2193 notification

### DIFF
--- a/Sandboxie/core/dll/proc.c
+++ b/Sandboxie/core/dll/proc.c
@@ -2457,7 +2457,7 @@ _FX BOOLEAN Proc_IsSoftwareUpdateW(const WCHAR *path)
         //SbieApi_Log(2191, SoftName);
         SbieApi_Log(2191, Dll_ImageName);
         SbieApi_Log(2192, NULL);
-        SbieApi_Log(2193, NULL);
+        //SbieApi_Log(2193, NULL);
     }
 
     return IsUpdate;


### PR DESCRIPTION
SBIE2193 notification appears when a program update (inside a sandbox) is blocked by one of the rules specified in BlockSoftwareUpdaters template.

https://github.com/sandboxie-plus/Sandboxie/blob/432fef2b5cad9c3d04f563fc788ae3eb055a621e/Sandboxie/msgs/Sbie-English-1033.txt#L366-L367

Deleting a content sandbox or the sandbox itself is not always required after a program update, so I'm more oriented to disable the following warning than rewriting it.
