### PR TITLE
Add dark title bar support for Windows 11.

### DIFF
--- a/SandboxiePlus/SandMan/SandMan.h
+++ b/SandboxiePlus/SandMan/SandMan.h
@@ -72,6 +72,7 @@ public:
 	bool				CheckCertificate(QWidget* pWidget);
 
 	void				UpdateTheme();
+	void				UpdateTitleTheme(const HWND& hwnd);
 
 	void				UpdateCertState();
 
@@ -221,6 +222,7 @@ private slots:
 	void				OnSysTray(QSystemTrayIcon::ActivationReason Reason);
 
 	void				SetUITheme();
+	void				SetTitleTheme(const HWND& hwnd);
 
 	void				AddLogMessage(const QString& Message);
 	void				AddFileRecovered(const QString& BoxName, const QString& FilePath);


### PR DESCRIPTION
<img width="925" alt="image" src="https://user-images.githubusercontent.com/29057533/194131931-e937dbac-8306-42d7-a6d9-d81fde64137f.png">
<img width="899" alt="image" src="https://user-images.githubusercontent.com/29057533/194132445-6ff9967a-8d45-4e8a-ad77-8ee1f1546ccf.png">
