### PR TITLE
Fix: Recovery: Only show delete confirmation dialog if file/folder selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,23 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 
-## [1.8.2 / 5.63.2] - 2023-03-12
+## [1.8.2 / 5.63.2] - 2023-03-27
 
 ### Added
 - reworked CreateAppContainerToken hook to return a restricted token instead to fix [#2762](https://github.com/sandboxie-plus/Sandboxie/issues/2762)
 -- Note: this behaviour can be disabled with 'FakeAppContainerToken=program.exe,n'
 - enabled app container compatybility in app compartment mode
--- Note: this should improve msedge compatybility
+-- Note: this should improve msedge compatibility
 
 ### Changed
 - renamed 'DropAppContainerTokens=program.exe,n' to 'DropAppContainerToken=program.exe,n'
-- 'DropAppContainerToken=program.exe,y' can now be used in App Compartment boxes is howeever not recomended security whise
+- 'DropAppContainerToken=program.exe,y' can now be used in App Compartment boxes is howeever not recomended security wise
 
 ### Fixed
 - issue with global ini section editing
 - fixed issue with *UseRegDeleteV2=y' [#2756](https://github.com/sandboxie-plus/Sandboxie/issues/2756)
-
+- Auto-run path now supports any length
+- Recovery Window: Delete confirmation dialog no longer shown when no file/folder selected
 
 
 

--- a/SandboxiePlus/SandMan/Windows/RecoveryWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/RecoveryWindow.cpp
@@ -242,7 +242,10 @@ void CRecoveryWindow::OnDelete()
 {
 	QMap<QString, SRecItem> FileMap = GetFiles();
 
-	if (QMessageBox("Sandboxie-Plus", tr("Do you really want to delete %1 selected files?").arg(FileMap.count()), QMessageBox::Question, QMessageBox::Yes, QMessageBox::No | QMessageBox::Default | QMessageBox::Escape, QMessageBox::NoButton, this).exec() != QMessageBox::Yes)
+	if (FileMap.isEmpty())
+		return;
+
+	if (QMessageBox::Yes != QMessageBox("Sandboxie-Plus", tr("Do you really want to delete %1 selected files?").arg(FileMap.count()), QMessageBox::Question, QMessageBox::Yes, QMessageBox::No | QMessageBox::Default | QMessageBox::Escape, QMessageBox::NoButton, this).exec())
 		return;
 
 	foreach(const QString & FilePath, FileMap.keys())


### PR DESCRIPTION
Fix: Recovery: Only show delete confirmation dialog if file/folder selected