### PR TITLE
Update german translation

### DIFF
--- a/SandboxiePlus/SandMan/Troubleshooting/lang_de.json
+++ b/SandboxiePlus/SandMan/Troubleshooting/lang_de.json
@@ -1,10 +1,10 @@
 {
-"Description Text...": "Beschreibungs Text...",
-"Fix current issues": "Aktuelle problemem beheben",
-"Fix issues with sandboxing": "Sandbox probleme beheben",
+"Description Text...": "Beschreibungstext...",
+"Fix current issues": "Aktuelle Probleme beheben",
+"Fix issues with sandboxing": "Sandboxprobleme beheben",
 "An Application does not work properly when sandboxed": "Eine Anwendung funktioniert nicht richtig",
-"Issues with a web browser": "Probleme mit Web browser beheben",
-"Perform Sandbox maintenance": "Sandbox Wartung",
+"Issues with a web browser": "Probleme mit Webbrowser beheben",
+"Perform Sandbox maintenance": "Sandboxwartung durchführen",
 "Fix issues with the UI or Shell": "UI Fehler beheben",
 
 "Yes": "Ja",
@@ -15,7 +15,7 @@
 "Loaded %1 templates": "%1 Vorlagen geladen",
 
 "Browser shortcut is missing from the desktop": "Browser-Verknüpfung fehlt auf dem Desktop",
-"This procedure will add a browser shortcut to the desktop": "Dieses Verfahren wird eine Browser-Verknüpfung zum Desktop hinzufügen",
+"This procedure will add a browser shortcut to the desktop": "Dieser Vorgang wird eine Browser-Verknüpfung zum Desktop hinzufügen",
 "Default Browser": "Standardbrowser",
 "Another": "Ein anderer",
 "Select Browser": "Browser auswählen",
@@ -24,7 +24,7 @@
 "Select Browser Path": "Browserpfad auswählen",
 
 "Explorer Context Menu extension does not work": "Explorer-Kontextmenü-Erweiterung funktioniert nicht",
-"This procedure will re install the shell integration": "Dieses Verfahren wird die Shell-Integration neu installieren",
+"This procedure will re install the shell integration": "Dieser Vorgang wird die Shell-Integration neu installieren",
 "Add Run Sandboxed": "Führe in Sandbox aus hinzufügen",
 "Add Run Unsandboxed": "Führe ohne Sandbox aus hinzufügen",
 "Install legacy shell extensions": "Legacy-Shell-Erweiterungen installieren",
@@ -37,11 +37,11 @@
 "Disable DropAdminRights": "DropAdminRights deaktivieren",
 "Enable FakeAdminRights": "FakeAdminRights aktivieren",
 "running installer, pid: %1 press NEXT once it finishes to continue": "Installer wird ausgeführt, pid: %1 drücken Sie auf WEITER, sobald er fertig ist, um fortzufahren",
-"Was the issue resolved?": "Wurde das problem behoben?",
+"Was the issue resolved?": "Wurde das Problem behoben?",
 
 "Webcam or Sound does not work when sandboxed": "Webcam oder Ton funktioniert nicht in einer Sandbox",
 "To enable webcam support on Windows 11, the isolation level must be reduced. \nIf you want to proceed, please press NEXT and select a sandbox to modify. \n": "Um die Webcam-Unterstützung unter Windows 11 zu aktivieren, muss das Isolationsniveau reduziert werden. \nWenn Sie fortfahren möchten, drücken Sie bitte auf WEITER und wählen eine Sandbox zur Modifikation aus. \n",
-"\nPlease note that this required preset works only with a valid supporter certificate!": "\nBitte beachten Sie, dass dieses erforderliche Voreinstellung nur mit einem gültigen Unterstützerzertifikat funktioniert!",
+"\nPlease note that this required preset works only with a valid supporter certificate!": "\nBitte beachten Sie, dass diese erforderliche Voreinstellung nur mit einem gültigen Unterstützerzertifikat funktioniert!",
 "Select which box to turn into a reduced isolation app compartment box.": "Wählen Sie, welche Box in eine Box mit reduziertem Isolations-App-Fach umgewandelt werden soll.",
-"The mitigation has been applied please try out the web cam in %1 and indicate if the issue has been resolved.": "Die Milderung wurde angewendet, bitte testen Sie die Webcam in %1 und geben an, ob das Problem behoben wurde."
+"The mitigation has been applied please try out the web cam in %1 and indicate if the issue has been resolved.": "Die Abhilfe wurde angewendet, bitte testen Sie die Webcam in %1 und geben an, ob das Problem behoben wurde."
 }

--- a/SandboxiePlus/SandMan/Troubleshooting/lang_de.json
+++ b/SandboxiePlus/SandMan/Troubleshooting/lang_de.json
@@ -42,6 +42,6 @@
 "Webcam or Sound does not work when sandboxed": "Webcam oder Ton funktioniert nicht in einer Sandbox",
 "To enable webcam support on Windows 11, the isolation level must be reduced. \nIf you want to proceed, please press NEXT and select a sandbox to modify. \n": "Um die Webcam-Unterstützung unter Windows 11 zu aktivieren, muss das Isolationsniveau reduziert werden. \nWenn Sie fortfahren möchten, drücken Sie bitte auf WEITER und wählen eine Sandbox zur Modifikation aus. \n",
 "\nPlease note that this required preset works only with a valid supporter certificate!": "\nBitte beachten Sie, dass diese erforderliche Voreinstellung nur mit einem gültigen Unterstützerzertifikat funktioniert!",
-"Select which box to turn into a reduced isolation app compartment box.": "Wählen Sie, welche Box in eine Box mit reduziertem Isolations-App-Fach umgewandelt werden soll.",
+"Select which box to turn into a reduced isolation app compartment box.": "Wählen Sie, welche Box in eine Applikationsunterteilungsbox mit reduzierter Isolation umgewandelt werden soll.",
 "The mitigation has been applied please try out the web cam in %1 and indicate if the issue has been resolved.": "Die Abhilfe wurde angewendet, bitte testen Sie die Webcam in %1 und geben an, ob das Problem behoben wurde."
 }

--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -2240,10 +2240,6 @@ Notiz: Die Updateprüfung ist oft zeitversetzt zu den letzten GitHub-Veröffentl
         <translation>Sandboxie-Plus Benachrichtigungen</translation>
     </message>
     <message>
-        <source>PID %1</source>
-        <translation type="vanished">PID %1</translation>
-    </message>
-    <message>
         <location filename="Windows/PopUpWindow.cpp" line="187"/>
         <source>Do you want to allow the print spooler to write outside the sandbox for %1 (%2)?</source>
         <translatorcomment>Kept &apos;print spooler&apos; in brackets to allow easier online lookup.</translatorcomment>
@@ -3107,7 +3103,7 @@ Anders als der Vorschaukanal, enthält es keine ungetesteten, möglicherweise fe
     <message>
         <location filename="SandMan.cpp" line="1899"/>
         <source>USB sandbox not found; creating: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>USB-Sandbox nicht gefunden; erzeuge: %1</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="2301"/>
@@ -4992,7 +4988,7 @@ This file is part of Sandboxie and all change done to it will be reverted next t
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="1187"/>
         <source>Volume not attached</source>
-        <translation type="unfinished"></translation>
+        <translation>Datenträger nicht eingesteckt</translation>
     </message>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="1208"/>
@@ -8571,27 +8567,27 @@ Anders als der Vorschaukanal, enthält es keine ungetesteten, möglicherweise fe
     <message>
         <location filename="Forms/SettingsWindow.ui" line="2257"/>
         <source>USB Drive Sandboxing</source>
-        <translation type="unfinished"></translation>
+        <translation>USB-Laufwerk Sandboxing</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="2273"/>
         <source>Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Datenträger</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="2278"/>
         <source>Information</source>
-        <translation type="unfinished"></translation>
+        <translation>Information</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="2286"/>
         <source>Sandbox for USB drives:</source>
-        <translation type="unfinished"></translation>
+        <translation>Sandbox für USB-Laufwerke:</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="2299"/>
         <source>Automatically sandbox all attached USB drives</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatisch alle eingesteckten USB-Laufwerke sandboxen</translation>
     </message>
     <message>
         <location filename="Forms/SettingsWindow.ui" line="2326"/>


### PR DESCRIPTION
Fresh fork to translate the new strings and to update the newly added troubleshooting translation for the German language.

I choose "Datenträger" for "Volume", as this should be more easily understood, compared to "Volumen", which is technically valid, but has other meanings as well.