### PR TITLE
Handles double check of dde messages

### DIFF
--- a/Sandboxie/core/dll/guidde.c
+++ b/Sandboxie/core/dll/guidde.c
@@ -355,8 +355,18 @@ _FX BOOLEAN Gui_DDE_COPYDATA_Received(
     Sbie_snwprintf(prop_name, 64, SBIE L"_DDE_%08p", (void*)hWnd);
     hClientWnd = Gui_GetPropCommon((HWND)wParam, prop_name, TRUE, 0);
     if (TlsData->gui_dde_client_hwnd != (HWND)-1) {
-        if ((! hClientWnd) || (hClientWnd != TlsData->gui_dde_client_hwnd))
-            return FALSE;
+#ifdef _WIN64
+		if ((!hClientWnd) || (hClientWnd != TlsData->gui_dde_client_hwnd))
+			return FALSE;
+#else
+		// When I double click an.xlsx file, my excel will run here, but Gui_GetPropCommon will return empty.
+		// This is a problem for Office 32-bit, so I uncheck the hClientWnd double check for 32-bit programs
+		// lmdd change
+		if (hClientWnd == 0)
+			hClientWnd = TlsData->gui_dde_client_hwnd;
+		else if (hClientWnd != TlsData->gui_dde_client_hwnd)
+			return FALSE;
+#endif
     }
 
     //


### PR DESCRIPTION
In the default configuration, I opened Explorer, double-clicked an xlsx file, and excel opened, but the document did not.
The reason is that when excel processes dde messages, the handle to the service query is NULL,So I cancel the 32 bit double check.
office2016 64-bit office doesn't have this problem, but 32-bit office does（The operating system of my computer is x64）

#2890 
Recirculation step:
1.Install excel2016 32bit
2.Open explorer in the sandbox,Double-click an xlsx file
3.excel will open, but files will not
