### PR TITLE
Fixed the problem that m_pCleanUpButton UI is displayed empty when NoIcons=1.

### DIFF
--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -698,6 +698,7 @@ void CSandMan::CreateToolBar()
 	//m_pToolBar->addAction(m_pMenuEmptyAll);
 	//m_pToolBar->addSeparator();
 	m_pToolBar->addAction(m_pKeepTerminated);
+	m_pToolBar->addSeparator();
 	//m_pToolBar->addAction(m_pCleanUp);
 
 	m_pCleanUpButton = new QToolButton();

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -703,6 +703,7 @@ void CSandMan::CreateToolBar()
 	m_pCleanUpButton = new QToolButton();
 	m_pCleanUpButton->setIcon(CSandMan::GetIcon("Clean"));
 	m_pCleanUpButton->setToolTip(tr("Cleanup"));
+	m_pCleanUpButton->setText(tr("Cleanup"));
 	m_pCleanUpButton->setPopupMode(QToolButton::MenuButtonPopup);
 	m_pCleanUpButton->setMenu(m_pCleanUpMenu);
 	//QObject::connect(m_pCleanUpButton, SIGNAL(triggered(QAction*)), , SLOT());


### PR DESCRIPTION
Fixed the problem that `m_pCleanUpButton` UI is displayed empty when `NoIcons=1`.
<img width="632" alt="image" src="https://user-images.githubusercontent.com/29057533/192132161-185f3f38-da3d-4649-b33f-5beb7c418023.png">
<img width="617" alt="image" src="https://user-images.githubusercontent.com/29057533/192132194-0b135a19-8ab6-458d-9ba9-97d200378dc5.png">

