### PR TITLE
Call getclassname2 when there is a gui proxy

### DIFF
--- a/Sandboxie/core/dll/guiclass.c
+++ b/Sandboxie/core/dll/guiclass.c
@@ -1092,7 +1092,7 @@ _FX BOOLEAN Gui_IsWindowAccessible(HWND hWnd)
 
         WCHAR clsnm[256];
         ULONG have_clsnm = __sys_GetClassNameW(hWnd, clsnm, 255);
-        if (! have_clsnm)
+        if (! have_clsnm && Gui_UseProxyService)
             have_clsnm = Gui_GetClassName2(hWnd, clsnm, 255, TRUE);
         if (have_clsnm) {
 


### PR DESCRIPTION
Fixed a bug that was still used when there was no gui proxy

