### PR TITLE
Minor string changes

### DIFF
--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -57,7 +57,7 @@
            <item row="8" column="1" colspan="2">
             <widget class="QCheckBox" name="chkMonitorSize">
              <property name="text">
-              <string>Count and display the disk space ocupied by each sandbox</string>
+              <string>Count and display the disk space occupied by each sandbox</string>
              </property>
             </widget>
            </item>

--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -409,7 +409,7 @@
            <item row="10" column="2" colspan="2">
             <widget class="QLabel" name="label_11">
              <property name="text">
-              <string>* results may vary depending on the view mode</string>
+              <string>* a partially checked checkbox will leave the behavior to be determined by the view mode.</string>
              </property>
             </widget>
            </item>

--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -409,7 +409,7 @@
            <item row="10" column="2" colspan="2">
             <widget class="QLabel" name="label_11">
              <property name="text">
-              <string>* indetermined means depending on the selected view mode</string>
+              <string>* results may vary depending on the view mode</string>
              </property>
             </widget>
            </item>

--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -409,7 +409,7 @@
            <item row="10" column="2" colspan="2">
             <widget class="QLabel" name="label_11">
              <property name="text">
-              <string>* indetermined means depanding on the view mode</string>
+              <string>* indetermined means depending on the selected view mode</string>
              </property>
             </widget>
            </item>

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -367,7 +367,7 @@ void CSandMan::CreateMenus(bool bAdvanced)
 	if(bAdvanced) {
 		m_pDisableRecovery = m_pMenuFile->addAction(tr("Disable File Recovery"));
 		m_pDisableRecovery->setCheckable(true);
-		m_pDisableMessages = m_pMenuFile->addAction(tr("Disable Message PopUp"));
+		m_pDisableMessages = m_pMenuFile->addAction(tr("Disable Message Popup"));
 		m_pDisableMessages->setCheckable(true);
 	}
 	else {
@@ -485,7 +485,7 @@ void CSandMan::CreateOldMenus()
 		//m_pDisableRecovery = m_pMenuFile->addAction(tr("Disable File Recovery"));
 		//m_pDisableRecovery->setCheckable(true);
 		m_pDisableRecovery = NULL;
-		//m_pDisableMessages = m_pMenuFile->addAction(tr("Disable Message PopUp"));
+		//m_pDisableMessages = m_pMenuFile->addAction(tr("Disable Message Popup"));
 		//m_pDisableMessages->setCheckable(true);	
 		m_pDisableMessages = NULL;
 		m_pMenuFile->addSeparator();

--- a/SandboxiePlus/SandMan/sandman_en.ts
+++ b/SandboxiePlus/SandMan/sandman_en.ts
@@ -4877,7 +4877,7 @@ Please note that this values are currently user specific and saved globally for 
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="60"/>
-        <source>Count and display the disk space ocupied by each sandbox</source>
+        <source>Count and display the disk space occupied by each sandbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_en.ts
+++ b/SandboxiePlus/SandMan/sandman_en.ts
@@ -4897,7 +4897,7 @@ Please note that this values are currently user specific and saved globally for 
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="412"/>
-        <source>* indetermined means depanding depending on the view mode</source>
+        <source>* indetermined means depanding on the view mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_en.ts
+++ b/SandboxiePlus/SandMan/sandman_en.ts
@@ -4897,7 +4897,7 @@ Please note that this values are currently user specific and saved globally for 
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="412"/>
-        <source>* indetermined means depanding on the view mode</source>
+        <source>* indetermined means depending on the selected view mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_en.ts
+++ b/SandboxiePlus/SandMan/sandman_en.ts
@@ -4877,7 +4877,7 @@ Please note that this values are currently user specific and saved globally for 
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="60"/>
-        <source>Count and display the disk space occupied by each sandbox</source>
+        <source>Count and display the disk space ocupied by each sandbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4897,7 +4897,7 @@ Please note that this values are currently user specific and saved globally for 
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="412"/>
-        <source>* results may vary depending on the view mode</source>
+        <source>* indetermined means depanding depending on the view mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_en.ts
+++ b/SandboxiePlus/SandMan/sandman_en.ts
@@ -4897,7 +4897,7 @@ Please note that this values are currently user specific and saved globally for 
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="412"/>
-        <source>* indetermined means depending on the selected view mode</source>
+        <source>* results may vary depending on the view mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Hello! This fixes a minor spelling error under the Sandboxie-Plus settings.

Edit: Perhaps it would be better to not use the word occupied at all. Maybe "used" would be better?