### PR TITLE
Fixes LibreWolf's addons not being included in the template

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -76,6 +76,7 @@ Tmpl.Waterfox=%AppData%\Waterfox\Profiles\*
 Tmpl.PaleMoon=%AppData%\Moonchild Productions\Pale Moon\Profiles\*
 Tmpl.SeaMonkey=%AppData%\Mozilla\SeaMonkey\Profiles\*
 Tmpl.LibreWolf=%AppData%\LibreWolf\Profiles\*
+Tmpl.LibreWolf_Extensions=%AppData%\LibreWolf\Extensions\*
 
 # Firefox-based addon path
 Tmpl.Zotero=%Tmpl.Firefox%\zotero
@@ -506,7 +507,7 @@ OpenFilePath=librewolf.exe,%Local AppData%\LibreWolf\Profiles\*\safebrowsing*
 Tmpl.Title=#4338,LibreWolf
 Tmpl.Class=WebBrowser
 OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\*
-OpenFilePath=librewolf.exe,%AppData%\librewolf*
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf_Extensions%\*
 
 #
 # Firefox Add-ons

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -75,8 +75,7 @@ Tmpl.Firefox=%AppData%\Mozilla\Firefox\Profiles\*
 Tmpl.Waterfox=%AppData%\Waterfox\Profiles\*
 Tmpl.PaleMoon=%AppData%\Moonchild Productions\Pale Moon\Profiles\*
 Tmpl.SeaMonkey=%AppData%\Mozilla\SeaMonkey\Profiles\*
-Tmpl.LibreWolf=%AppData%\LibreWolf\Profiles\*
-Tmpl.LibreWolf_Extensions=%AppData%\LibreWolf\Extensions\*
+Tmpl.LibreWolf=%AppData%\LibreWolf\*
 
 # Firefox-based addon path
 Tmpl.Zotero=%Tmpl.Firefox%\zotero
@@ -477,37 +476,36 @@ ForceProcess=librewolf.exe
 [Template_LibreWolf_Bookmarks_DirectAccess]
 Tmpl.Title=#4336,LibreWolf
 Tmpl.Class=WebBrowser
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\bookmark*
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\places*
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\favicons.sqlite
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\bookmark*
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\places*
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\favicons.sqlite
 
 [Template_LibreWolf_Cookies_DirectAccess]
 Tmpl.Title=#4328,LibreWolf
 Tmpl.Class=WebBrowser
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\cookies*
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\cookies*
 
 [Template_LibreWolf_Passwords_DirectAccess]
 Tmpl.Title=#4331,LibreWolf
 Tmpl.Class=WebBrowser
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\logins.json
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\key*.db
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\logins.json
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\key*.db
 
 [Template_LibreWolf_Session_DirectAccess]
 Tmpl.Title=#4340,LibreWolf
 Tmpl.Class=WebBrowser
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\sessionstore.js*
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\sessionstore.js*
 
 [Template_LibreWolf_Phishing_DirectAccess]
 Tmpl.Title=#4337,LibreWolf
 Tmpl.Class=WebBrowser
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\cert9.db
+OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\Profiles\*\cert9.db
 OpenFilePath=librewolf.exe,%Local AppData%\LibreWolf\Profiles\*\safebrowsing*
 
 [Template_LibreWolf_Profile_DirectAccess]
 Tmpl.Title=#4338,LibreWolf
 Tmpl.Class=WebBrowser
 OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\*
-OpenFilePath=librewolf.exe,%Tmpl.LibreWolf_Extensions%\*
 
 #
 # Firefox Add-ons

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -506,6 +506,7 @@ OpenFilePath=librewolf.exe,%Local AppData%\LibreWolf\Profiles\*\safebrowsing*
 Tmpl.Title=#4338,LibreWolf
 Tmpl.Class=WebBrowser
 OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\*
+OpenFilePath=librewolf.exe,%AppData%\librewolf*
 
 #
 # Firefox Add-ons


### PR DESCRIPTION
For whatever reason LibreWolf stores some of its addon data in the AppData Roaming folder, instead of storing it all in the Local AppData folder like Firefox does.

The end result? Even with access to "the entire profile folder" your addons are stored in the sandbox rather than outside of it.

This fixes that, so that LibreWolf users can once again enable "Auto delete content when last sandboxed process terminates" without having to reinstall all their addons afterwards.