### PR TITLE
FixDirLinkErr

### DIFF
--- a/Sandboxie/core/dll/ipc.c
+++ b/Sandboxie/core/dll/ipc.c
@@ -643,7 +643,7 @@ _FX void Ipc_CreateObjects(void)
     wcscpy(buffer, CopyPath);
     wcscat(buffer, L"\\Global");
 
-    status = SbieApi_CreateDirOrLink(buffer, buffer2);
+    status = SbieApi_CreateDirOrLink(buffer, CopyPath);
 
     if (! NT_SUCCESS(status)) {
         errlvl = 41;


### PR DESCRIPTION
Fixed a link error when the path was created with a symbolic link, which could cause a software exception