### PR TITLE
Spelling and grammar fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added workaround for NtQueryObject locking up in exotic scenarios, to enable it use 'UseDriverObjLookup=y'
 
 ### Changed
-- improved business certificate handling, added usage count and machine count options
+- improved business certificate handling, added usage count and machine bound options
 
 ### Fixed
 - fixed issues with pinned shortcuts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added workaround for NtQueryObject locking up in egsotic scenarios, to enable it use 'UseDriverObjLookup=y'
 
 ### Changed
-- improved business certificate handling, added usage count and machine bount options
+- improved business certificate handling, added usage count and machine count options
 
 ### Fixed
 - fixed issues with pinned shortcuts
@@ -53,7 +53,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - reworked NT Object Handle handling
-- "OpenClipboard=n" now is also implemented in user mode, making it work for green boxes
+- "OpenClipboard=n" now is also implemented in user mode, making it work for compartment boxes
 - changed Delete V2 scheme to use drive letters in FilePaths.dat (remains backward compatible with using NT paths) [#3053](https://github.com/sandboxie-plus/Sandboxie/issues/3053)
 - improved robustness of snapshot merging [#3017](https://github.com/sandboxie-plus/Sandboxie/issues/3017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - added support for URL shortcut files in Run Menu [#3151](https://github.com/sandboxie-plus/Sandboxie/issues/3151)
 - added workaround for NtQueryObject locking up in exotic scenarios, to enable it use 'UseDriverObjLookup=y'
-- Addon Manager: tootlip to version column with maintainer info [#3167](https://github.com/sandboxie-plus/Sandboxie/issues/3167)
-- Addes mechanism to open websites for addons [#3166](https://github.com/sandboxie-plus/Sandboxie/issues/3166)
+- Addon Manager: added tooltip to version column with maintainer info [#3167](https://github.com/sandboxie-plus/Sandboxie/issues/3167)
+- added mechanism to open websites for addons [#3166](https://github.com/sandboxie-plus/Sandboxie/issues/3166)
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - added support for URL shortcut files in Run Menu [#3151](https://github.com/sandboxie-plus/Sandboxie/issues/3151)
-- added workaround for NtQueryObject locking up in egsotic scenarios, to enable it use 'UseDriverObjLookup=y'
+- added workaround for NtQueryObject locking up in exotic scenarios, to enable it use 'UseDriverObjLookup=y'
 
 ### Changed
 - improved business certificate handling, added usage count and machine count options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - added support for URL shortcut files in Run Menu [#3151](https://github.com/sandboxie-plus/Sandboxie/issues/3151)
 - added workaround for NtQueryObject locking up in exotic scenarios, to enable it use 'UseDriverObjLookup=y'
-- Addon Manager: added tooltip to version column with maintainer info [#3167](https://github.com/sandboxie-plus/Sandboxie/issues/3167)
+- Addon Manager: added tooltip to version column with maintainer information [#3167](https://github.com/sandboxie-plus/Sandboxie/issues/3167)
 - added mechanism to open websites for addons [#3166](https://github.com/sandboxie-plus/Sandboxie/issues/3166)
 
 

--- a/Sandboxie/core/dll/custom.c
+++ b/Sandboxie/core/dll/custom.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004-2020 Sandboxie Holdings, LLC 
- * Copyright 2020-2021 David Xanatos, xanasoft.com
+ * Copyright 2020-2023 David Xanatos, xanasoft.com
  *
  * This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -178,7 +178,7 @@ _FX UCHAR GetSetCustomLevel(UCHAR SetLevel)
 
         //
         // if UseRegDeleteV2 is set, check if RegPaths.dat was loaded
-        // if not it means the box was previusly a V1 box,
+        // if not it means the box was previously a V1 box,
         // hence return 0 and re run customization
         // 
         // note: DeleteShellAssocKeys deletes the sandboxie shell integration keys

--- a/Sandboxie/core/dll/file_del.c
+++ b/Sandboxie/core/dll/file_del.c
@@ -753,7 +753,7 @@ _FX WCHAR *File_TranslateDosToNtPath2(const WCHAR *DosPath)
                     if (File_DriveAddSN && *drive->sn) {
 
                         //
-                        // if the volume serial numbers dont match return NULL
+                        // if the volume serial numbers don't match return NULL
                         //
 
                         if (_wcsnicmp(DosPath + 2, drive->sn, 9) != 0) {

--- a/Sandboxie/core/dll/ipc.c
+++ b/Sandboxie/core/dll/ipc.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004-2020 Sandboxie Holdings, LLC 
- * Copyright 2020-2021 David Xanatos, xanasoft.com
+ * Copyright 2020-2023 David Xanatos, xanasoft.com
  *
  * This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -4197,7 +4197,7 @@ _FX NTSTATUS Ipc_MergeDirectoryObject(IPC_MERGE *merge, WCHAR* path, BOOLEAN joi
                 if (entry) {
 
                     if (entry->TypeName.Length == directoryInfo->TypeName.Length && memcmp(entry->TypeName.Buffer, directoryInfo->TypeName.Buffer, entry->TypeName.Length) == 0)
-                        continue; // identical entry, nothign to do
+                        continue; // identical entry, nothing to do
 
                     // same name but different type, remove old entry
                     List_Remove(&merge->objects, entry);

--- a/Sandboxie/core/dll/util_32.asm
+++ b/Sandboxie/core/dll/util_32.asm
@@ -294,7 +294,7 @@ InstrumentationCallbackAsm@0 proc
     push    eax
 
     mov     eax, 1                      ; Set EAX to 1 for comparison
-    cmp     fs:1b8h, eax                ; See if the recurion flag (Win10 TEB InstrumentationCallbackDisabled) has been set
+    cmp     fs:1b8h, eax                ; See if the recursion flag (Win10 TEB InstrumentationCallbackDisabled) has been set
     je      resume                      ; Jump and restore the registers if it has and resume
 
     pop     eax

--- a/Sandboxie/core/drv/file_flt.c
+++ b/Sandboxie/core/drv/file_flt.c
@@ -478,7 +478,7 @@ check:
     }
 
     //
-    // check if there are any protected root folders and restict the access to
+    // check if there are any protected root folders and restrict the access to them
     //
 
     if (Iopb->MajorFunction == IRP_MJ_CREATE && File_ProtectedRoots.count != 0 && Data->Iopb->TargetFileObject) {

--- a/Sandboxie/core/drv/token.c
+++ b/Sandboxie/core/drv/token.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004-2020 Sandboxie Holdings, LLC 
- * Copyright 2020-2021 David Xanatos, xanasoft.com
+ * Copyright 2020-2023 David Xanatos, xanasoft.com
  *
  * This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -1254,7 +1254,7 @@ _FX void *Token_RestrictHelper1(
                 &NewTokenObject);
 
 			//
-			// We restore here the original sid pointer as it was previusly
+			// Here we restore the original sid pointer as it was previously
 			// done in Token_ResetPrimary before dereferencing the token object.
 			//
 

--- a/SandboxiePlus/MiscHelpers/Archive/ArchiveThread.cpp
+++ b/SandboxiePlus/MiscHelpers/Archive/ArchiveThread.cpp
@@ -106,7 +106,7 @@ QMap<QString, quint64> C7zWorker::GetFileList()
 	QMap<QString, quint64> FileList;
 	if(!m_Mutex.tryLock(100))
 	{
-		//LogLine(LOG_DEBUG | LOG_ERROR, tr("atempted to get the file list of a already busy archive thread"));
+		//LogLine(LOG_DEBUG | LOG_ERROR, tr("attempted to get the file list of an already busy archive thread"));
 		return FileList;
 	}
 	
@@ -259,7 +259,7 @@ QMap<QString, quint64> CRarWorker::GetFileList()
 	QMap<QString, quint64> FileList;
 	if(!m_Mutex.tryLock(100))
 	{
-		//LogLine(LOG_DEBUG | LOG_ERROR, tr("atempted to get the file list of a already busy archive thread"));
+		//LogLine(LOG_DEBUG | LOG_ERROR, tr("attempted to get the file list of an already busy archive thread"));
 		return FileList;
 	}
 	

--- a/SandboxiePlus/QSbieAPI/Sandboxie/SbieIni.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/SbieIni.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2020 - 2023, David Xanatos
+ * Copyright 2020-2023 David Xanatos, xanasoft.com
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/SandboxiePlus/QSbieAPI/Sandboxie/SbieIni.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/SbieIni.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2020, David Xanatos
+ * Copyright (c) 2020 - 2023, David Xanatos
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -315,7 +315,7 @@ do_write:
 	}
 
 do_delete:
-	// Selete ini section
+	// Delete ini section
 	if (deleteOld)
 	{
 		SB_STATUS Status = m_pAPI->SbieIniSet(m_Name, "*", "", CSbieAPI::eIniUpdate, true);

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -889,7 +889,7 @@ void COptionsWindow::WriteTextSafe(const QString& Name, const QString& Value)
 			List.removeAt(i--);
 	}
 
-	// Prepand the global entry
+	// Prepend the global entry
 	if (!Value.isEmpty()) List.append(Value);
 
 	WriteTextList(Name, List);

--- a/SandboxieTools/UpdUtil/UpdUtil.cpp
+++ b/SandboxieTools/UpdUtil/UpdUtil.cpp
@@ -825,7 +825,7 @@ std::shared_ptr<SAddon> ReadAddon(const JSONObject& addon, const std::wstring& c
 
 	for (auto I = addon.begin(); I != addon.end(); ++I) {
 		if (I->first.find(L'-') != std::wstring::npos)
-			continue; // skip all entries containting "-"
+			continue; // skip all entries containing "-"
 		pAddon->Data.insert(*I);
 	}
 
@@ -1037,7 +1037,7 @@ int RemoveAddon(std::shared_ptr<SAddon> pAddon, const std::wstring& base_dir)
 	{
 		std::wstring cmdLine = ReadRegistryStringValue(pAddon->UninstallKey, L"UninstallString");
 		if(cmdLine.empty()) // when the expected uninstall key is not present,
-			return ret; // then seams addon was already uninstalled
+			return ret; // then it seems the addon was already uninstalled
 
 		STARTUPINFO si = { sizeof(si), 0 };
 		PROCESS_INFORMATION pi = { 0 };

--- a/SandboxieTools/UpdUtil/UpdUtil.cpp
+++ b/SandboxieTools/UpdUtil/UpdUtil.cpp
@@ -1453,7 +1453,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 		}
 
 		//
-		// load addons apropriate for the current installation
+		// load addons appropriate for the current installation
 		//
 
 		std::shared_ptr<TAddonMap> pAddons;
@@ -1507,12 +1507,12 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 					if (!I->second->IsDefault)
 						continue;
 
-					// dont add default addons marked to be removed
+					// don't add default addons marked to be removed
 					auto F = std::find(remove_addons.begin(), remove_addons.end(), I->first);
 					if (F != remove_addons.end())
 						continue;
 
-					// dont add already added addons
+					// don't add already added addons
 					F = std::find(add_addons.begin(), add_addons.end(), I->first);
 					if (F != add_addons.end())
 						continue;

--- a/SandboxieTools/UpdUtil/UpdUtil.h
+++ b/SandboxieTools/UpdUtil/UpdUtil.h
@@ -36,7 +36,7 @@
 #define ERROR_CANCELED		(-9)
 #define ERROR_INTERNAL		(-10)	// internal error, should not happen
 #define ERROR_NO_ADDON		(-11)	// addon not found
-#define ERROR_NO_ADDON2		(-12)	// no addon for this paltform or framework
+#define ERROR_NO_ADDON2		(-12)	// no addon for this platform or framework
 #define ERROR_BAD_ADDON		(-13)
 #define ERROR_BAD_ADDON2	(-14)
 #define ERROR_DELETE		(-15)


### PR DESCRIPTION
A fresh fork to update some files in which spelling mistakes and subsequently grammar mistakes have been found.

Some findings were not processed for being German strings (containing the word "vor") that got added by something. They might get treated differently by codespell. I am not going to mess with that.

Furthermore, `/SandboxiePlus/SandMan/Forms/OptionsWindow.ui:1381` was not addressed since that is a string and I am not confident about whenever it should be `Sandboxie's` or` Sandboxies'`.