### PR TITLE
Spelling fixes

### DIFF
--- a/SandboxiePlus/MiscHelpers/Archive/ArchiveInterface.cpp
+++ b/SandboxiePlus/MiscHelpers/Archive/ArchiveInterface.cpp
@@ -131,7 +131,7 @@ bool CArchiveInterface::Init()
 		return false;
 	}
 
-	//LogLine(LOG_SUCCESS | LOG_DEBUG, QObject::tr("7z: Loaded Successfuly"));
+	//LogLine(LOG_SUCCESS | LOG_DEBUG, QObject::tr("7z: Loaded Successfully"));
 	m_Operational = true;
 	return true;
 }

--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -5430,7 +5430,7 @@ an Stelle von &quot;*&quot;.</translation>
         <source>Configure which processes can access NT IPC objects like ALPC ports and other processes memory and context.
 To specify a process use &apos;$:program.exe&apos; as path.</source>
         <translation>Konfiguriere welche Prozesse Zugriff auf NT IPC Objekte haben, wie ALPC-Ports und anderen Prozessspeicher und Kontext.
-Um eine Prozess anzugeben verwenden Sie &apos;$:program.exe&apos; als Pfad.</translation>
+Um einen Prozess anzugeben verwenden Sie &apos;$:program.exe&apos; als Pfad.</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="2212"/>


### PR DESCRIPTION
This is a fresh fork to fix a grammatical error and one spelling mistake found in ArchiveInterface, by codespell.

(Due to me being unable to tell if 'writen' could be changed to 'written' without breaking the code, I did not attempt to change the other files, reported by codespell. I was also unable to tell if 'Characts' was a desired spelling, which I guess to be the case, since the property name is the same.)