### PR TITLE
Fixed a command line issue when creating a process

### DIFF
--- a/Sandboxie/core/dll/proc.c
+++ b/Sandboxie/core/dll/proc.c
@@ -857,7 +857,7 @@ _FX BOOL Proc_CreateProcessInternalW(
     BOOL ok;
     BOOL resume_thread = FALSE;
     WCHAR* lpAlteredCommandLine = NULL;
-    
+
     Proc_LastCreatedProcessHandle = NULL;
     LPCWSTR pSrcCommandLine = lpApplicationName;
 
@@ -1318,15 +1318,13 @@ _FX BOOL Proc_CreateProcessInternalW(
         }
     }
 
-	
-    // Handle some command line issues 
-    // need add Config "RecoverAppNameProcess=appname" ,for example "RecoverAppNameProcess=excel.exe"
-    // changed by lmdd 
-    if (pSrcCommandLine == NULL && lpApplicationName)
-    {
-	const WCHAR* lpProgram = wcsrchr(lpApplicationName, L'\\');
-	if (lpProgram &&SbieDll_CheckStringInList(lpProgram + 1, NULL, L"RecoverAppNameProcess"))
-	lpApplicationName = NULL;
+    // Handle some command line issues
+    // need to add Config "RecoverAppNameProcess=appname", for example "RecoverAppNameProcess=excel.exe"
+    // changed by lmdd
+    if (pSrcCommandLine == NULL && lpApplicationName) {
+        const WCHAR* lpProgram = wcsrchr(lpApplicationName, L'\\');
+        if (lpProgram && SbieDll_CheckStringInList(lpProgram + 1, NULL, L"RecoverAppNameProcess"))
+            lpApplicationName = NULL;
     }
 
     //

--- a/Sandboxie/core/dll/proc.c
+++ b/Sandboxie/core/dll/proc.c
@@ -857,8 +857,9 @@ _FX BOOL Proc_CreateProcessInternalW(
     BOOL ok;
     BOOL resume_thread = FALSE;
     WCHAR* lpAlteredCommandLine = NULL;
-
+    
     Proc_LastCreatedProcessHandle = NULL;
+    LPCWSTR pSrcCommandLine = lpApplicationName;
 
     //
     // check if we block the process or launch it some other way
@@ -1315,6 +1316,17 @@ _FX BOOL Proc_CreateProcessInternalW(
             hToken = NULL;
             SbieApi_MonitorPutMsg(MONITOR_OTHER | MONITOR_TRACE, L"Dropped AppContainer Token");
         }
+    }
+
+	
+    // Handle some command line issues 
+    // need add Config "RecoverAppNameProcess=appname" ,for example "RecoverAppNameProcess=excel.exe"
+    // changed by lmdd 
+    if (pSrcCommandLine == NULL && lpApplicationName)
+    {
+	const WCHAR* lpProgram = wcsrchr(lpApplicationName, L'\\');
+	if (lpProgram &&SbieDll_CheckStringInList(lpProgram + 1, NULL, L"RecoverAppNameProcess"))
+	lpApplicationName = NULL;
     }
 
     //


### PR DESCRIPTION
Fixed command line issues caused by overmodifying the createprocessinternalw parameter. At some point, lpApplicationName needs to be null.