### PR TITLE
fix:office ui

### DIFF
--- a/Sandboxie/core/dll/dll.h
+++ b/Sandboxie/core/dll/dll.h
@@ -219,6 +219,7 @@ typedef struct _THREAD_DATA {
 
     BOOL            gui_should_suppress_msgbox;
 
+	BOOL            gui_connecting_desktop;
     //
     // sbieapi:  SbieSvc port handle
     //

--- a/Sandboxie/core/dll/gui.c
+++ b/Sandboxie/core/dll/gui.c
@@ -207,6 +207,10 @@ BOOLEAN Gui_UseProxyService = TRUE;
 
         P_GetOpenFileNameW          __sys_GetOpenFileNameW          = NULL;
 
+		typedef BOOL(*P_ClientThreadSetup)();
+		P_ClientThreadSetup       __sys_ClientThreadSetup = NULL;
+
+		static HMODULE            g_User32_Module = NULL;
 
 //---------------------------------------------------------------------------
 // Functions
@@ -325,6 +329,8 @@ static BOOL Gui_AnimateWindow(HWND hwnd, ULONG time, ULONG flags);
 static DWORD Gui_WaitForInputIdle(HANDLE hProcess, DWORD dwMilliseconds);
 
 static BOOL Gui_AttachThreadInput(DWORD idAttach, DWORD idAttachTo, BOOL fAttach);
+
+static BOOL Gui_ClientThreadSetup();
 
 
 //---------------------------------------------------------------------------
@@ -515,7 +521,11 @@ _FX BOOLEAN Gui_Init(HMODULE module)
     GUI_IMPORT_AW(DdeInitialize)
 
     GUI_IMPORT___(AttachThreadInput);
-
+	g_User32_Module = module;
+	__sys_ClientThreadSetup = (P_ClientThreadSetup)GetProcAddress(module, "ClientThreadSetup");
+	if (__sys_ClientThreadSetup != NULL) {
+		SBIEDLL_HOOK_GUI(ClientThreadSetup);
+	}
     ProcName = NULL;
 
 import_fail:
@@ -833,7 +843,7 @@ _FX BOOLEAN Gui_ConnectToWindowStationAndDesktop(HMODULE User32)
 	if (Dll_CompartmentMode || SbieApi_QueryConfBool(NULL, L"NoSandboxieDesktop", FALSE))
 		return TRUE;
 	// NoSbieDesk END
-
+	THREAD_DATA* TlsData = Dll_GetTlsData(NULL);
     //
     // process is already connected to window station, connect to desktop
     //
@@ -854,7 +864,12 @@ _FX BOOLEAN Gui_ConnectToWindowStationAndDesktop(HMODULE User32)
     {
         return FALSE;
     }
+	if (TlsData->gui_connecting_desktop) {
+		// 避免重入
+		return TRUE;
+	}
 
+	TlsData->gui_connecting_desktop = TRUE;
     //
     // the first win32k service call (i.e. service number >= 0x1000)
     // triggers "thread GUI conversion".  the kernel system service
@@ -1047,7 +1062,7 @@ _FX BOOLEAN Gui_ConnectToWindowStationAndDesktop(HMODULE User32)
             Dll_Free(rpl);
         }
     }
-
+	TlsData->gui_connecting_desktop = FALSE;
     //
     // the first thread, as well as any subsequent new thread, has to
     // explicitly connect to a desktop object by handle, for the same
@@ -2654,4 +2669,9 @@ _FX BOOLEAN ComDlg32_Init(HMODULE hModule)
     //}
 
     return TRUE;
+}
+
+static BOOL Gui_ClientThreadSetup() {
+	Gui_ConnectToWindowStationAndDesktop(g_User32_Module);
+	return __sys_ClientThreadSetup();
 }

--- a/Sandboxie/core/dll/gui.c
+++ b/Sandboxie/core/dll/gui.c
@@ -865,7 +865,7 @@ _FX BOOLEAN Gui_ConnectToWindowStationAndDesktop(HMODULE User32)
         return FALSE;
     }
 	if (TlsData->gui_connecting_desktop) {
-		// 避免重入
+		// avoid re-entry
 		return TRUE;
 	}
 


### PR DESCRIPTION
This commit fix bug of:us office 2016+ version (include 2019),you can see WINWORD.exe process is started,but you can't see the UI of WINWORD.exe.
The reason is when a process is started, but not the main thread load user32.dll,then other threads can't switch to the desktop,so hook ClientStartUp,to make sure every thread can switch to desktop.