### PR TITLE
Add Contribution entries in Help menu

### DIFF
--- a/Sandboxie/apps/control/MyFrame.cpp
+++ b/Sandboxie/apps/control/MyFrame.cpp
@@ -139,11 +139,12 @@ BEGIN_MESSAGE_MAP(CMyFrame, CFrameWnd)
     ON_COMMAND(ID_CONF_EDIT,                    OnCmdConfEdit)
     ON_COMMAND(ID_CONF_RELOAD,                  OnCmdConfReload)
 
-	ON_COMMAND(ID_HELP_SUPPORT,                 OnCmdHelpSupport)
+    ON_COMMAND(ID_HELP_SUPPORT,                 OnCmdHelpSupport)
+    ON_COMMAND(ID_HELP_CONTRIBUTION,            OnCmdHelpContribution)
     ON_COMMAND(ID_HELP_TOPICS,                  OnCmdHelpTopics)
     ON_COMMAND(ID_HELP_TUTORIAL,                OnCmdHelpTutorial)
     ON_COMMAND(ID_HELP_FORUM,                   OnCmdHelpForum)
-	ON_COMMAND(ID_HELP_UPDATE,                  OnCmdHelpUpdate)
+    ON_COMMAND(ID_HELP_UPDATE,                  OnCmdHelpUpdate)
     ON_COMMAND(ID_HELP_UPGRADE,                 OnCmdHelpUpgrade)
     ON_COMMAND(ID_HELP_MIGRATION,               OnCmdHelpMigrate)
     ON_COMMAND(ID_HELP_ABOUT,                   OnCmdHelpAbout)
@@ -994,6 +995,15 @@ void CMyFrame::OnCmdHelpSupport()
 	CRunBrowser x(this, L"https://sandboxie-plus.com/go.php?to=donate");
 }
 
+//---------------------------------------------------------------------------
+// OnCmdHelpContribution
+//---------------------------------------------------------------------------
+
+
+void CMyFrame::OnCmdHelpContribution()
+{
+	CRunBrowser x(this, L"https://sandboxie-plus.com/go.php?to=sbie-contribute");
+}
 
 //---------------------------------------------------------------------------
 // OnCmdHelpTopics
@@ -1004,7 +1014,6 @@ void CMyFrame::OnCmdHelpTopics()
 {
     CRunBrowser::OpenHelp(this, L"HelpTopics");
 }
-
 
 //---------------------------------------------------------------------------
 // OnCmdHelpTutorial

--- a/Sandboxie/apps/control/MyFrame.h
+++ b/Sandboxie/apps/control/MyFrame.h
@@ -119,11 +119,12 @@ class CMyFrame : public CFrameWnd
     afx_msg void OnCmdConfLock();
     afx_msg void OnCmdConfEdit();
     afx_msg void OnCmdConfReload();
-	afx_msg void OnCmdHelpSupport();
+    afx_msg void OnCmdHelpSupport();
+    afx_msg void OnCmdHelpContribution();
     afx_msg void OnCmdHelpTopics();
     afx_msg void OnCmdHelpTutorial();
     afx_msg void OnCmdHelpForum();
-	afx_msg void OnCmdHelpUpdate();
+    afx_msg void OnCmdHelpUpdate();
     afx_msg void OnCmdHelpUpgrade();
     afx_msg void OnCmdHelpMigrate();
     afx_msg void OnCmdHelpAbout();

--- a/Sandboxie/apps/control/SbieControl.rc
+++ b/Sandboxie/apps/control/SbieControl.rc
@@ -124,6 +124,7 @@ BEGIN
     POPUP "3451"
     BEGIN
         MENUITEM "3504",                        ID_HELP_SUPPORT
+        MENUITEM "3505",                        ID_HELP_CONTRIBUTION
         MENUITEM SEPARATOR
         MENUITEM "3452",                        ID_HELP_TOPICS
         MENUITEM "3453",                        ID_HELP_TUTORIAL

--- a/Sandboxie/apps/control/resource.h
+++ b/Sandboxie/apps/control/resource.h
@@ -54,6 +54,7 @@
 #define ID_HELP_UPDATE                  40044
 #define ID_HELP_UPGRADE                 40046
 #define ID_HELP_MIGRATION               40047
+#define ID_HELP_CONTRIBUTION            40048
 #define ID_HELP_ABOUT                   40045
 #define ID_PROCESS_TERMINATE            40051
 #define ID_PROCESS_SETTINGS             40052

--- a/Sandboxie/msgs/Sbie-English-1033.txt
+++ b/Sandboxie/msgs/Sbie-English-1033.txt
@@ -1240,7 +1240,11 @@ Re&load Configuration
 .
 
 3504;txt;01
-&Support Sandboxie
+&Support Sandboxie with Donations
+.
+
+3505;txt;01
+Contribute to Sandboxie
 .
 
 3451;txt;01

--- a/Sandboxie/msgs/Text-Italian-1040.txt
+++ b/Sandboxie/msgs/Text-Italian-1040.txt
@@ -1374,7 +1374,11 @@ Crea collegamento sul desktop
 .
 
 3504;txt;01
-&Supporta Sandboxie
+&Sostieni Sandboxie con le donazioni
+.
+
+3505;txt;01
+Come contribuire al progetto
 .
 
 #----------------------------------------------------------------------------

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -435,13 +435,14 @@ void CSandMan::CreateHelpMenu(bool bAdvanced)
 {
 	m_pMenuHelp = m_pMenuBar->addMenu(tr("&Help"));
 		//m_pMenuHelp->addAction(tr("Support Sandboxie-Plus on Patreon"), this, SLOT(OnHelp()));
-		m_pSupport = m_pMenuHelp->addAction(tr("Support Sandboxie-Plus with a Donation"), this, SLOT(OnHelp()));
+		m_pSupport = m_pMenuHelp->addAction(tr("Support Sandboxie-Plus with Donations"), this, SLOT(OnHelp()));
 		//if (!bAdvanced) {
 		//	m_pMenuHelp->removeAction(m_pSupport);
 		//	m_pMenuBar->addAction(m_pSupport);
 		//}
-		m_pForum = m_pMenuHelp->addAction(tr("Visit Support Forum"), this, SLOT(OnHelp()));
+		m_pContribution = m_pMenuHelp->addAction(tr("Contribute to Sandboxie-Plus"), this, SLOT(OnHelp()));
 		m_pManual = m_pMenuHelp->addAction(tr("Online Documentation"), this, SLOT(OnHelp()));
+		m_pForum = m_pMenuHelp->addAction(tr("Visit Support Forum"), this, SLOT(OnHelp()));
 		m_pMenuHelp->addSeparator();
 		m_pUpdate = m_pMenuHelp->addAction(tr("Check for Updates"), this, SLOT(CheckForUpdates()));
 		m_pMenuHelp->addSeparator();
@@ -3115,10 +3116,12 @@ void CSandMan::OnHelp()
 {
 	if (sender() == m_pSupport)
 		QDesktopServices::openUrl(QUrl("https://sandboxie-plus.com/go.php?to=donate"));
-	else if (sender() == m_pForum)
-		QDesktopServices::openUrl(QUrl("https://sandboxie-plus.com/go.php?to=sbie-forum"));
+	else if (sender() == m_pContribution)
+		QDesktopServices::openUrl(QUrl("https://sandboxie-plus.com/go.php?to=sbie-contribute"));
 	else if (sender() == m_pManual)
 		QDesktopServices::openUrl(QUrl("https://sandboxie-plus.com/go.php?to=sbie-docs"));
+	else if (sender() == m_pForum)
+		QDesktopServices::openUrl(QUrl("https://sandboxie-plus.com/go.php?to=sbie-forum"));
 	else
 		QDesktopServices::openUrl(QUrl("https://sandboxie-plus.com/go.php?to=patreon"));
 }

--- a/SandboxiePlus/SandMan/SandMan.h
+++ b/SandboxiePlus/SandMan/SandMan.h
@@ -338,6 +338,7 @@ private:
 
 	QMenu*				m_pMenuHelp;
 	QAction*			m_pSupport;
+	QAction*			m_pContribution;
 	QAction*			m_pForum;
 	QAction*			m_pManual;
 	QAction*			m_pUpdate;


### PR DESCRIPTION
There is no explicit reference in the user interface about the contributor certificates, so let's put a contribution entry for both Plus and Classic UIs in the Help menu.

Plus UI help menu without a certificate applied:
![Plus_help_no_cert](https://user-images.githubusercontent.com/12372772/209469517-de5b4d51-095d-4097-a3ac-72d15393250b.png)

Plus UI help menu with a certificate applied:
![Plus_help_cert](https://user-images.githubusercontent.com/12372772/209469520-e9da69e0-77f8-49cf-b9ac-a9bf79ed78d9.png)

Classic UI help menu:
![Classic_help](https://user-images.githubusercontent.com/12372772/209469539-863110cd-770b-425b-a67e-42e4b47555bd.png)
