### PR TITLE
Spelling fixes

### DIFF
--- a/SandboxiePlus/MiscHelpers/Common/Xml.cpp
+++ b/SandboxiePlus/MiscHelpers/Common/Xml.cpp
@@ -221,7 +221,7 @@ bool CXml::Parse(QString &Name, QVariant &Variant, QXmlStreamReader &xml, bool b
 
 /* SQVariants provides a lookup list of all known QVariant types for to/from string conversion
 *
-*	Note: All commented out types dont have native to string converion 
+*	Note: All commented out types don't have native to string conversion 
 *			If there is a need to use them a manual conversion must be implemented in CXml
 */
 struct SQVariants{
@@ -236,10 +236,10 @@ struct SQVariants{
 		Map.insert("ULongLong"	, QVariant::ULongLong);
 		Map.insert("Double"		, QVariant::Double);
 		Map.insert("Char"		, QVariant::Char);
-		Map.insert("Map"		, QVariant::Map);	// conainter type
-		Map.insert("List"		, QVariant::List);	// conainter type
+		Map.insert("Map"		, QVariant::Map);	// container type
+		Map.insert("List"		, QVariant::List);	// container type
 		Map.insert("String"		, QVariant::String);
-		Map.insert("StringList"	, QVariant::StringList);	// conainter type
+		Map.insert("StringList"	, QVariant::StringList);	// container type
 		Map.insert("ByteArray"	, QVariant::ByteArray);
 		//Map.insert("BitArray"	, QVariant::BitArray);
 		Map.insert("Date"		, QVariant::Date);

--- a/SandboxiePlus/QtSingleApp/INSTALL.TXT
+++ b/SandboxiePlus/QtSingleApp/INSTALL.TXT
@@ -239,7 +239,7 @@ Using the component as a DLL
 Uninstalling
 ------------
 
-    The following command will remove any fils that have been
+    The following command will remove any files that have been
     automatically placed outside the package directory itself during
     installation and building
 

--- a/SandboxiePlus/QtSingleApp/README.TXT
+++ b/SandboxiePlus/QtSingleApp/README.TXT
@@ -25,7 +25,7 @@ Version history:
 
 2.6: - - initialize() is now obsolete, no longer necessary to call
      it
-     - - Fixed race condition where multiple instances migth be started
+     - - Fixed race condition where multiple instances might be started
      - - QtSingleCoreApplication variant provided for non-GUI (console)
      usage
      - Complete reimplementation. Visible changes:

--- a/SandboxiePlus/QtSingleApp/src/qtlockedfile.cpp
+++ b/SandboxiePlus/QtSingleApp/src/qtlockedfile.cpp
@@ -158,8 +158,8 @@ QtLockedFile::LockMode QtLockedFile::lockMode() const
     can be locked.
 
     If \a block is true, this function will block until the lock is
-    aquired. If \a block is false, this function returns \e false
-    immediately if the lock cannot be aquired.
+    acquired. If \a block is false, this function returns \e false
+    immediately if the lock cannot be acquired.
 
     If this object already has a lock of type \a mode, this function
     returns \e true immediately. If this object has a lock of a


### PR DESCRIPTION
Fresh fork to fix some spelling mistakes found by codespell. 

`endcode` in SandboxiePlus/QtSingleApp/src/qtsingleapplication.cpp#L120 is supposed to be endcode, so it was not changed.