### PR TITLE
Update for German language

### DIFF
--- a/Sandboxie/msgs/Text-German-1031.txt
+++ b/Sandboxie/msgs/Text-German-1031.txt
@@ -162,6 +162,10 @@ SBIE1301 Der Prozess '%2' wurde außerhalb der Sandbox gestartet
 # SBIE1302 Sandbox '%2' wurde nicht definiert oder aktiviert
 # .
 
+1305;pop;inf;02
+SBIE1305 Blockiert, dass sandgeboxtes Abbild geladen wurde - %2
+.
+
 1306;pop;inf;01
 SBIE1306 Sandboxie-Treiber (SbieDrv) kann jetzt nicht entladen werden
 .
@@ -448,6 +452,10 @@ SBIE2224 Sandgeboxtes Programm ist abgestürzt: %2
 SBIE2225 Es wurde versucht auf eine EFS-Datei zuzugreifen: %2
 .
 
+2226;pop;wrn;01
+SBIE2226 Prozess konnte wegen fehlenden erhöhten Rechten nicht starten; zur Behebung fügen Sie "ApplyElevateCreateProcessFix=y" zu der ini-Sektion für diese Box hinzu %2
+.
+
 #----------------------------------------------------------------------------
 # SbieDrv
 #
@@ -576,6 +584,10 @@ SBIE2336 Fehler im GUI-Server:  %2
 
 2337;pop;err;01
 SBIE2337 Konnte Programm nicht starten:  %2
+.
+
+2338;pop;err;01
+SBIE2338 Nicht unterstützte Architektur in Prozess %2 vorgefunden
 .
 
 #----------------------------------------------------------------------------

--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -5833,7 +5833,7 @@ Bitte beachten Sie, dass diese Werte aktuell nutzerspezifisch sind und global f�
         <location filename="Forms/OptionsWindow.ui" line="3646"/>
         <source>Here you can configure advanced per process options to improve compatibility and/or customize sandboxing behavior.</source>
         <oldsource>Here you can configure advanced per process options to improve compatibility and/or customize sand boxing behavior.</oldsource>
-        <translation type="unfinished">Hier können Sie pro Prozess Optionen konfigurieren, um die Kompatibilität zu verbessern und/oder das Sandboxverhalten zu personalisieren.</translation>
+        <translation>Hier können Sie pro Prozess Optionen konfigurieren, um die Kompatibilität zu verbessern und/oder das Sandboxverhalten zu personalisieren.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="3657"/>


### PR DESCRIPTION
Fresh fork

Sandman_de.ts does not contain anything new, but marks a string as finished, due to the source being changed, without the translation to be affected.

Text-German-1031, contains new strings. No spelling mistakes were found.