### PR TITLE
Avoid window overlap when editing templates.

### DIFF
--- a/SandboxiePlus/SandMan/Windows/OptionsTemplates.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsTemplates.cpp
@@ -177,6 +177,8 @@ void COptionsWindow::OnTemplateDoubleClicked(QTreeWidgetItem* pItem, int Column)
 	QSharedPointer<CSbieIni> pTemplate = QSharedPointer<CSbieIni>(new CSbieIni(pItem->data(1, Qt::UserRole).toString(), m_pBox->GetAPI()));
 
 	COptionsWindow OptionsWindow(pTemplate, pItem->text(1));
+	QPoint ParentPos = mapToGlobal(rect().topLeft());
+	OptionsWindow.move(ParentPos.x() + 30, ParentPos.y() + 10);
 	OptionsWindow.exec();
 
 	if(pItem->text(0) == "Local")


### PR DESCRIPTION
When editing a template, the new OptionsWindow obscures the old window, which is not easily noticeable and can be misunderstood.