### PR TITLE
Request to cancel a security workaround for VMnet0

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -209,8 +209,7 @@ ClosedClsid={470C0EBD-5D73-4D58-9CED-E91E22E23282}
 
 [Template_ThirdPartyIsolation]
 # close VMNet0 virtual network
-ClosedFilePath=\Device\VMnetUserif
-
+# ClosedFilePath=\Device\VMnetUserif
 
 #
 # Internet Explorer


### PR DESCRIPTION
Canceled close VMNet0 virtual network, because most users don't need it. In fact, I have to edit it manually after update sandboxie everytime to reenable it. 