### PR TITLE
Update sandman_de.ts

### DIFF
--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -642,12 +642,12 @@ Notiz: Die Updateprüfung ist oft zeitversetzt zu den letzten GitHub-Veröffentl
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="159"/>
         <source>Version 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Version 1</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="160"/>
         <source>Version 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Version 2</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="195"/>
@@ -677,19 +677,19 @@ Notiz: Die Updateprüfung ist oft zeitversetzt zu den letzten GitHub-Veröffentl
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="286"/>
         <source>Indeterminate</source>
-        <translation type="unfinished"></translation>
+        <translation>unbestimmt</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="458"/>
         <location filename="Windows/OptionsGeneral.cpp" line="558"/>
         <source>Always copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Immer kopieren</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="459"/>
         <location filename="Windows/OptionsGeneral.cpp" line="559"/>
         <source>Don&apos;t copy</source>
-        <translation type="unfinished"></translation>
+        <translation>Nicht kopieren</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="460"/>

--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -677,7 +677,7 @@ Notiz: Die Updateprüfung ist oft zeitversetzt zu den letzten GitHub-Veröffentl
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="286"/>
         <source>Indeterminate</source>
-        <translation>unbestimmt</translation>
+        <translation>Unbestimmt</translation>
     </message>
     <message>
         <location filename="Windows/OptionsGeneral.cpp" line="458"/>


### PR DESCRIPTION
Another fresh fork to provide the translations for newly added strings. There are two commits as I went back to change the translation to have it reflect the uppercase start.

One string was not translated, as I was not sure, what `Copy empty` was supposed to mean. Since the original is as good as a faulty translation, I did not touch it, yet. My guess had been that it is an empty copy, which could be "Leerkopie", but that does not seem to fit the rest, where there is an option to always copy or never copy, so that I assume that it should be a verb, expressing what Sandboxie will do.