### PR TITLE
Update sandman_de.ts

### DIFF
--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -1234,10 +1234,7 @@ Sie können %USER% verwenden, um für jeden Benutzer die Sandbox in einem eigene
         <source>Your Sandboxie-Plus supporter certificate is expired, however for the current build you are using it remains active, when you update to a newer build exclusive supporter features will be disabled.<byte value="xd"/>
 <byte value="xd"/>
 Do you still want to update?</source>
-        <oldsource>Your Sandboxie-Plus supporter certificate is expired, howeever for the current build you are using it remains active, when you update to a newer build exclusive supporter features will be disabled.<byte value="xd"/>
-<byte value="xd"/>
-Do you still want to update?</oldsource>
-        <translation type="unfinished">Ihr Sandboxie-Plus Unterstützerzertifikat ist abgelaufen, die aktuell von Ihnen verwendete Version bleibt jedoch aktiv; falls Sie aber zu einer neueren Version wechseln, werden exklusive Unterstützerfunktionen deaktiviert.
+        <translation type>Ihr Sandboxie-Plus Unterstützerzertifikat ist abgelaufen, die aktuell von Ihnen verwendete Version bleibt jedoch aktiv; falls Sie aber zu einer neueren Version wechseln, werden exklusive Unterstützerfunktionen deaktiviert.
 
 Möchten Sie dennoch updaten?</translation>
     </message>


### PR DESCRIPTION
Fresh fork to restore a translation after typo fix in the source, oldsource has been removed as it is not needed for reference. No changes to the content were made.

