### PR TITLE
Typo fixes and readme update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Sandboxie is a sandbox-based isolation software for 32-bit and 64-bit Windows NT-based operating systems. It creates a sandbox-like isolated operating environment in which applications can be run or installed without permanently modifying local & mapped drives or the Windows registry. An isolated virtual environment allows controlled testing of untrusted programs and web surfing.<br>
 
+Sandboxie allows you to create virtually unlimited sandboxes to isolate programs from the host and each other, while also allowing you to run as many programs simultaneously in a single box as you wish.
+
 |  System requirements  |      Release notes     |      Security policy      |      Contribution guidelines   |
 |         :---:         |          :---:         |          :---:            |          :---:                 |
 | Windows 7 or higher, 32-bit or 64-bit. |  [CHANGELOG.md](./CHANGELOG.md)  |   [SECURITY.md](./SECURITY.md)  |  [CONTRIBUTING.md](./CONTRIBUTING.md)  |

--- a/Sandboxie/core/drv/file_flt.c
+++ b/Sandboxie/core/drv/file_flt.c
@@ -1041,7 +1041,7 @@ _FX NTSTATUS File_Api_UnprotectRoot(PROCESS* proc, ULONG64* parms)
             len = sizeof(PROTECTED_ROOT) + root->file_root_len * sizeof(WCHAR);
             Mem_Free(root, len);
 
-            status = STATUS_SUCCESS; // dont break in case a root was added more then once
+            status = STATUS_SUCCESS; // don't break in case a root was added more than once
         }
 
         root = next_root;

--- a/Sandboxie/core/drv/token.c
+++ b/Sandboxie/core/drv/token.c
@@ -1152,13 +1152,13 @@ _FX void *Token_RestrictHelper1(
 		// Note: Sandboxie originally called here SeFilterToken already,
 		// this duplicated NewTokenObject and discarded it.
 		//
-		// Howeever the blunt method used in the code below to replace the
-		// token SID can create a dependancy on proc->SandboxieLogonSid
+		// However the blunt method used in the code below to replace the
+		// token SID can create a dependency on proc->SandboxieLogonSid
 		// formally AnonymousLogonSid which can cause issues and BSOD's
 		// It also has required a mitigation in Token_ResetPrimary, restoring
 		// the SID pointer so that the token object can be safely destroyed.
 		//
-		// Therefor the invokation of SeFilterToken has been moved after
+		// Therefore the invocation of SeFilterToken has been moved after
 		// the SID manipulation, this way the modified TempNewTokenObject
 		// will be quickly and safely disposed of. So we continue from there 
 		// on out with a proper unhacked token object.

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -3149,7 +3149,7 @@ OpenIpcPath=\RPC Control\OSPPCTransportEndpoint-*
 # Office 2013
 Tmpl.ScanService=sppsvc
 OpenIpcPath=\RPC Control\SPPCTransportEndpoint-*
-# piggyback a fix for Excell
+# piggyback a fix for Excel
 UseDragDropHack=excel.exe,n
 
 [Template_OfficeClickToRun]

--- a/SandboxiePlus/QSbieAPI/Helpers/DbgHelper.cpp
+++ b/SandboxiePlus/QSbieAPI/Helpers/DbgHelper.cpp
@@ -73,7 +73,7 @@ void CSymbolProvider::run()
 
 	while (m_bRunning)
 	{
-		quint64 OldTime = GetTickCount64() - 3000; // cleanup everythign older than 3 sec
+		quint64 OldTime = GetTickCount64() - 3000; // cleanup everything older than 3 sec
 		if (LastCleanUp < OldTime) 
         {
 			QMutexLocker Lock(&m_SymLock);
@@ -128,7 +128,7 @@ QString CSymbolProvider::Resolve(quint64 pid, quint64 Address)
                 break;
         }
 
-        static QAtomicInt FakeHandle = 1; // real handles are divisable b 4
+        static QAtomicInt FakeHandle = 1; // real handles are divisible by 4
         if (Worker.handle == (quint64)INVALID_HANDLE_VALUE)
             Worker.handle = FakeHandle.fetchAndAddAcquire(4);
 

--- a/SandboxiePlus/SandMan/Views/TraceView.cpp
+++ b/SandboxiePlus/SandMan/Views/TraceView.cpp
@@ -130,7 +130,7 @@ CTraceTree::CTraceTree(QWidget* parent)
 	QByteArray Split = theConf->GetBlob("MainWindow/TraceSplitter");
 	if(!Split.isEmpty())
 		m_pSplitter->restoreState(Split);
-	//else { // by default colapse the details pannel
+	//else { // by default colapse the details panel
 	//	auto Sizes = m_pSplitter->sizes();
 	//	Sizes[1] = 0;
 	//	m_pSplitter->setSizes(Sizes);


### PR DESCRIPTION
Another fresh fork to fix some spelling mistakes, in comments, found by code spell. Two fixes make changes to the grammar.

The latest commit adds some line to the readme, to help people understand what Sandboxie can do. E.g. that it is not limited in the amount of sandboxes nor that apps can't share a box.