### PR TITLE
Improve removal of leftovers

### DIFF
--- a/Installer/Sandboxie-Plus.iss
+++ b/Installer/Sandboxie-Plus.iss
@@ -83,6 +83,7 @@ Type: files; Name: "{app}\translations\sandman_pt.qm"
 Type: files; Name: "{app}\translations\sandman_ua.qm"
 Type: files; Name: "{app}\SbieDrv.sys.w10"
 Type: files; Name: "{app}\SbieDrv.sys.rc4"
+Type: files; Name: "{app}\SbieIni.exe.sig"
 
 
 [Registry]

--- a/Sandboxie/install/SandboxieVS.nsi
+++ b/Sandboxie/install/SandboxieVS.nsi
@@ -43,8 +43,8 @@ SetCompressor /SOLID /FINAL lzma
 ;    !define _W7DRV_COMPAT "$%SbieVer%.x86"
 ;!endif
 
-;!define SBIEDRV_SYS4    "${SBIEDRV_SYS}.rc4"
-;!define SBIEDRV_SYSX    "${SBIEDRV_SYS}.w10"
+!define SBIEDRV_SYS4    "${SBIEDRV_SYS}.rc4" ; to clean up afterwards
+!define SBIEDRV_SYSX    "${SBIEDRV_SYS}.w10" ; to clean up afterwards
 
 !define OUTFILE_BOTH    "${PRODUCT_NAME}Install.exe"
 !define NAME_Win32      "${PRODUCT_FULL_NAME} ${VERSION} (32-bit)"
@@ -1044,7 +1044,7 @@ WriteLoop:
 
     File /oname=${START_EXE} "${BIN_ROOT}\Start.exe"
     File /oname=${START_EXE}.sig "${BIN_ROOT}\Start.exe.sig"
-    
+
     File /oname=${SBIECTRL_EXE} "${BIN_ROOT}\SbieCtrl.exe"
     File /oname=${SBIECTRL_EXE}.sig "${BIN_ROOT}\SbieCtrl.exe.sig"
 
@@ -1108,6 +1108,9 @@ SkipCopyInstaller:
 
     Delete "$DESKTOP\${PRODUCT_NAME} Quick Launch.lnk"
     Delete "$QUICKLAUNCH\${PRODUCT_NAME} Quick Launch.lnk"
+    Delete "$INSTDIR\${SBIEDRV_SYS4}"
+    Delete "$INSTDIR\${SBIEDRV_SYSX}"
+    Delete "$INSTDIR\${SBIEINI_EXE}.sig"
 
 FunctionEnd
 
@@ -1139,8 +1142,8 @@ Function DeleteProgramFiles
     Delete "$INSTDIR\${SBIEMSG_DLL}"
 
     Delete "$INSTDIR\${SBIEDRV_SYS}"
-;    Delete "$INSTDIR\${SBIEDRV_SYS4}"
-;    Delete "$INSTDIR\${SBIEDRV_SYSX}"
+    Delete "$INSTDIR\${SBIEDRV_SYS4}" ; leftover
+    Delete "$INSTDIR\${SBIEDRV_SYSX}" ; leftover
 
     Delete "$INSTDIR\KmdUtil.exe"
 
@@ -1168,6 +1171,7 @@ Function DeleteProgramFiles
     Delete "$INSTDIR\Manifest2.txt"
 
     Delete "$INSTDIR\${SBIEINI_EXE}"
+    Delete "$INSTDIR\${SBIEINI_EXE}.sig" ; leftover
 
     Delete "$INSTDIR\LICENSE.EXE"
 

--- a/Sandboxie/install/SandboxieVS.nsi
+++ b/Sandboxie/install/SandboxieVS.nsi
@@ -43,8 +43,8 @@ SetCompressor /SOLID /FINAL lzma
 ;    !define _W7DRV_COMPAT "$%SbieVer%.x86"
 ;!endif
 
-!define SBIEDRV_SYS4    "${SBIEDRV_SYS}.rc4" ; to clean up afterwards
-!define SBIEDRV_SYSX    "${SBIEDRV_SYS}.w10" ; to clean up afterwards
+;!define SBIEDRV_SYS4    "${SBIEDRV_SYS}.rc4"
+;!define SBIEDRV_SYSX    "${SBIEDRV_SYS}.w10"
 
 !define OUTFILE_BOTH    "${PRODUCT_NAME}Install.exe"
 !define NAME_Win32      "${PRODUCT_FULL_NAME} ${VERSION} (32-bit)"
@@ -1108,8 +1108,8 @@ SkipCopyInstaller:
 
     Delete "$DESKTOP\${PRODUCT_NAME} Quick Launch.lnk"
     Delete "$QUICKLAUNCH\${PRODUCT_NAME} Quick Launch.lnk"
-    Delete "$INSTDIR\${SBIEDRV_SYS4}"
-    Delete "$INSTDIR\${SBIEDRV_SYSX}"
+    Delete "$INSTDIR\${SBIEDRV_SYS}.rc4"
+    Delete "$INSTDIR\${SBIEDRV_SYS}.w10"
     Delete "$INSTDIR\${SBIEINI_EXE}.sig"
 
 FunctionEnd
@@ -1142,8 +1142,8 @@ Function DeleteProgramFiles
     Delete "$INSTDIR\${SBIEMSG_DLL}"
 
     Delete "$INSTDIR\${SBIEDRV_SYS}"
-    Delete "$INSTDIR\${SBIEDRV_SYS4}" ; leftover
-    Delete "$INSTDIR\${SBIEDRV_SYSX}" ; leftover
+    Delete "$INSTDIR\${SBIEDRV_SYS}.rc4" ; leftover
+    Delete "$INSTDIR\${SBIEDRV_SYS}.w10" ; leftover
 
     Delete "$INSTDIR\KmdUtil.exe"
 


### PR DESCRIPTION
- added the removal of `SbieIni.exe.sig` - this is a leftover coming from v0.8.8 / 5.50.8: https://github.com/sandboxie-plus/Sandboxie/issues/1003
- added the cleanup of `SbieDrv.sys.w10` + `SbieDrv.sys.rc4` in the Classic installer, because the Sandboxie Plus installer already removes both at install time.

Any help to test this PR would be appreciated.