### PR TITLE
Resolves #2963. Keep submenus visible on mouse leave.

### DIFF
--- a/SandboxiePlus/SandMan/Helpers/KeepSubMenusVisibleStyle.h
+++ b/SandboxiePlus/SandMan/Helpers/KeepSubMenusVisibleStyle.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QProxyStyle>
+
+// Keep submenus open when mouse leaves
+class KeepSubMenusVisibleStyle : public QProxyStyle {
+public:
+	KeepSubMenusVisibleStyle(QStyle* style = 0) : QProxyStyle(style) {}
+
+	int styleHint(StyleHint styleHint, const QStyleOption* opt = nullptr,
+		const QWidget* widget = nullptr, QStyleHintReturn* returnData = nullptr) const
+	{
+		if (styleHint == SH_Menu_SubMenuDontStartSloppyOnLeave) return 1;
+		return QProxyStyle::styleHint(styleHint, opt, widget, returnData);
+	}
+};

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -35,6 +35,7 @@
 #include <QSessionManager>
 #include "Helpers/FullScreen.h"
 #include "Helpers/WinHelper.h"
+#include "Helpers/KeepSubMenusVisibleStyle.h"
 
 CSbiePlusAPI* theAPI = NULL;
 
@@ -350,10 +351,18 @@ void CSandMan::CreateUI()
 
 	int iViewMode = theConf->GetInt("Options/ViewMode", 1);
 
+	// ==== hack ====
+	auto oldStyle = qApp->style();
+	auto kvs = new KeepSubMenusVisibleStyle(oldStyle);
+	qApp->setStyle(kvs);
+	kvs->setParent(this);
+
 	if(iViewMode == 2)
 		CreateOldMenus();
 	else
 		CreateMenus(iViewMode == 1);
+
+	qApp->setStyle(oldStyle);
 
 	m_pMainLayout = new QVBoxLayout(m_pMainWidget);
 	m_pMainLayout->setContentsMargins(2,2,2,2);

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -447,6 +447,7 @@
     <QtMoc Include="BoxMonitor.h" />
     <ClInclude Include="Helpers\FindTool.h" />
     <ClInclude Include="Helpers\FullScreen.h" />
+    <ClInclude Include="Helpers\KeepSubMenusVisibleStyle.h" />
     <ClInclude Include="Helpers\ReadDirectoryChanges.h" />
     <ClInclude Include="Helpers\ReadDirectoryChangesPrivate.h" />
     <ClInclude Include="Helpers\ThreadSafeQueue.h" />

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -221,6 +221,9 @@
     <ClInclude Include="Helpers\WinHelper.h">
       <Filter>Helpers</Filter>
     </ClInclude>
+    <ClInclude Include="Helpers\KeepSubMenusVisibleStyle.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <QtMoc Include="SandMan.h">

--- a/SandboxiePlus/SandMan/main.cpp
+++ b/SandboxiePlus/SandMan/main.cpp
@@ -9,6 +9,7 @@
 #include <windows.h>
 #include "./Windows/SettingsWindow.h"
 #include "./Wizards/SetupWizard.h"
+#include "./Helpers/KeepSubMenusVisibleStyle.h"
 
 CSettings* theConf = NULL;
 
@@ -61,6 +62,7 @@ int main(int argc, char *argv[])
 
 	QtSingleApplication app(argc, argv);
 	app.setQuitOnLastWindowClosed(false);
+	app.setStyle(new KeepSubMenusVisibleStyle(app.style()));
 
 	//InitConsole(false);
 

--- a/SandboxiePlus/SandMan/main.cpp
+++ b/SandboxiePlus/SandMan/main.cpp
@@ -9,7 +9,6 @@
 #include <windows.h>
 #include "./Windows/SettingsWindow.h"
 #include "./Wizards/SetupWizard.h"
-#include "./Helpers/KeepSubMenusVisibleStyle.h"
 
 CSettings* theConf = NULL;
 
@@ -62,7 +61,6 @@ int main(int argc, char *argv[])
 
 	QtSingleApplication app(argc, argv);
 	app.setQuitOnLastWindowClosed(false);
-	app.setStyle(new KeepSubMenusVisibleStyle(app.style()));
 
 	//InitConsole(false);
 


### PR DESCRIPTION
Feature:
* Don't hide sub-menus on mouse leave.

Review:
* May require testing on platforms other than Win10x64.