### PR TITLE
Add translations folder to deprecated

### DIFF
--- a/Installer/Sandboxie-Plus.iss
+++ b/Installer/Sandboxie-Plus.iss
@@ -78,10 +78,7 @@ Filename: "{app}\{#MyAppName}.ini"; Section: "Options"; Key: "UiLanguage"; Strin
 
 [InstallDelete]
 ; Remove deprecated files at install time.
-Type: files; Name: "{app}\translations\sandman_zh-CN.qm"
-Type: files; Name: "{app}\translations\sandman_zh-TW.qm"
-Type: files; Name: "{app}\translations\sandman_pt.qm"
-Type: files; Name: "{app}\translations\sandman_ua.qm"
+Type: filesandordirs; Name: "{app}\translations"
 Type: files; Name: "{app}\SbieDrv.sys.w10"
 Type: files; Name: "{app}\SbieDrv.sys.rc4"
 Type: files; Name: "{app}\SbieIni.exe.sig"


### PR DESCRIPTION
As I understand it, in version 1.6, translations are loaded from the `translations.7z` archive. And the `translations` folder is no longer needed. In any case, its removal did not cause me any problems.

Fix suggested by @isaak654.