### PR TITLE
Update lupdate.yml

### DIFF
--- a/.github/workflows/lupdate.yml
+++ b/.github/workflows/lupdate.yml
@@ -11,14 +11,14 @@ jobs:
     name: SBIE Plus lupdate
     # Skip the job on forks
     if: (github.event_name == 'schedule' && github.repository_owner == 'sandboxie-plus') || (github.event_name != 'schedule')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-      - name: Install qt6-base-dev
+      - name: Install Qt 5 packages
         shell: bash
         run: |
-          sudo apt-get install --no-install-recommends qt6-base-dev
+          sudo apt-get install --no-install-recommends qtbase5-dev qttools5-dev-tools
 
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This will restore Qt 5 packages again in order to fix the previous commit ad93dd2 in a proper way.
See also: https://bugs.launchpad.net/ubuntu/+source/qtchooser/+bug/1964763

![could not find a Qt installation](https://user-images.githubusercontent.com/12372772/203833559-5c71c911-62b8-4b23-b7e2-28c9861956be.png)
https://github.com/sandboxie-plus/Sandboxie/actions/runs/3536961025/jobs/5936504990#step:4:8
`lupdate: could not find a Qt installation of ''`