### PR TITLE
Fix memory corruption in WFP driver

### DIFF
--- a/Sandboxie/core/drv/wfp.c
+++ b/Sandboxie/core/drv/wfp.c
@@ -670,6 +670,9 @@ BOOLEAN WFP_UpdateProcess(PROCESS* proc)
 	BOOLEAN LogTraffic = FALSE;
 	BOOLEAN BlockInternet = FALSE;
 	LIST NewNetFwRules, OldNetFwRules;
+	
+	List_Init(&NewNetFwRules);
+	List_Init(&OldNetFwRules);
 
 	LogTraffic = Process_GetTraceFlag(proc, L"NetFwTrace") != 0;
 


### PR DESCRIPTION
Linked list was not initialized leading to memory corruption on WFP_FreeRules call iterating through invalid memory address.

Thank you for your contribution to the Sandboxie repository.

In order to reduce the risk of accidental merges, it's highly recommended for beginners to open a new Pull Request in draft state by clicking the button "Create Draft Pull Request", instead of using the default "Create Pull Request" option. 

In addition, you can convert an existing pull request to a draft by clicking the "Convert to draft" link in the right sidebar under "Reviewers".

All new translators are encouraged to look at the "Localization notes and tips" before creating a pull request: https://git.io/J9G19
