### PR TITLE
Configurable toolbar items

### DIFF
--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -348,6 +348,11 @@ void CSandMan::CreateUI()
 {
 	SetUITheme();
 
+	// Clear old ToolBar references.
+	m_pNewBoxButton = nullptr;
+	m_pCleanUpButton = nullptr;
+	m_pEditIniButton = nullptr;	
+	
 	int iViewMode = theConf->GetInt("Options/ViewMode", 1);
 
 	if(iViewMode == 2)
@@ -738,7 +743,10 @@ QSet<QString> CSandMan::GetToolBarItemsConfig()
 	auto list = theConf->GetStringList(ToolBarConfigKey, DefaultToolBarItems);
 
 	QSet<QString> validSet;
-	for (auto item : GetAvailableToolBarActions()) validSet.insert(item.scriptName);
+
+	for (auto item : GetAvailableToolBarActions()) {		
+		if (!item.scriptName.isEmpty()) validSet.insert(item.scriptName);
+	}
 
 	// remove invalid and obsolete items
 	QSet<QString> items;
@@ -759,45 +767,52 @@ QList<ToolBarAction> CSandMan::GetAvailableToolBarActions()
 {
 	// Assumes Advanced-Mode and (menu-)actions have been created.
 	// Return items in toolbar display order
-	
+
 	return QList<ToolBarAction> {
-		ToolBarAction{"NewBox", m_pNewBox},
-		ToolBarAction{"NewGroup", m_pNewGroup},
-		ToolBarAction{"ImportBox", m_pImportBox},
-		ToolBarAction{nullptr, nullptr},        // separator
-		ToolBarAction{"CleanUpMenu", nullptr},  // special case
-		ToolBarAction{"Settings", m_pMenuSettings},
-		ToolBarAction{"EditIni", m_pEditIni},
-		ToolBarAction{"EditTemplates", m_pEditIni2},
-		ToolBarAction{"EditPlusIni", m_pEditIni3},
-		ToolBarAction{"ReloadIni", m_pReloadIni},
-		ToolBarAction{"Refresh", m_pRefreshAll},
-		ToolBarAction{nullptr, nullptr},
-		ToolBarAction{"RunBoxed", m_pRunBoxed},
-		ToolBarAction{"IsBoxed", m_pWndFinder},
-		ToolBarAction{"TerminateAll", m_pEmptyAll},
-		ToolBarAction{"KeepTerminated", m_pKeepTerminated},
-		ToolBarAction{"BrowseFiles", m_pMenuBrowse},
-		ToolBarAction{"EnableMonitor", m_pEnableMonitoring},
-		ToolBarAction{nullptr, nullptr},
-		ToolBarAction{"Connect", m_pConnect},
-		ToolBarAction{"Disconnect", m_pDisconnect},
-		ToolBarAction{"StopAll", m_pStopAll},
-		ToolBarAction{"SetupWizard", m_pSetupWizard},
-		ToolBarAction{"UninstallAll", m_pUninstallAll},
-		ToolBarAction{nullptr, nullptr},
-		ToolBarAction{"CheckForUpdates", m_pUpdate},
-		ToolBarAction{"About", m_pAbout},
-		ToolBarAction{nullptr, nullptr},
-		ToolBarAction{"Exit", m_pExit},
-		ToolBarAction{nullptr, nullptr},
-		ToolBarAction{"Contribute", m_pContribution}
+			ToolBarAction{ "NewBoxMenu", nullptr, tr("New-Box Menu") },  //tr: Name of button in toolbar for showing actions new box, new group, import},
+			ToolBarAction{ "NewBox", m_pNewBox },
+			ToolBarAction{ "NewGroup", m_pNewGroup },
+			ToolBarAction{ "ImportBox", m_pImportBox },
+			ToolBarAction{ "", nullptr },        // separator
+			ToolBarAction{ "CleanUpMenu", nullptr, tr("Cleanup") }, //tr: Name of button in toolbar for cleanup-all action
+			ToolBarAction{ "Settings", m_pMenuSettings },
+			ToolBarAction{ "EditIniMenu", nullptr, tr("Edit-ini Menu") },  //tr: Name of button in toolbar for showing edit-ini files actions},
+			ToolBarAction{ "EditIni", m_pEditIni },
+			ToolBarAction{ "EditTemplates", m_pEditIni2 },
+			ToolBarAction{ "EditPlusIni", m_pEditIni3 },
+			ToolBarAction{ "ReloadIni", m_pReloadIni },
+			ToolBarAction{ "Refresh", m_pRefreshAll },
+			ToolBarAction{ "", nullptr },
+			ToolBarAction{ "RunBoxed", m_pRunBoxed },
+			ToolBarAction{ "IsBoxed", m_pWndFinder },
+			ToolBarAction{ "TerminateAll", m_pEmptyAll },
+			ToolBarAction{ "KeepTerminated", m_pKeepTerminated },
+			ToolBarAction{ "BrowseFiles", m_pMenuBrowse },
+			ToolBarAction{ "EnableMonitor", m_pEnableMonitoring },
+			//TODO These need icons
+			//ToolBarAction{ "", nullptr },
+			//ToolBarAction{ "DisableForce", m_pDisableForce},
+			//ToolBarAction{ "DisableRecovery", m_pDisableRecovery },
+			//ToolBarAction{ "DisableMessages", m_pDisableMessages },
+			ToolBarAction{ "", nullptr },
+			ToolBarAction{ "Connect", m_pConnect },
+			ToolBarAction{ "Disconnect", m_pDisconnect },
+			ToolBarAction{ "StopAll", m_pStopAll },
+			// ToolBarAction{"SetupWizard", m_pSetupWizard},
+			// ToolBarAction{"UninstallAll", m_pUninstallAll}, // removed because not always valid in menu system
+			ToolBarAction{ "", nullptr },
+			ToolBarAction{ "CheckForUpdates", m_pUpdate },
+			ToolBarAction{ "About", m_pAbout },
+			ToolBarAction{ "", nullptr },
+			ToolBarAction{ "Exit", m_pExit },
+			ToolBarAction{ "", nullptr },
+			ToolBarAction{ "Contribute", m_pContribution }
 	};
 }
 
 void CSandMan::OnResetToolBarMenuConfig()
 {
-	theConf->SetValue(ToolBarConfigKey, DefaultToolBarItems.split(','));
+	theConf->SetValue(ToolBarConfigKey, DefaultToolBarItems);
 	CreateToolBar(true);
 }
 
@@ -825,12 +840,13 @@ void CSandMan::CreateToolBarConfigMenu(const QList<ToolBarAction>& actions, cons
 		}
 
 		QString text = sa.scriptName;
-		if (sa.action)
+		if (!sa.nameOverride.isEmpty())
+			text = sa.nameOverride;
+		else if (sa.action)
 			text = sa.action->text();  // tr: already localised
-		else if (sa.scriptName == "CleanUpMenu")
-			text = tr("Cleanup");  //tr: Name of button in toolbar for cleanup-all action
 		else
-			; //TODO: Log internal error. Special-case mapping not implemented
+			qDebug() << "ERROR: Missing display name for " << sa.scriptName;
+
 		auto scriptName = sa.scriptName;
 		auto menuAction = m_pToolBarContextMenu->addAction(text, this, [scriptName, this]() {
 			OnToolBarMenuItemClicked(scriptName);
@@ -851,7 +867,7 @@ void CSandMan::CreateToolBarConfigMenu(const QList<ToolBarAction>& actions, cons
 void CSandMan::CreateToolBar(bool rebuild)
 {
 	// Assumes UI is in Advanced-Mode and menus have been built.
-
+	
 	auto pOldToolBar = m_pToolBar;
 	m_pToolBar = new QToolBar();
 	m_pMainLayout->insertWidget(0, m_pToolBar);
@@ -859,20 +875,24 @@ void CSandMan::CreateToolBar(bool rebuild)
 		m_pLabel->deleteLater(); // should really be owned by m_pToolBar, not m_pMainWidget
 		m_pMainLayout->removeWidget(pOldToolBar);
 		pOldToolBar->deleteLater();
+		m_pNewBoxButton = nullptr;  // deleted by pOldToolBar
+		m_pEditIniButton = nullptr;
+		m_pCleanUpButton = nullptr;
 	}
-
-	//debug connect(m_pToolBar, &QToolBar::destroyed, this, [this](){ qDebug() << "QToolBar::destroyed()"; });
 
 	auto items = GetToolBarItemsConfig();
 	auto scriptableActions = GetAvailableToolBarActions();
 	CreateToolBarConfigMenu(scriptableActions, items);
 
-	bool needsSeparator = false; // prevent leading, trailing, or consecutive separators
+	// Prevent leading, trailing, or consecutive separators
+	bool needsSeparator = false; // true if we need to add a separator before the next action
+	bool latestIsAction = false; // true if the most recent toolbar item is not a separator
 
 	for (auto sa : scriptableActions)
 	{
-		if (sa.scriptName == nullptr) {
-			needsSeparator = true;
+		if (sa.scriptName.isEmpty()) {
+			// only trigger if we just added an action
+			if (latestIsAction) needsSeparator = true;
 			continue;
 		}
 
@@ -883,20 +903,59 @@ void CSandMan::CreateToolBar(bool rebuild)
 			needsSeparator = false;
 		}
 
+		latestIsAction = true;
+
 		if (sa.action)
 		{
 			m_pToolBar->addAction(sa.action);
 		}
 		else if (sa.scriptName == "CleanUpMenu")
-		{			
-			m_pCleanUpButton = new QToolButton();
-			m_pCleanUpButton->setIcon(CSandMan::GetIcon("Clean"));
-			m_pCleanUpButton->setToolTip(tr("Cleanup"));
-			m_pCleanUpButton->setText(tr("Cleanup"));
-			m_pCleanUpButton->setPopupMode(QToolButton::MenuButtonPopup);
-			m_pCleanUpButton->setMenu(m_pCleanUpMenu);		
-			QObject::connect(m_pCleanUpButton, SIGNAL(clicked(bool)), this, SLOT(OnCleanUp()));
-			m_pToolBar->addWidget(m_pCleanUpButton);
+		{
+			auto but = new QToolButton();
+			but->setIcon(CSandMan::GetIcon("Clean"));
+			but->setToolTip(tr("Cleanup"));
+			but->setText(tr("Cleanup"));
+			but->setPopupMode(QToolButton::MenuButtonPopup);
+			but->setMenu(m_pCleanUpMenu);		
+			QObject::connect(but, SIGNAL(clicked(bool)), this, SLOT(OnCleanUp()));
+			m_pCleanUpButton = but;
+			m_pToolBar->addWidget(but);
+		}
+		else if (sa.scriptName == "NewBoxMenu")
+		{
+			auto but = new QToolButton();
+			but->setIcon(CSandMan::GetIcon("NewBox"));
+			but->setToolTip(tr("Create New Box"));
+			but->setText(tr("Create New Box"));
+			but->setPopupMode(QToolButton::MenuButtonPopup);
+			auto menu = new QMenu(but);
+			menu->addAction(m_pNewBox);
+			menu->addAction(m_pNewGroup);
+			menu->addAction(m_pImportBox);
+			but->setMenu(menu);
+			QObject::connect(but, &QToolButton::clicked, this, [this]() {GetBoxView()->AddNewBox();});
+			m_pNewBoxButton = but;
+			m_pToolBar->addWidget(but);
+		}
+		else if (sa.scriptName == "EditIniMenu")
+		{
+			auto but = new QToolButton();
+			but->setIcon(CSandMan::GetIcon("Editor"));
+			but->setToolTip(tr("Edit Sandboxie.ini"));
+			but->setText(tr("Edit Sandboxie.ini"));
+			but->setPopupMode(QToolButton::MenuButtonPopup);
+			auto menu = new QMenu(but);
+			menu->addAction(m_pEditIni);
+			menu->addAction(m_pEditIni2);
+			menu->addAction(m_pEditIni3);
+			but->setMenu(menu);
+			QObject::connect(but, &QToolButton::clicked, this, [this]() {OnEditIni();});
+			m_pEditIniButton = but;
+			m_pToolBar->addWidget(but);
+		}
+		else
+		{
+			qDebug() << "ERROR: You forgot to handle ToolBarAction scriptName " << sa.scriptName;
 		}
 	}
 
@@ -2110,6 +2169,10 @@ void CSandMan::UpdateState()
 	if(m_pEditIni2) m_pEditIni2->setEnabled(isConnected);
 	m_pReloadIni->setEnabled(isConnected);
 	if(m_pEnableMonitoring) m_pEnableMonitoring->setEnabled(isConnected);
+
+	if (m_pNewBoxButton) m_pNewBoxButton->setEnabled(isConnected);
+	if (m_pEditIniButton) m_pEditIniButton->setEnabled(isConnected);
+	if (m_pCleanUpButton) m_pCleanUpButton->setEnabled(isConnected);
 }
 
 void CSandMan::OnMenuHover(QAction* action)

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -764,33 +764,33 @@ QList<ToolBarAction> CSandMan::GetAvailableToolBarActions()
 		ToolBarAction{"NewBox", m_pNewBox},
 		ToolBarAction{"NewGroup", m_pNewGroup},
 		ToolBarAction{"ImportBox", m_pImportBox},
-		ToolBarAction{NULL, NULL},           // separator
-		ToolBarAction{"CleanUpMenu", NULL},  // special case
+		ToolBarAction{nullptr, nullptr},        // separator
+		ToolBarAction{"CleanUpMenu", nullptr},  // special case
 		ToolBarAction{"Settings", m_pMenuSettings},
 		ToolBarAction{"EditIni", m_pEditIni},
 		ToolBarAction{"EditTemplates", m_pEditIni2},
 		ToolBarAction{"EditPlusIni", m_pEditIni3},
 		ToolBarAction{"ReloadIni", m_pReloadIni},
 		ToolBarAction{"Refresh", m_pRefreshAll},
-		ToolBarAction{NULL, NULL},
+		ToolBarAction{nullptr, nullptr},
 		ToolBarAction{"RunBoxed", m_pRunBoxed},
 		ToolBarAction{"IsBoxed", m_pWndFinder},
 		ToolBarAction{"TerminateAll", m_pEmptyAll},
 		ToolBarAction{"KeepTerminated", m_pKeepTerminated},
 		ToolBarAction{"BrowseFiles", m_pMenuBrowse},
 		ToolBarAction{"EnableMonitor", m_pEnableMonitoring},
-		ToolBarAction{NULL, NULL},
+		ToolBarAction{nullptr, nullptr},
 		ToolBarAction{"Connect", m_pConnect},
 		ToolBarAction{"Disconnect", m_pDisconnect},
 		ToolBarAction{"StopAll", m_pStopAll},
 		ToolBarAction{"SetupWizard", m_pSetupWizard},
 		ToolBarAction{"UninstallAll", m_pUninstallAll},
-		ToolBarAction{NULL, NULL},
+		ToolBarAction{nullptr, nullptr},
 		ToolBarAction{"CheckForUpdates", m_pUpdate},
 		ToolBarAction{"About", m_pAbout},
-		ToolBarAction{NULL, NULL},
+		ToolBarAction{nullptr, nullptr},
 		ToolBarAction{"Exit", m_pExit},
-		ToolBarAction{NULL, NULL},
+		ToolBarAction{nullptr, nullptr},
 		ToolBarAction{"Contribute", m_pContribution}
 	};
 }
@@ -819,7 +819,7 @@ void CSandMan::CreateToolBarConfigMenu(const QList<ToolBarAction>& actions, cons
 
 	for (auto sa : actions)
 	{
-		if (sa.scriptName == NULL) {
+		if (sa.scriptName == nullptr) {
 			m_pToolBarContextMenu->addSeparator();
 			continue;
 		}
@@ -871,7 +871,7 @@ void CSandMan::CreateToolBar(bool rebuild)
 
 	for (auto sa : scriptableActions)
 	{
-		if (sa.scriptName == NULL) {
+		if (sa.scriptName == nullptr) {
 			needsSeparator = true;
 			continue;
 		}

--- a/SandboxiePlus/SandMan/SandMan.h
+++ b/SandboxiePlus/SandMan/SandMan.h
@@ -23,11 +23,14 @@ class CSbieTemplates;
 class CTraceView;
 
 struct ToolBarAction {
-	// Identifier of action stored in ini. Null for separator.	
-	QString scriptName;
+	// Identifier of action stored in ini. Empty for separator.	
+	QString scriptName = "";
 
 	// Not owned. Null for special cases.
 	QAction* action;
+
+	// Display name override for display in toolbar config menu. Empty if no override.
+	QString nameOverride = "";
 };
 
 class CSandMan : public QMainWindow
@@ -289,11 +292,12 @@ private:
 	void				OnToolBarMenuItemClicked(const QString& scriptName);
 	void				OnResetToolBarMenuConfig();
 
-	const				QString ToolBarConfigKey = "UIConfig/ToolBarItems";
+	const QString       ToolBarConfigKey = "UIConfig/ToolBarItems";
 
 	// per 1.9.3 menu. no whitespace!
-	const				QString DefaultToolBarItems = "Settings,KeepTerminated,CleanUpMenu,BrowseFiles,EditIni,EnableMonitor";
-
+	const QStringList	DefaultToolBarItems = QString(
+						  "Settings,KeepTerminated,CleanUpMenu,BrowseFiles,EditIni,EnableMonitor"
+						).split(',');
 
 	QWidget*			m_pMainWidget;
 	QVBoxLayout*		m_pMainLayout;
@@ -359,6 +363,8 @@ private:
 	QAction*			m_pCleanUpTrace;
 	QAction*			m_pCleanUpRecovery;
 	QToolButton*		m_pCleanUpButton;
+	QToolButton*		m_pNewBoxButton = nullptr;
+	QToolButton*		m_pEditIniButton = nullptr;
 	//QToolButton*		m_pEditButton;
 	QAction*			m_pKeepTerminated;
 	QAction*			m_pShowAllSessions;

--- a/SandboxiePlus/SandMan/SandMan.h
+++ b/SandboxiePlus/SandMan/SandMan.h
@@ -22,6 +22,13 @@ class CBoxBorder;
 class CSbieTemplates;
 class CTraceView;
 
+struct ToolBarAction {
+	// Identifier of action stored in ini. Null for separator.	
+	QString scriptName;
+
+	// Not owned. Null for special cases.
+	QAction* action;
+};
 
 class CSandMan : public QMainWindow
 {
@@ -250,7 +257,7 @@ private:
 	void				CreateMaintenanceMenu();
 	void				CreateViewBaseMenu();
 	void				CreateHelpMenu(bool bAdvanced);
-	void				CreateToolBar();
+	void				CreateToolBar(bool bRebuild);
 	void				CreateLabel();
 	void				CreateView(int iViewMode);
 	void				CreateTrayIcon();
@@ -274,6 +281,19 @@ private:
 	void				CleanupShortcutPath(const QString& Path);
 	void				DeleteShortcut(const QString& Path);
 	void				CleanUpStartMenu(QMap<QString, QMap<QString, SBoxLink> >& BoxLinks);
+
+	QSet<QString>		GetToolBarItemsConfig();
+	void				SetToolBarItemsConfig(const QSet<QString>& items);
+	QList<ToolBarAction> GetAvailableToolBarActions();
+	void                CreateToolBarConfigMenu(const QList<ToolBarAction>& actions, const QSet<QString>& currentSet);
+	void				OnToolBarMenuItemClicked(const QString& scriptName);
+	void				OnResetToolBarMenuConfig();
+
+	const				QString ToolBarConfigKey = "UIConfig/ToolBarItems";
+
+	// per 1.9.3 menu. no whitespace!
+	const				QString DefaultToolBarItems = "Settings,KeepTerminated,CleanUpMenu,BrowseFiles,EditIni,EnableMonitor";
+
 
 	QWidget*			m_pMainWidget;
 	QVBoxLayout*		m_pMainLayout;


### PR DESCRIPTION
Related: #2938 

Feature:
* Ability to select what items are displayed in the advanced-mode toolbar of SB+.
* Right-click on toolbar for context menu to select items to be displayed
* Limited to actions that have an associated icon

Code review:
* Please, special attention to object allocation/destruction. Never ever worked with Qt before, and spoilt with years of C# garbage collection.

Thoughts:
* CSandMan actions should ideally be decoupled from Menu and be attached to main window. As before, toolbar kind of "borrows" them and assumes the menu is there and is complete.
* As before, the m_pSomeActionName members in CSandMan are a bit risky. Their validity is context based, not NULLed.

![image](https://github.com/sandboxie-plus/Sandboxie/assets/28550406/e4fea9ff-cebc-450a-9a71-e621479b7a1f)

