### PR TITLE
Fixed the display problem of Sandman.

### DIFF
--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -381,10 +381,6 @@ void CSandMan::CreateUI()
 		GetBoxView()->GetTree()->setPalette(pizzaPalete); // QApplication::setPalette(pizzaPalete);
 		GetFileView()->GetTree()->setPalette(pizzaPalete); // QApplication::setPalette(pizzaPalete);
 	}
-	else {
-		GetBoxView()->GetTree()->setPalette(QApplication::palette());
-		GetFileView()->GetTree()->setPalette(QApplication::palette());
-	}
 }
 
 void CSandMan::CreateMaintenanceMenu()


### PR DESCRIPTION
Problem triggered if the system color changes after Sandman starts in a dark color.

![image](https://user-images.githubusercontent.com/29057533/194259689-cf890529-b6a4-489f-92d2-72fc10f65cbe.png)


This issue has existed in multiple past versions.
I think these lines of code are redundant, but it brings up this display error. Please let me know if I've overlooked something.