### PR TITLE
Build Sandboxie-Plus with Qt 5.15.13 (L)GPL instead of 5.15.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,11 +60,7 @@ jobs:
     #     arch:  'win64_msvc2019_64'
 
     - name: Install Qt5 x64
-      uses: jurplel/install-qt-action@v3
-      with:
-        version: '5.15.2'
-        arch:  'win64_msvc2019_64'
-        cache: true
+      run: SandboxiePlus\install_qt.cmd x64
 
     - name: Installing Jom
       run: SandboxiePlus\install_jom.cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,15 +57,7 @@ jobs:
 #          cache: true
 
       - name: Install Qt5 x64
-        uses: jurplel/install-qt-action@v3
-        with:
-          version: '5.15.2'
-      #    dir: ..
-      #    arch:  ${{ matrix.qt-target }}
-          arch:  'win64_msvc2019_64'
-      #    tools: 'tools_qtcreator,4.14.0-0-202012170949,qt.tools.qtcreator'
-      #    cached: ${{ steps.cache-qt.outputs.cache-hit }}
-          cache: true
+        run: SandboxiePlus\install_qt.cmd x64
 
       - name: Installing Jom
       #  if: steps.cache-qt.outputs.cache-hit != 'true'
@@ -96,7 +88,7 @@ jobs:
 #        run: Installer\fix_qt6_win7.cmd
 
       - name: Add missing languages for Qt5 (issue 1528)
-        run: Installer\fix_qt5_languages.cmd Win32
+        run: Installer\fix_qt5_languages.cmd x64
 
       - name: Get openssl binaries
         run: Installer\get_openssl.cmd
@@ -246,15 +238,7 @@ jobs:
     #
 
       - name: Install Qt5 x86
-        uses: jurplel/install-qt-action@v3
-        with:
-          version: '5.15.2'
-      #    dir: ..
-      #    arch:  ${{ matrix.qt-target }}
-          arch:  'win32_msvc2019'
-      #    tools: 'tools_qtcreator,4.14.0-0-202012170949,qt.tools.qtcreator'
-      #    cached: ${{ steps.cache-qt.outputs.cache-hit }}
-          cache: true
+        run: SandboxiePlus\install_qt.cmd Win32
 
       - name: Installing Jom
       #  if: steps.cache-qt.outputs.cache-hit != 'true'

--- a/Installer/copy_build.cmd
+++ b/Installer/copy_build.cmd
@@ -3,14 +3,14 @@ REM @ECHO OFF
 IF %1 == x86 (
   set archPath=Win32
   call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
-  set qtPath=%~dp0..\..\Qt\5.15.2\msvc2019
+  set qtPath=%~dp0..\..\Qt\5.15.13\msvc2019
   set instPath=%~dp0\SbiePlus_x86
 )
 IF %1 == x64 (
   set archPath=x64
   call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 REM  set qtPath=%~dp0..\..\Qt\6.3.1\msvc2019_64
-  set qtPath=%~dp0..\..\Qt\5.15.2\msvc2019_64
+  set qtPath=%~dp0..\..\Qt\5.15.13\msvc2019_64
   set instPath=%~dp0\SbiePlus_x64
 )
 IF %1 == ARM64 (

--- a/Installer/fix_qt5_languages.cmd
+++ b/Installer/fix_qt5_languages.cmd
@@ -1,3 +1,5 @@
+if %1 == x64 if exist %~dp0..\..\Qt\5.15.13\msvc2019_64\bin\lrelease.exe set PATH=%PATH%;%~dp0..\..\Qt\5.15.13\msvc2019_64\bin\
+if %1 == Win32 if exist %~dp0..\..\Qt\5.15.13\msvc2019\bin\lrelease.exe set PATH=%PATH%;%~dp0..\..\Qt\5.15.13\msvc2019\bin\
 mkdir %~dp0qttranslations
 mkdir %~dp0qttranslations\ts
 mkdir %~dp0qttranslations\qm

--- a/SandboxiePlus/ReadMe.md
+++ b/SandboxiePlus/ReadMe.md
@@ -8,7 +8,7 @@ Sandboxie Plus builds under Visual Studio 2019, as it offers the widest compatib
 1) We will be installing Visual Studio Community Edition which is sufficient for our purposes, during the installation we need to take care of selecting a Windows SDK version which matches the WDK version we will be installing in the next step.
 	- If you have VS 2019 already installed, you can open the installer and check which SDK you have and add if necessary one matching the WDK.
 2) Next, we will install WDK 20xxx which is required to build the driver, the WDK installer installs the required VS plugin at the end.
-3) So far so good, at this point we already have all we need to build Sandboxie Classic. To build the SandMan UI of Sandboxie Plus, though, we also need the Qt Framework, we can use either 5.15.2 or 6.3.x, but since Qt 6.x does not support Windows 7 without custom patches to base components, we will stick with Qt 5.15.2 for this tutorial.
+3) So far so good, at this point we already have all we need to build Sandboxie Classic. To build the SandMan UI of Sandboxie Plus, though, we also need the Qt Framework, we can use either 5.15.13 or 6.3.x, but since Qt 6.x does not support Windows 7 without custom patches to base components, we will stick with Qt 5.15.13 for this tutorial.
 	- Note: however, if you want to build SandMan UI for ARM64, you will need to use Qt 6.3.x or later.
 4) We use Qt's online installer and select all required components. I like to also install the source and debug information, but this is just for convenience when debugging and not needed for the build process.
 5) Last but not least, we have to install the VS extension for Qt and configure it to point to our Qt installation.

--- a/SandboxiePlus/install_qt.cmd
+++ b/SandboxiePlus/install_qt.cmd
@@ -1,0 +1,22 @@
+if %1 == Win32 (
+    if exist %~dp0..\..\Qt\5.15.13\msvc2019\bin\qmake.exe goto done
+
+    curl -LsSO --output-dir %~dp0..\..\ https://github.com/LumitoLuma/qt-opensource-lts-builds/releases/download/v5.15.13-lgpl/qt-everywhere-5.15.13-Windows_10-MSVC2019-x86.7z
+    "C:\Program Files\7-Zip\7z.exe" x -aoa -o%~dp0..\..\Qt\ %~dp0..\..\qt-everywhere-5.15.13-Windows_10-MSVC2019-x86.7z
+    certutil -hashfile %~dp0..\..\qt-everywhere-5.15.13-Windows_10-MSVC2019-x86.7z SHA256 | find /i "b90392ed27bfa20cc8a9d2e42908c1a721d952ab4e7c7d70d478246437a8eeac"
+)
+if %1 == x64 (
+    if exist %~dp0..\..\Qt\5.15.13\msvc2019_64\bin\qmake.exe goto done
+
+    curl -LsSO --output-dir %~dp0..\..\ https://github.com/LumitoLuma/qt-opensource-lts-builds/releases/download/v5.15.13-lgpl/qt-everywhere-5.15.13-Windows_10-MSVC2019-x86_64.7z
+    "C:\Program Files\7-Zip\7z.exe" x -aoa -o%~dp0..\..\Qt\ %~dp0..\..\qt-everywhere-5.15.13-Windows_10-MSVC2019-x86_64.7z
+    certutil -hashfile %~dp0..\..\qt-everywhere-5.15.13-Windows_10-MSVC2019-x86_64.7z SHA256 | find /i "e17ece39f1f0521085fa8d9d014cfa6bc85ccfbc07ae5688ed9dc08d9f1f6d28"
+)
+
+if %ERRORLEVEL% == 1 exit /b 1
+
+:done
+
+REM dir %~dp0..\..\
+REM dir %~dp0..\..\Qt
+REM dir %~dp0..\..\Qt\5.15.13

--- a/SandboxiePlus/qmake_plus.cmd
+++ b/SandboxiePlus/qmake_plus.cmd
@@ -5,21 +5,21 @@ REM echo arch: %1
 
 
 IF %1 == Win32 (
-  set qt_path=%~dp0..\..\Qt\5.15.2\msvc2019
+  set qt_path=%~dp0..\..\Qt\5.15.13\msvc2019
 
   REM get private headers for QtCore
-  Xcopy /E /I /Y /Q %~dp0..\..\Qt\5.15.2\msvc2019\include\QtCore\5.15.2\QtCore %~dp0..\..\Qt\5.15.2\msvc2019\include\QtCore
+  Xcopy /E /I /Y /Q %~dp0..\..\Qt\5.15.13\msvc2019\include\QtCore\5.15.13\QtCore %~dp0..\..\Qt\5.15.13\msvc2019\include\QtCore
   
   set build_arch=Win32
   set qt_params= 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
 )
 IF %1 == x64 (
-  set qt_path=%~dp0..\..\Qt\5.15.2\msvc2019_64
+  set qt_path=%~dp0..\..\Qt\5.15.13\msvc2019_64
 REM  set qt_path=%~dp0..\..\Qt\6.3.1\msvc2019_64
   
   REM get private headers for QtCore
-  Xcopy /E /I /Y /Q %~dp0..\..\Qt\5.15.2\msvc2019_64\include\QtCore\5.15.2\QtCore %~dp0..\..\Qt\5.15.2\msvc2019_64\include\QtCore
+  Xcopy /E /I /Y /Q %~dp0..\..\Qt\5.15.13\msvc2019_64\include\QtCore\5.15.13\QtCore %~dp0..\..\Qt\5.15.13\msvc2019_64\include\QtCore
 REM  Xcopy /E /I /Y /Q %~dp0..\..\Qt\6.3.1\msvc2019_64\include\QtCore\6.3.1\QtCore %~dp0..\..\Qt\6.3.1\msvc2019_64\include\QtCore
   
   set build_arch=x64


### PR DESCRIPTION
Sandboxie-Plus uses Qt 5.15.2 for some of its UI and software components. That Qt version is from ~4 years ago, and it may have software and/or security issues that were fixed in the following releases. Qt states that they have solved >1000 bugs and/or security issues since 5.15.2.

Qt releases the source code of its LTS builds like one year after they get pushed to the commercial branch. On March 8, Qt open sourced release 5.15.13. I have fully compiled that release (in release mode ― not debug) for Windows x64 and x86, and modified SBIE Plus' build scripts to use those builds instead.

![SBIE-Qt-5 15 13](https://github.com/sandboxie-plus/Sandboxie/assets/50250351/f0bfafd0-a609-4c65-be9e-c2558bd50efe)

After some testing on both x64 and x86 releases, no new bugs were found. Qt ARM64 builds are left intact.

Note: my own Qt builds have no modified or additional source code, and have been downloaded directly from Qt's website (https://download.qt.io/official_releases/qt/5.15/5.15.13/single/qt-everywhere-opensource-src-5.15.13.zip). They have been configured with the `-release -opensource` flags.