### PR TITLE
Fix translation error

### DIFF
--- a/SandboxiePlus/SandMan/sandman_zh_CN.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_CN.ts
@@ -7999,7 +7999,7 @@ Sandboxie 提供了针对这些情况的处理选项，可以在此页面进行�
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1470"/>
         <source>Allow Process</source>
-        <translation>所有进程</translation>
+        <translation>允许进程</translation>
     </message>
     <message>
         <location filename="Forms/OptionsWindow.ui" line="1395"/>


### PR DESCRIPTION
The translation for "Allow Process" should be “允许进程” rather than “全部进程”.