### PR TITLE
Fix typos, tiny improvments.

### DIFF
--- a/Sandboxie/core/svc/ProcessServer.cpp
+++ b/Sandboxie/core/svc/ProcessServer.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004-2020 Sandboxie Holdings, LLC 
- * Copyright 2020-2021 David Xanatos, xanasoft.com
+ * Copyright 2020-2023 David Xanatos, xanasoft.com
  *
  * This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -1044,10 +1044,10 @@ BOOL ProcessServer::RunSandboxedSetDacl(
             //
 
             //
-            // in Sandboxie version 5.57 instead of using the anonymous SID 
+            // since Sandboxie version 5.57 instead of using the anonymous SID 
             // we can use box specific custom SIDs,
             // when comparing we skip the revision and the SubAuthorityCount
-            // also we conpare only the domain portion of the SID as the rest 
+            // also we compare only the domain portion of the SID as the rest 
             // will be different for each box
             //
            

--- a/SandboxiePlus/SandMan/CustomStyles.h
+++ b/SandboxiePlus/SandMan/CustomStyles.h
@@ -46,7 +46,7 @@ public:
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-// Keeps submenus visible when the mosue leaves
+// Keeps submenus visible when the mouse leaves them
 //
 
 class KeepSubMenusVisibleStyle : public QProxyStyle {

--- a/SandboxiePlus/SandMan/Views/TraceView.cpp
+++ b/SandboxiePlus/SandMan/Views/TraceView.cpp
@@ -132,7 +132,7 @@ CTraceTree::CTraceTree(QWidget* parent)
 	QByteArray Split = theConf->GetBlob("MainWindow/TraceSplitter");
 	if(!Split.isEmpty())
 		m_pSplitter->restoreState(Split);
-	//else { // by default colapse the details panel
+	//else { // by default collapse the details panel
 	//	auto Sizes = m_pSplitter->sizes();
 	//	Sizes[1] = 0;
 	//	m_pSplitter->setSizes(Sizes);


### PR DESCRIPTION
Fix spelling mistakes in comments, improve phrasing and bumping copyright.