### PR TITLE
Fix: Autorun long path's over 130 characters (including NUL character) not supported.

### DIFF
--- a/SandboxiePlus/SandMan/Helpers/WinAdmin.cpp
+++ b/SandboxiePlus/SandMan/Helpers/WinAdmin.cpp
@@ -115,14 +115,20 @@ bool IsAutorunEnabled()
 	bool result = false;
 
 	HKEY hkey = nullptr;
-	if (RegOpenKeyEx (HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_ALL_ACCESS, &hkey) == ERROR_SUCCESS)
+	if (ERROR_SUCCESS == RegOpenKeyEx (HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_ALL_ACCESS, &hkey))
 	{
-		WCHAR buffer[MAX_PATH] = {0};
-		DWORD size = _countof (buffer);
-
-		if (RegQueryValueEx (hkey, AUTO_RUN_KEY_NAME, nullptr, nullptr, (LPBYTE)buffer, &size) == ERROR_SUCCESS)
+		// First, determine the required buffer size, including NUL terminator (in bytes). RegGetValue() alway's adds
+		// an extra NULL terminator to size, even if one already exists, in case the stored value doesn't have one.
+		DWORD size {0};
+		if (ERROR_SUCCESS == RegGetValue(hkey, nullptr, AUTO_RUN_KEY_NAME, RRF_RT_REG_SZ, nullptr, nullptr, &size))
 		{
-			result = true; // todo: check path
+			// Then, allocate the buffer (in WCHARs) and retrieve the auto-run value. If successful, the size
+			// variable will be set to the actual size, without the extra NUL terminator.
+			auto buffer = std::make_unique< WCHAR[] >(size / sizeof(WCHAR));
+			if (ERROR_SUCCESS == RegGetValue(hkey, nullptr, AUTO_RUN_KEY_NAME, RRF_RT_REG_SZ, nullptr, reinterpret_cast<LPBYTE>(buffer.get()), &size))
+			{
+				result = true; // todo: check path
+			}
 		}
 
 		RegCloseKey (hkey);
@@ -136,21 +142,22 @@ bool AutorunEnable (bool is_enable)
 	bool result = false;
 
 	HKEY hkey = nullptr;
-	if (RegOpenKeyEx (HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_ALL_ACCESS, &hkey) == ERROR_SUCCESS)
+	if (ERROR_SUCCESS == RegOpenKeyEx (HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_ALL_ACCESS, &hkey))
 	{
 		if (is_enable)
 		{
-			wchar_t szPath[MAX_PATH];
-			if (GetModuleFileName(NULL, szPath, ARRAYSIZE(szPath)))
+			constexpr size_t MAX_PATH_EX = 32767; // Long file path max length, in characters
+			auto szPath = std::make_unique< WCHAR[] >(MAX_PATH_EX);
+			if (GetModuleFileName(NULL, szPath.get(), MAX_PATH_EX))
 			{
-				std::wstring path = L"\"" + std::wstring(szPath) + L"\" -autorun";
+				const std::wstring path = L"\"" + std::wstring(szPath.get()) + L"\" -autorun";
 
-				result = (RegSetValueEx(hkey, AUTO_RUN_KEY_NAME, 0, REG_SZ, (LPBYTE)path.c_str(), DWORD((path.length() + 1) * sizeof(WCHAR))) == ERROR_SUCCESS);
+				result = (ERROR_SUCCESS == RegSetValueEx(hkey, AUTO_RUN_KEY_NAME, 0, REG_SZ, reinterpret_cast<const BYTE*>(path.c_str()), static_cast<DWORD>((path.length() + 1) * sizeof(WCHAR))));
 			}
 		}
 		else
 		{
-			result = (RegDeleteValue (hkey, AUTO_RUN_KEY_NAME) == ERROR_SUCCESS);
+			result = (ERROR_SUCCESS == RegDeleteValue (hkey, AUTO_RUN_KEY_NAME));
 		}
 
 		RegCloseKey (hkey);

--- a/SandboxiePlus/SandMan/Helpers/WinAdmin.cpp
+++ b/SandboxiePlus/SandMan/Helpers/WinAdmin.cpp
@@ -117,8 +117,8 @@ bool IsAutorunEnabled()
 	HKEY hkey = nullptr;
 	if (ERROR_SUCCESS == RegOpenKeyEx (HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Run", 0, KEY_ALL_ACCESS, &hkey))
 	{
-		// First, determine the required buffer size, including NUL terminator (in bytes). RegGetValue() alway's adds
-		// an extra NULL terminator to size, even if one already exists, in case the stored value doesn't have one.
+		// First, determine the required buffer size, including NUL terminator (in bytes). RegGetValue() always adds
+		// an extra NUL terminator to size, even if one already exists, in case the stored value doesn't have one.
 		DWORD size {0};
 		if (ERROR_SUCCESS == RegGetValue(hkey, nullptr, AUTO_RUN_KEY_NAME, RRF_RT_REG_SZ, nullptr, nullptr, &size))
 		{


### PR DESCRIPTION
Patch now supports unlimited characters (including NUL terminator), as the required buffer size is determined first, before allocating the buffer.

I also changed the check condition "ERROR_SUCCESS" to have that first, as it makes it clearer from first glance what you're checking against, instead of having to look to the end of the line. It also has the benefit when comparing against a variable, that it protect's against accidentally only using a single '=' sign instead of '==' - the former resulting in assignment, with result always being true if not zero. In this case it doesn't really apply, but I think it's preferable.

I'm happy to switch it back to the other way round if you want.

Also switched to using C++ style casting style, as it makes intent clearer and makes it easier to search for places where casting is taking place.