### PR TITLE
Update sandman_de.ts and change-log typo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added hidden message list
 - added option to prevent processes located outside the sandbox from loading boxed DLLs
 -- to enable it, use "ProtectHostImages=y"
-- add option to block box inter programs but not box extern once (garbled sentence ???)
+- added option to block box intern programs but not box external ones
 - added SbieLogon option to the new box wizard [#2823](https://github.com/sandboxie-plus/Sandboxie/issues/2823)
 - added a few UI debug options [#2816](https://github.com/sandboxie-plus/Sandboxie/issues/2816)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - added local template editorto the global settings window
 - added hidden message list
-- added option to prevent processes located outside teh sandbox from loading boxed dll's
+- added option to prevent processes located outside the sandbox from loading boxed dll's
 -- to enable it use "ProtectHostImages=y"
 - add option to block box inter programs but not box extern once
 - added SbieLogon option to the new box wizard [#2823](https://github.com/sandboxie-plus/Sandboxie/issues/2823)
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - run menu entries now can have custom icons
-- the init edit page will automatically switch to edit when the user chages somethign
+- the init edit page will automatically switch to edit when the user changes something
 - improved change handling in the global settings window
 - reorganized global options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 
-## [1.8.5 / 5.63.5] - 2023-04-17
+## [1.9.0 / 5.64.0] - 2023-04-17
 
 ### Added
-- added local template editorto the global settings window
+- added local template editor to the global settings window
 - added hidden message list
-- added option to prevent processes located outside the sandbox from loading boxed dll's
--- to enable it use "ProtectHostImages=y"
-- add option to block box inter programs but not box extern once
+- added option to prevent processes located outside the sandbox from loading boxed DLLs
+-- to enable it, use "ProtectHostImages=y"
+- add option to block box inter programs but not box extern once (garbled sentence ???)
 - added SbieLogon option to the new box wizard [#2823](https://github.com/sandboxie-plus/Sandboxie/issues/2823)
 - added a few UI debug options [#2816](https://github.com/sandboxie-plus/Sandboxie/issues/2816)
 
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - reorganized global options
 
 ### Fixed
-- fixed issue with group renaming in the sandman UI [#2804](https://github.com/sandboxie-plus/Sandboxie/issues/2804)
+- fixed issue with group renaming in the SandMan UI [#2804](https://github.com/sandboxie-plus/Sandboxie/issues/2804)
 
 
 

--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -4424,9 +4424,8 @@ Prozesse in dieser Box werden denken, dass sie mit Adminrechten laufen, ohne das
         <location filename="Wizards/NewBoxWizard.cpp" line="575"/>
         <source>
 Processes in this box will be running with a custom process token indicating the sandbox they belong to.</source>
-        <oldsource>
-Processes in this box will be running with a custom process token indicating the sandbox thay belong to.</oldsource>
-        <translation type="unfinished"></translation>
+        <translation>
+Prozesse in dieser Box werden mit einem eigenen Prozesstoken laufen, die anzeigen zu welcher Sandbox sie gehören.</translation>
     </message>
     <message>
         <location filename="Wizards/NewBoxWizard.cpp" line="606"/>


### PR DESCRIPTION
Fresh fork to initially translate a string that has been changed, while also removing its old source and fixing mistakes in the change-log, that codespell marked as bad.