### PR TITLE
Prevents processes in the sandbox from capturing screen images.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - added menu entry to restart Sandman as admin [#3581](https://github.com/sandboxie-plus/Sandboxie/issues/3581) (thx Yeyixiao)
-- added option to block in-sandbox program to intercept sandbox window images [#1985](https://github.com/sandboxie-plus/Sandboxie/issues/1985) (thx Yeyixiao)
+- Added the option to prevent sandboxed programs from accessing the images of the window outside the sandbox [#1985](https://github.com/sandboxie-plus/Sandboxie/issues/1985) (thx Yeyixiao)
 - added option to protect the window image of the in-sandbox process from being truncated (thx Yeyixiao)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - added menu entry to restart Sandman as admin [#3581](https://github.com/sandboxie-plus/Sandboxie/issues/3581) (thx Yeyixiao)
-- added option to block taking screen capture/screenshot of sandboxed processes [#624](https://github.com/sandboxie-plus/Sandboxie/issues/624) (thx Yeyixiao)
+- added option to block in-sandbox program to intercept sandbox window images [#1985](https://github.com/sandboxie-plus/Sandboxie/issues/1985) (thx Yeyixiao)
+- added option to protect the window image of the in-sandbox process from being truncated (thx Yeyixiao)
 
 ### Fixed
 - fixed shortcut issue with suspending all processes [#3582](https://github.com/sandboxie-plus/Sandboxie/issues/3582#issuecomment-1969628215)

--- a/Sandboxie/core/dll/gui.c
+++ b/Sandboxie/core/dll/gui.c
@@ -380,6 +380,9 @@ _FX BOOLEAN Gui_Init(HMODULE module)
     Gui_UseProxyService = !Dll_CompartmentMode && !SbieApi_QueryConfBool(NULL, L"NoSandboxieDesktop", FALSE);
     // NoSbieDesk END
 
+	GUI_IMPORT___(GetWindowDC)
+	GUI_IMPORT___(GetDC)
+	GUI_IMPORT___(GetDCEx)
     GUI_IMPORT___(GetWindowThreadProcessId);
     GUI_IMPORT___(SetThreadDesktop);
     GUI_IMPORT___(SwitchDesktop);

--- a/Sandboxie/core/dll/gui.c
+++ b/Sandboxie/core/dll/gui.c
@@ -380,6 +380,7 @@ _FX BOOLEAN Gui_Init(HMODULE module)
     Gui_UseProxyService = !Dll_CompartmentMode && !SbieApi_QueryConfBool(NULL, L"NoSandboxieDesktop", FALSE);
     // NoSbieDesk END
 
+	GUI_IMPORT___(PrintWindow)
 	GUI_IMPORT___(GetWindowDC)
 	GUI_IMPORT___(GetDC)
 	GUI_IMPORT___(GetDCEx)

--- a/Sandboxie/core/dll/gui_p.h
+++ b/Sandboxie/core/dll/gui_p.h
@@ -418,6 +418,8 @@ typedef HDC(*P_GetDC)(HWND hWnd);
 
 typedef HDC(*P_GetDCEx)(HWND hWnd,HRGN hrgnClip,DWORD flags);
 
+typedef BOOL (*P_PrintWindow)(HWND hwnd,HDC  hdcBlt,UINT nFlags);
+
 typedef BOOL (*P_SetThreadDesktop)(HDESK hDesktop);
 
 typedef BOOL (*P_SwitchDesktop)(HDESK hDesktop);
@@ -543,6 +545,7 @@ extern ATOM Gui_WindowProcOldA_Atom;
 GUI_SYS_VAR(GetDC)
 GUI_SYS_VAR(GetDCEx)
 GUI_SYS_VAR(GetWindowDC)
+GUI_SYS_VAR(PrintWindow)
 
 GUI_SYS_VAR(ClipCursor)
 GUI_SYS_VAR(GetClipCursor)

--- a/Sandboxie/core/dll/gui_p.h
+++ b/Sandboxie/core/dll/gui_p.h
@@ -412,11 +412,11 @@ typedef int (*P_LoadString)(
 
 typedef BOOL (*P_SetProcessWindowStation)(HWINSTA hWinSta);
 
-typedef BOOL(*P_GetWindowDC)(HWND hWnd);
+typedef HDC(*P_GetWindowDC)(HWND hWnd);
 
-typedef BOOL(*P_GetDC)(HWND hWnd);
+typedef HDC(*P_GetDC)(HWND hWnd);
 
-typedef BOOL(*P_GetDCEx)(HWND hWnd,HRGN hrgnClip,DWORD flags);
+typedef HDC(*P_GetDCEx)(HWND hWnd,HRGN hrgnClip,DWORD flags);
 
 typedef BOOL (*P_SetThreadDesktop)(HDESK hDesktop);
 

--- a/Sandboxie/core/dll/gui_p.h
+++ b/Sandboxie/core/dll/gui_p.h
@@ -412,6 +412,12 @@ typedef int (*P_LoadString)(
 
 typedef BOOL (*P_SetProcessWindowStation)(HWINSTA hWinSta);
 
+typedef BOOL(*P_GetWindowDC)(HWND hWnd);
+
+typedef BOOL(*P_GetDC)(HWND hWnd);
+
+typedef BOOL(*P_GetDCEx)(HWND hWnd,HRGN hrgnClip,DWORD flags);
+
 typedef BOOL (*P_SetThreadDesktop)(HDESK hDesktop);
 
 typedef BOOL (*P_SwitchDesktop)(HDESK hDesktop);
@@ -534,6 +540,9 @@ extern ATOM Gui_WindowProcOldA_Atom;
 #endif
 #define GUI_SYS_VAR_2(nm)       GUI_SYS_VAR_AW(nm,A); GUI_SYS_VAR_AW(nm,W);
 
+GUI_SYS_VAR(GetDC)
+GUI_SYS_VAR(GetDCEx)
+GUI_SYS_VAR(GetWindowDC)
 
 GUI_SYS_VAR(ClipCursor)
 GUI_SYS_VAR(GetClipCursor)

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -1519,7 +1519,7 @@ _FX HDC Gui_GetDCEx(HWND hWnd,HRGN  hrgnClip,DWORD flags)
 	}
 	return __sys_GetWindowDC(hWnd);
 }
-_FX BOOL PrintWindow(
+_FX BOOL Gui_PrintWindow(
 	HWND hwnd,
 	HDC  hdcBlt,
 	UINT nFlags

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -1472,12 +1472,12 @@ _FX BOOL Gui_ImmAssociateContextEx(
 _FX HDC Gui_GetDC(HWND hWnd)
 {
 	if (SbieApi_QueryConfBool(NULL, L"IsBlockCapture", FALSE)) {
-		if (hWnd == NULL || hWnd == GetDesktopWindow()) {
+		if (hWnd == NULL || hWnd == __sys_GetDesktopWindow()) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
 		ULONG_PTR pid=0, tid=0;
-		if (!Gui_IsSameBox(hWnd, pid, tid)) {
+		if (!Gui_IsSameBox(hWnd, &pid, &tid)) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
@@ -1488,12 +1488,12 @@ _FX HDC Gui_GetDC(HWND hWnd)
 _FX HDC Gui_GetWindowDC(HWND hWnd)
 {
 	if (SbieApi_QueryConfBool(NULL, L"IsBlockCapture", FALSE)) {
-		if (hWnd == NULL || hWnd == GetDesktopWindow()) {
+		if (hWnd == NULL || hWnd == __sys_GetDesktopWindow()) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
 		ULONG_PTR pid = 0, tid = 0;
-		if (!Gui_IsSameBox(hWnd, pid, tid)) {
+		if (!Gui_IsSameBox(hWnd, &pid, &tid)) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
@@ -1504,12 +1504,13 @@ _FX HDC Gui_GetWindowDC(HWND hWnd)
 _FX HDC Gui_GetDCEx(HWND hWnd,HRGN  hrgnClip,DWORD flags)
 {
 	if (SbieApi_QueryConfBool(NULL, L"IsBlockCapture", FALSE)) {
-		if (hWnd == NULL || hWnd == GetDesktopWindow()) {
+		if (hWnd == NULL || hWnd == __sys_GetDesktopWindow()) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
 		ULONG_PTR pid = 0, tid = 0;
-		if (!Gui_IsSameBox(hWnd, pid, tid)) {
+
+		if (!Gui_IsSameBox(hWnd, &pid, &tid)) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -1476,7 +1476,7 @@ _FX HDC Gui_GetDC(HWND hWnd)
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
-		ULONG_PTR pid, tid;
+		ULONG_PTR pid=0, tid=0;
 		if (!Gui_IsSameBox(hWnd, pid, tid)) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
@@ -1492,7 +1492,7 @@ _FX HDC Gui_GetWindowDC(HWND hWnd)
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
-		ULONG_PTR pid, tid;
+		ULONG_PTR pid = 0, tid = 0;
 		if (!Gui_IsSameBox(hWnd, pid, tid)) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
@@ -1508,7 +1508,7 @@ _FX HDC Gui_GetDCEx(HWND hWnd,HRGN  hrgnClip,DWORD flags)
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;
 		}
-		ULONG_PTR pid, tid;
+		ULONG_PTR pid = 0, tid = 0;
 		if (!Gui_IsSameBox(hWnd, pid, tid)) {
 			SetLastError(ERROR_ACCESS_DENIED);
 			return NULL;

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -99,6 +99,9 @@ static LONG Gui_GetRawInputDeviceInfoW(
     _In_opt_ HANDLE hDevice, _In_ UINT uiCommand,
     _Inout_ LPVOID pData, _Inout_ PUINT pcbSize);
 
+static HDC Gui_GetDC(HWND hWnd);
+static HDC Gui_GetWindowDC(HWND hWnd);
+static HDC Gui_GetDCEx(HWND hWnd, HRGN  hrgnClip, DWORD flags);
 //---------------------------------------------------------------------------
 
 

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -176,7 +176,9 @@ _FX BOOLEAN Gui_InitMisc(HMODULE module)
         }
         SBIEDLL_HOOK_GUI(SwapMouseButton);
         SBIEDLL_HOOK_GUI(SetDoubleClickTime);
-
+		SBIEDLL_HOOK_GUI(GetWindowDC)
+		SBIEDLL_HOOK_GUI(GetDC)
+		SBIEDLL_HOOK_GUI(GetDCEx)
         if (Dll_OsBuild >= 6000) {
 
             //
@@ -1457,4 +1459,57 @@ _FX BOOL Gui_ImmAssociateContextEx(
     }
 
     return ok;
+}
+
+//---------------------------------------------------------------------------
+// Gui_GetDC
+//---------------------------------------------------------------------------
+
+
+_FX HDC Gui_GetDC(HWND hWnd)
+{
+	if (SbieApi_QueryConfBool(NULL, L"IsBlockCapture", FALSE)) {
+		if (hWnd == NULL || hWnd == GetDesktopWindow()) {
+			SetLastError(ERROR_ACCESS_DENIED);
+			return NULL;
+		}
+		ULONG_PTR pid, tid;
+		if (!Gui_IsSameBox(hWnd, pid, tid)) {
+			SetLastError(ERROR_ACCESS_DENIED);
+			return NULL;
+		}
+	}
+	return __sys_GetDC(hWnd);
+}
+
+_FX HDC Gui_GetWindowDC(HWND hWnd)
+{
+	if (SbieApi_QueryConfBool(NULL, L"IsBlockCapture", FALSE)) {
+		if (hWnd == NULL || hWnd == GetDesktopWindow()) {
+			SetLastError(ERROR_ACCESS_DENIED);
+			return NULL;
+		}
+		ULONG_PTR pid, tid;
+		if (!Gui_IsSameBox(hWnd, pid, tid)) {
+			SetLastError(ERROR_ACCESS_DENIED);
+			return NULL;
+		}
+	}
+	return __sys_GetWindowDC(hWnd);
+}
+
+_FX HDC Gui_GetDCEx(HWND hWnd,HRGN  hrgnClip,DWORD flags)
+{
+	if (SbieApi_QueryConfBool(NULL, L"IsBlockCapture", FALSE)) {
+		if (hWnd == NULL || hWnd == GetDesktopWindow()) {
+			SetLastError(ERROR_ACCESS_DENIED);
+			return NULL;
+		}
+		ULONG_PTR pid, tid;
+		if (!Gui_IsSameBox(hWnd, pid, tid)) {
+			SetLastError(ERROR_ACCESS_DENIED);
+			return NULL;
+		}
+	}
+	return __sys_GetWindowDC(hWnd);
 }

--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -45,7 +45,7 @@
         <enum>QTabWidget::North</enum>
        </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="tabGeneral">
         <attribute name="title">
@@ -55,7 +55,7 @@
          <item row="0" column="0">
           <widget class="QTabWidget" name="tabsGeneral">
            <property name="currentIndex">
-            <number>0</number>
+            <number>3</number>
            </property>
            <widget class="QWidget" name="tabOptions">
             <attribute name="title">
@@ -665,182 +665,192 @@
             <attribute name="title">
              <string>Restrictions</string>
             </attribute>
-            <layout class="QGridLayout" name="gridLayout_37">
-             <item row="0" column="0">
-              <layout class="QGridLayout" name="gridLayout_36">
-               <item row="9" column="2">
-                <widget class="QCheckBox" name="chkOpenCredentials">
-                 <property name="text">
-                  <string>Open Windows Credentials Store (user mode)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="2">
-                <spacer name="horizontalSpacer_5">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="10" column="1" colspan="2">
-                <widget class="QCheckBox" name="chkCloseClipBoard">
-                 <property name="text">
-                  <string>Block read access to the clipboard</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="0">
-                <spacer name="verticalSpacer_12">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="2" column="1" colspan="2">
-                <widget class="QCheckBox" name="chkBlockNetParam">
-                 <property name="text">
-                  <string>Prevent change to network and firewall parameters (user mode)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="1" colspan="2">
-                <widget class="QCheckBox" name="chkVmRead">
-                 <property name="text">
-                  <string>Allow to read memory of unsandboxed processes (not recommended)</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1" colspan="2">
-                <widget class="QCheckBox" name="chkBlockSpooler">
-                 <property name="text">
-                  <string>Block access to the printer spooler</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="2">
-                <widget class="QCheckBox" name="chkPrintToFile">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Allow the print spooler to print to files outside the sandbox</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1" colspan="2">
-                <widget class="QCheckBox" name="chkBlockNetShare">
-                 <property name="text">
-                  <string>Block network files and folders, unless specifically opened.</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="2">
-                <widget class="QCheckBox" name="chkOpenSpooler">
-                 <property name="text">
-                  <string>Remove spooler restriction, printers can be installed outside the sandbox</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="1" colspan="2">
-                <widget class="QCheckBox" name="chkOpenProtectedStorage">
-                 <property name="text">
-                  <string>Open System Protected Storage</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="2">
-                <widget class="QCheckBox" name="chkVmReadNotify">
-                 <property name="text">
-                  <string>Issue message 2111 when a process access is denied</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0" colspan="2">
-                <widget class="QLabel" name="lblOther">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                   <kerning>true</kerning>
-                  </font>
-                 </property>
-                 <property name="toolTip">
-                  <string>Protect the system from sandboxed processes</string>
-                 </property>
-                 <property name="text">
-                  <string>Other restrictions</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="1">
-                <widget class="QLabel" name="label_39">
-                 <property name="minimumSize">
-                  <size>
-                   <width>20</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>20</width>
-                   <height>16777215</height>
-                  </size>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0" colspan="2">
-                <widget class="QLabel" name="lblPrinting">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                   <kerning>true</kerning>
-                  </font>
-                 </property>
-                 <property name="toolTip">
-                  <string>Protect the system from sandboxed processes</string>
-                 </property>
-                 <property name="text">
-                  <string>Printing restrictions</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0" colspan="2">
-                <widget class="QLabel" name="lblNetwork">
-                 <property name="font">
-                  <font>
-                   <weight>75</weight>
-                   <bold>true</bold>
-                   <kerning>true</kerning>
-                  </font>
-                 </property>
-                 <property name="toolTip">
-                  <string>Protect the system from sandboxed processes</string>
-                 </property>
-                 <property name="text">
-                  <string>Network restrictions</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+            <layout class="QGridLayout" name="gridLayout_36">
+             <item row="0" column="0" colspan="2">
+              <widget class="QLabel" name="lblNetwork">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                 <kerning>true</kerning>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>Protect the system from sandboxed processes</string>
+               </property>
+               <property name="text">
+                <string>Network restrictions</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkBlockNetShare">
+               <property name="text">
+                <string>Block network files and folders, unless specifically opened.</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkBlockNetParam">
+               <property name="text">
+                <string>Prevent change to network and firewall parameters (user mode)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0" colspan="2">
+              <widget class="QLabel" name="lblPrinting">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                 <kerning>true</kerning>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>Protect the system from sandboxed processes</string>
+               </property>
+               <property name="text">
+                <string>Printing restrictions</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkBlockSpooler">
+               <property name="text">
+                <string>Block access to the printer spooler</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QCheckBox" name="chkOpenSpooler">
+               <property name="text">
+                <string>Remove spooler restriction, printers can be installed outside the sandbox</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="2">
+              <widget class="QCheckBox" name="chkPrintToFile">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Allow the print spooler to print to files outside the sandbox</string>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="0">
+              <widget class="QLabel" name="lblOther">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                 <kerning>true</kerning>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>Protect the system from sandboxed processes</string>
+               </property>
+               <property name="text">
+                <string>Other restrictions</string>
+               </property>
+              </widget>
+             </item>
+             <item row="8" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkOpenProtectedStorage">
+               <property name="text">
+                <string>Open System Protected Storage</string>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="1">
+              <widget class="QLabel" name="label_39">
+               <property name="minimumSize">
+                <size>
+                 <width>20</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>20</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="2">
+              <widget class="QCheckBox" name="chkOpenCredentials">
+               <property name="text">
+                <string>Open Windows Credentials Store (user mode)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="10" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkCloseClipBoard">
+               <property name="text">
+                <string>Block read access to the clipboard</string>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkVmRead">
+               <property name="text">
+                <string>Allow to read memory of unsandboxed processes (not recommended)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="12" column="2">
+              <widget class="QCheckBox" name="chkVmReadNotify">
+               <property name="text">
+                <string>Issue message 2111 when a process access is denied</string>
+               </property>
+              </widget>
+             </item>
+             <item row="13" column="0" rowspan="2">
+              <spacer name="verticalSpacer_12">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>43</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="13" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkBlockCapture">
+               <property name="text">
+                <string>Prevents an in-sandbox process from performing cross-sandbox window image manipulation.</string>
+               </property>
+              </widget>
+             </item>
+             <item row="14" column="2">
+              <widget class="QLabel" name="label_19">
+               <property name="text">
+                <string>(for example, screenshots) </string>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="2">
+              <spacer name="horizontalSpacer_5">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>556</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </widget>
@@ -1004,7 +1014,7 @@
          <item row="0" column="0">
           <widget class="QTabWidget" name="tabsSecurity">
            <property name="currentIndex">
-            <number>2</number>
+            <number>1</number>
            </property>
            <widget class="QWidget" name="tabHarden">
             <attribute name="title">
@@ -1442,6 +1452,7 @@
               <widget class="QLabel" name="lblBoxProtection">
                <property name="font">
                 <font>
+                 <weight>75</weight>
                  <bold>true</bold>
                  <kerning>true</kerning>
                 </font>
@@ -4949,7 +4960,6 @@ Please note that this values are currently user specific and saved globally for 
  </widget>
  <tabstops>
   <tabstop>tabs</tabstop>
-  <tabstop>tabsGeneral</tabstop>
   <tabstop>cmbBoxIndicator</tabstop>
   <tabstop>cmbBoxBorder</tabstop>
   <tabstop>btnBorderColor</tabstop>

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -521,6 +521,8 @@ void COptionsWindow::UpdateBoxIsolation()
 	ui.chkCloseClipBoard->setEnabled(!ui.chkNoSecurityIsolation->isChecked());
 	ui.chkVmRead->setEnabled(!ui.chkNoSecurityIsolation->isChecked());
 
+	ui.chkBlockCapture->setEnabled(!ui.chkNoSecurityIsolation->isChecked());
+
 	ui.chkCloseForBox->setEnabled(!ui.chkNoSecurityIsolation->isChecked());
 	ui.chkNoOpenForBox->setEnabled(!ui.chkNoSecurityIsolation->isChecked());
 

--- a/SandboxiePlus/SandMan/Windows/OptionsGeneral.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsGeneral.cpp
@@ -166,6 +166,7 @@ void COptionsWindow::CreateGeneral()
 	connect(ui.chkOpenProtectedStorage, SIGNAL(clicked(bool)), this, SLOT(OnPSTChanged()));
 	connect(ui.chkOpenCredentials, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
 	connect(ui.chkCloseClipBoard, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
+	connect(ui.chkBlockCapture, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
 	connect(ui.chkVmRead, SIGNAL(clicked(bool)), this, SLOT(OnVmRead()));
 	connect(ui.chkVmReadNotify, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
 	//connect(ui.chkOpenSmartCard, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
@@ -282,6 +283,7 @@ void COptionsWindow::LoadGeneral()
 	ui.chkOpenProtectedStorage->setChecked(m_BoxTemplates.contains("OpenProtectedStorage"));
 	ui.chkOpenCredentials->setChecked(!ui.chkOpenCredentials->isEnabled() || m_pBox->GetBool("OpenCredentials", false));
 	ui.chkCloseClipBoard->setChecked(!m_pBox->GetBool("OpenClipboard", true));
+	ui.chkBlockCapture->setChecked(m_pBox->GetBool("IsBlockCapture", false));
 	ui.chkVmReadNotify->setChecked(m_pBox->GetBool("NotifyProcessAccessDenied", false));
 	//ui.chkOpenSmartCard->setChecked(m_pBox->GetBool("OpenSmartCard", true));
 	//ui.chkOpenBluetooth->setChecked(m_pBox->GetBool("OpenBluetooth", false));
@@ -416,6 +418,7 @@ void COptionsWindow::SaveGeneral()
 	if (ui.chkOpenCredentials->isEnabled())
 		WriteAdvancedCheck(ui.chkOpenCredentials, "OpenCredentials", "y", "");
 	WriteAdvancedCheck(ui.chkCloseClipBoard, "OpenClipboard", "n", "");
+	WriteAdvancedCheck(ui.chkBlockCapture, "IsBlockCapture", "y", "n");
 	WriteAdvancedCheck(ui.chkVmReadNotify, "NotifyProcessAccessDenied", "y", "");
 	//WriteAdvancedCheck(ui.chkOpenSmartCard, "OpenSmartCard", "", "n");
 	//WriteAdvancedCheck(ui.chkOpenBluetooth, "OpenBluetooth", "y", "");


### PR DESCRIPTION
By hooking on Apis such as GetDC, attempts to get an out-sandbox window HDC or a desktop window HDC are intercepted.
https://github.com/sandboxie-plus/Sandboxie/issues/624
https://github.com/sandboxie-plus/Sandboxie/issues/1985