### PR TITLE
Update sandman_de.ts

### DIFF
--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -4259,8 +4259,7 @@ This file is part of Sandboxie and all change done to it will be reverted next t
     <message>
         <location filename="SbiePlusAPI.cpp" line="1206"/>
         <source>Failed to enumerate installed Windows updates</source>
-        <oldsource>Failed to search for updates</oldsource>
-        <translation type="unfinished">Suche nach Updates fehlgeschlagen</translation>
+        <translation>Fehler beim Ermitteln der installierten Windowsupdates</translation>
     </message>
     <message>
         <location filename="SbiePlusAPI.cpp" line="1212"/>


### PR DESCRIPTION
Updated the changed string and removed its old source, as there is no reason to keep the reference.

The new string describes the error, and its translation gets that across, even though the word enumerate has other translations, but those don't really fit, IMO.
