### PR TITLE
Remove get_qttranslations.cmd

### DIFF
--- a/Installer/fix_qt5_languages.cmd
+++ b/Installer/fix_qt5_languages.cmd
@@ -1,8 +1,8 @@
 mkdir %~dp0qttranslations
 mkdir %~dp0qttranslations\ts
 mkdir %~dp0qttranslations\qm
-set fileName=qttranslations-everywhere-src-6.2.3.zip
-set downloadUrl=https://download.qt.io/archive/qt/6.2/6.2.3/submodules/%filename%
+set fileName=qttranslations-everywhere-src-6.3.1.zip
+set downloadUrl=https://download.qt.io/archive/qt/6.3/6.3.1/submodules/%filename%
 curl -LsSO --output-dir %~dp0qttranslations\ %downloadUrl%
 "C:\Program Files\7-Zip\7z.exe" e -i!*\translations\qt_*.ts -i!*\translations\qtbase_*.ts -i!*\translations\qtmultimedia_*.ts %~dp0qttranslations\%filename% -bd -o%~dp0qttranslations\ts\
 for %%a in (%~dp0qttranslations\ts\*.ts) do (lrelease.exe -silent %%a -qm %~dp0qttranslations\qm\%%~na.qm)

--- a/Installer/get_qttranslations.cmd
+++ b/Installer/get_qttranslations.cmd
@@ -1,8 +1,0 @@
-mkdir %~dp0qttranslations
-mkdir %~dp0qttranslations\ts
-mkdir %~dp0qttranslations\qm
-set fileName=qttranslations-everywhere-src-6.2.3.zip
-set downloadUrl=https://download.qt.io/archive/qt/6.2/6.2.3/submodules/%filename%
-curl -LsSO --output-dir %~dp0qttranslations\ %downloadUrl%
-"C:\Program Files\7-Zip\7z.exe" e -i!*\translations\qt_*.ts -i!*\translations\qtbase_*.ts -i!*\translations\qtmultimedia_*.ts %~dp0qttranslations\%filename% -bd -o%~dp0qttranslations\ts\
-for %%a in (%~dp0qttranslations\ts\*.ts) do (lrelease.exe -silent %%a -qm %~dp0qttranslations\qm\%%~na.qm)

--- a/Installer/merge_builds.cmd
+++ b/Installer/merge_builds.cmd
@@ -2,7 +2,8 @@
 
 call %~dp0get_openssl.cmd
 
-call %~dp0get_qttranslations.cmd
+REM Moved to main.yml
+REM call %~dp0fix_qt5_languages.cmd
 
 cmd.exe /c %~dp0copy_build.cmd x64
 


### PR DESCRIPTION
It had already been renamed as fix_qt5_languages.cmd.

c.c. @DevSplash (original author of #1605)