### PR TITLE
[Chromium] Update browser paths

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -87,7 +87,7 @@ Tmpl.Chrome=%Local AppData%\Google\Chrome\User Data\Default
 Tmpl.Edge=%Local AppData%\Microsoft\Edge\User Data\Default
 Tmpl.Vivaldi=%Local AppData%\Vivaldi\User Data\Default
 Tmpl.Brave=%Local AppData%\BraveSoftware\Brave-Browser\User Data\Default
-Tmpl.Opera=%AppData%\Opera Software\Opera Stable
+Tmpl.Opera=%AppData%\Opera Software\Opera Stable\Default
 Tmpl.Yandex=%Local AppData%\Yandex\YandexBrowser\User Data\Default
 Tmpl.Ungoogled=%Local AppData%\Chromium\User Data\Default
 Tmpl.Iron=%Local AppData%\Chromium\User Data\Default
@@ -470,7 +470,7 @@ OpenIpcPath=*\BaseNamedObjects\windows_webcache_counters_*
 
 
 #
-# Windows Remote Management (WinRM) is a large security hole.  
+# Windows Remote Management (WinRM) is a large security hole.
 # A sandboxed app running in an elevated cmd shell can send any admin command to the host.
 # Block the WinRS.exe and the automation dlls to make it very difficult for someone to use.
 # See ICD-10136 "Sandboxie security hole allows guest to run any command in host as admin"
@@ -483,7 +483,7 @@ ClosedFilePath=|%SystemRoot%\Sys*\winrs.exe
 
 
 #
-# this template replaces OpenProtectedStorage=y 
+# this template replaces OpenProtectedStorage=y
 #
 
 [Template_OpenProtectedStorage]
@@ -942,7 +942,7 @@ OpenFilePath=chrome.exe,%Tmpl.Chrome%\Visited Links*
 [Template_Chrome_Cookies_DirectAccess]
 Tmpl.Title=#4328,Google Chrome
 Tmpl.Class=WebBrowser
-OpenFilePath=chrome.exe,%Tmpl.Chrome%\Cookies*
+OpenFilePath=chrome.exe,%Tmpl.Chrome%\Network\Cookies*
 
 [Template_Chrome_Passwords_DirectAccess]
 Tmpl.Title=#4331,Google Chrome
@@ -999,7 +999,7 @@ OpenFilePath=msedge.exe,%Tmpl.Edge%\Visited Links*
 [Template_Edge_Cookies_DirectAccess]
 Tmpl.Title=#4328,Microsoft Edge
 Tmpl.Class=WebBrowser
-OpenFilePath=msedge.exe,%Tmpl.Edge%\Cookies*
+OpenFilePath=msedge.exe,%Tmpl.Edge%\Network\Cookies*
 
 [Template_Edge_Passwords_DirectAccess]
 Tmpl.Title=#4331,Microsoft Edge
@@ -1074,7 +1074,7 @@ OpenFilePath=vivaldi.exe,%Tmpl.Vivaldi%\Visited Links*
 [Template_Vivaldi_Cookies_DirectAccess]
 Tmpl.Title=#4328,Vivaldi
 Tmpl.Class=WebBrowser
-OpenFilePath=vivaldi.exe,%Tmpl.Vivaldi%\Cookies*
+OpenFilePath=vivaldi.exe,%Tmpl.Vivaldi%\Network\Cookies*
 
 [Template_Vivaldi_Notes_DirectAccess]
 Tmpl.Title=#4341,Vivaldi
@@ -1140,7 +1140,7 @@ OpenFilePath=brave.exe,%Tmpl.Brave%\Visited Links*
 [Template_Brave_Cookies_DirectAccess]
 Tmpl.Title=#4328,Brave Browser
 Tmpl.Class=WebBrowser
-OpenFilePath=brave.exe,%Tmpl.Brave%\Cookies*
+OpenFilePath=brave.exe,%Tmpl.Brave%\Network\Cookies*
 
 [Template_Brave_Passwords_DirectAccess]
 Tmpl.Title=#4331,Brave Browser
@@ -1200,7 +1200,7 @@ OpenFilePath=opera.exe,%Tmpl.Opera%\Visited Links*
 [Template_Opera_Cookies_DirectAccess]
 Tmpl.Title=#4328,Opera
 Tmpl.Class=WebBrowser
-OpenFilePath=opera.exe,%Tmpl.Opera%\Cookies*
+OpenFilePath=opera.exe,%Tmpl.Opera%\Network\Cookies*
 
 [Template_Opera_Passwords_DirectAccess]
 Tmpl.Title=#4331,Opera
@@ -1261,7 +1261,7 @@ OpenFilePath=browser.exe,%Tmpl.Yandex%\Visited Links*
 [Template_Yandex_Cookies_DirectAccess]
 Tmpl.Title=#4328,Yandex Browser
 Tmpl.Class=WebBrowser
-OpenFilePath=browser.exe,%Tmpl.Yandex%\Cookies*
+OpenFilePath=browser.exe,%Tmpl.Yandex%\Network\Cookies*
 
 [Template_Yandex_Passwords_DirectAccess]
 Tmpl.Title=#4331,Yandex Browser
@@ -1321,7 +1321,7 @@ OpenFilePath=chrome.exe,%Tmpl.Ungoogled%\Visited Links*
 [Template_Ungoogled_Cookies_DirectAccess]
 Tmpl.Title=#4328,Ungoogled Chromium
 Tmpl.Class=WebBrowser
-OpenFilePath=chrome.exe,%Tmpl.Ungoogled%\Cookies*
+OpenFilePath=chrome.exe,%Tmpl.Ungoogled%\Network\Cookies*
 
 [Template_Ungoogled_Passwords_DirectAccess]
 Tmpl.Title=#4331,Ungoogled Chromium
@@ -1375,7 +1375,7 @@ OpenFilePath=chrome.exe,%Tmpl.Iron%\Visited Links*
 [Template_Iron_Cookies_DirectAccess]
 Tmpl.Title=#4328,SRWare Iron
 Tmpl.Class=WebBrowser
-OpenFilePath=chrome.exe,%Tmpl.Iron%\Cookies*
+OpenFilePath=chrome.exe,%Tmpl.Iron%\Network\Cookies*
 
 [Template_Iron_Passwords_DirectAccess]
 Tmpl.Title=#4331,SRWare Iron
@@ -1435,7 +1435,7 @@ OpenFilePath=Maxthon.exe,%Tmpl.Maxthon_6%\Visited Links*
 [Template_Maxthon6_Cookies_DirectAccess]
 Tmpl.Title=#4328,Maxthon 6
 Tmpl.Class=WebBrowser
-OpenFilePath=Maxthon.exe,%Tmpl.Maxthon_6%\Cookies*
+OpenFilePath=Maxthon.exe,%Tmpl.Maxthon_6%\Network\Cookies*
 
 [Template_Maxthon6_Passwords_DirectAccess]
 Tmpl.Title=#4331,Maxthon 6
@@ -1490,7 +1490,7 @@ OpenFilePath=dragon.exe,%Tmpl.Dragon%\Visited Links*
 [Template_Dragon_Cookies_DirectAccess]
 Tmpl.Title=#4328,Comodo Dragon
 Tmpl.Class=WebBrowser
-OpenFilePath=dragon.exe,%Tmpl.Dragon%\Cookies*
+OpenFilePath=dragon.exe,%Tmpl.Dragon%\Network\Cookies*
 
 [Template_Dragon_Passwords_DirectAccess]
 Tmpl.Title=#4331,Comodo Dragon
@@ -1605,7 +1605,7 @@ OpenFilePath=slimjet.exe,%Tmpl.Slimjet%\Visited Links*
 [Template_Slimjet_Cookies_DirectAccess]
 Tmpl.Title=#4328,Slimjet
 Tmpl.Class=WebBrowser
-OpenFilePath=slimjet.exe,%Tmpl.Slimjet%\Cookies*
+OpenFilePath=slimjet.exe,%Tmpl.Slimjet%\Network\Cookies*
 
 [Template_Slimjet_Passwords_DirectAccess]
 Tmpl.Title=#4331,Slimjet

--- a/SandboxiePlus/SandMan/Wizards/TemplateWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/TemplateWizard.cpp
@@ -207,7 +207,7 @@ bool CTemplateWizard::CreateNewTemplate(CSandBox* pBox, ETemplateType Type, QWid
                         QSharedPointer<CSbieIni> pTemplate = QSharedPointer<CSbieIni>(new CSbieIni("Template_Local_" + Section + "_Cookies_DirectAccess", theAPI));
                         pTemplate->SetText("Tmpl.Title", tr("Allow direct access to %1 cookies").arg(Name));
                         pTemplate->SetText("Tmpl.Class", "Local");
-                        pTemplate->AppendText("OpenFilePath", BrowserBinary + "," + ProfilePath + "*\\Cookies*");
+                        pTemplate->AppendText("OpenFilePath", BrowserBinary + "," + ProfilePath + "*\\Network\\Cookies*");
 
                         if (wizard.field("cookies").toBool() && pBox)
                             pBox->AppendText("Template", pTemplate->GetName().mid(9));


### PR DESCRIPTION
1) Updated most Chromium templates ending with "Cookies_DirectAccess" , here the directory `\Network` must be added before `\Cookies*` (except the entry related to [Osiris browser](https://github.com/sandboxie-plus/Sandboxie/pull/3436#issuecomment-1817672861))

2) The `\Default` directory must be appended to the "Tmpl.Opera" variable

3) Fixed some trailing spaces

4) Updated browser template wizard for Chromium