### PR TITLE
Fix: Autorun long path's over 130 characters (including NUL character) not currently supported

### DIFF
--- a/SandboxiePlus/SandMan/Helpers/WinAdmin.cpp
+++ b/SandboxiePlus/SandMan/Helpers/WinAdmin.cpp
@@ -110,6 +110,8 @@ bool IsAdminUser(bool OnlyFull)
 
 #define AUTO_RUN_KEY_NAME APP_NAME L"_AutoRun"
 
+constexpr size_t MAX_PATH_EX = 32767; // Long file path max length, in character's
+
 bool IsAutorunEnabled()
 {
 	bool result = false;
@@ -117,8 +119,8 @@ bool IsAutorunEnabled()
 	HKEY hkey = nullptr;
 	if (RegOpenKeyEx (HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_ALL_ACCESS, &hkey) == ERROR_SUCCESS)
 	{
-		WCHAR buffer[MAX_PATH] = {0};
-		DWORD size = _countof (buffer);
+		WCHAR buffer[MAX_PATH_EX] {0};
+		DWORD size = sizeof (buffer);
 
 		if (RegQueryValueEx (hkey, AUTO_RUN_KEY_NAME, nullptr, nullptr, (LPBYTE)buffer, &size) == ERROR_SUCCESS)
 		{
@@ -140,7 +142,7 @@ bool AutorunEnable (bool is_enable)
 	{
 		if (is_enable)
 		{
-			wchar_t szPath[MAX_PATH];
+			wchar_t szPath[MAX_PATH_EX] {0};
 			if (GetModuleFileName(NULL, szPath, ARRAYSIZE(szPath)))
 			{
 				std::wstring path = L"\"" + std::wstring(szPath) + L"\" -autorun";


### PR DESCRIPTION
This is a simple patch to add support for auto-run paths up to 32767 WCHAR's (including NUL character).

It also fixes the bug where _countof() was used instead of sizeof(), since RegQueryValueEx() expects the buffer size to be specified in bytes, not WCHAR's. Changing this on it's own would've increased max path length to 260 WCHAR's.

It's only for Sandboxie-Plus, but I plan on doing more comprehensive patch for everywhere MAX_PATH is currently used.

I have another patch which determine's required buffer size before-hand and only allocate's what's needed on the heap, but thought I'd keep it simple for starter's.