### PR TITLE
Fixed issue with shortcuts

### DIFF
--- a/SandboxiePlus/SandMan/BoxMonitor.cpp
+++ b/SandboxiePlus/SandMan/BoxMonitor.cpp
@@ -26,10 +26,17 @@ quint64 CBoxMonitor::CounDirSize(const QString& Directory, SBox* Box)
 		return TotalSize;
 
 	QDir Dir(Directory);
-	foreach(const QFileInfo & Info, Dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot))
+	foreach(const QFileInfo & Info, Dir.entryInfoList(QDir::Files | QDir::Dirs | QDir::Hidden | QDir::System | QDir::NoDotAndDotDot))
 	{
 		if (Info.isDir())
 			TotalSize += CounDirSize(Info.filePath(), Box);
+		else if (Info.isShortcut())
+		{
+			QFile File(Info.filePath());
+			if (File.open(QFile::ReadOnly))
+				TotalSize += File.size();
+			File.close();
+		}
 		else
 			TotalSize += QFile(Info.filePath()).size();
 	}

--- a/SandboxiePlus/SandMan/SbiePlusAPI.cpp
+++ b/SandboxiePlus/SandMan/SbiePlusAPI.cpp
@@ -166,6 +166,19 @@ public:
 		return QFile::open(flags);
 	}
 
+	qint64 size() const override
+	{
+		qint64 Size = QFile::size();
+		if (QFileInfo(fileName()).isShortcut())
+		{
+			QFile File(fileName());
+			if (File.open(QFile::ReadOnly))
+				Size = File.size();
+			File.close();
+		}
+		return Size;
+	}
+
 protected:
 	CSbieProgressPtr m_pProgress;
 	CArchive* m_pArchive;


### PR DESCRIPTION
- [x] Fixed issue where shortcut size was counted as actual file size.

https://user-images.githubusercontent.com/29057533/211897636-f9325d74-afb0-4874-b07f-a3e33768d030.mp4



- [x] The file size of the hidden directory shortcuts will now be counted.
- [x] fixed #2585