### PR TITLE
Job Object Limit

### DIFF
--- a/Sandboxie/core/dll/gui.c
+++ b/Sandboxie/core/dll/gui.c
@@ -416,13 +416,16 @@ _FX BOOLEAN Gui_Init(HMODULE module)
     GUI_IMPORT___(ClipCursor);
     GUI_IMPORT___(GetClipCursor);
     GUI_IMPORT___(GetCursorPos);
-    GUI_IMPORT___(SetCursorPos);
+	GUI_IMPORT___(SetCursorPos);
+	HMODULE temp = module;
+	module = Dll_Kernel32;
 	GUI_IMPORT___(Sleep);
 	GUI_IMPORT___(SleepEx);
 	GUI_IMPORT___(GetTickCount);
 	GUI_IMPORT___(GetTickCount64);
 	GUI_IMPORT___(QueryUnbiasedInterruptTime);
 	GUI_IMPORT___(QueryPerformanceCounter);
+	module = temp;
 
     GUI_IMPORT___(MsgWaitForMultipleObjects);
     GUI_IMPORT_AW(PeekMessage);

--- a/Sandboxie/core/dll/gui.c
+++ b/Sandboxie/core/dll/gui.c
@@ -417,6 +417,8 @@ _FX BOOLEAN Gui_Init(HMODULE module)
     GUI_IMPORT___(GetClipCursor);
     GUI_IMPORT___(GetCursorPos);
 	GUI_IMPORT___(SetCursorPos);
+
+	GUI_IMPORT___(SetTimer);
 	HMODULE temp = module;
 	module = Dll_Kernel32;
 	GUI_IMPORT___(Sleep);

--- a/Sandboxie/core/dll/gui.c
+++ b/Sandboxie/core/dll/gui.c
@@ -417,6 +417,12 @@ _FX BOOLEAN Gui_Init(HMODULE module)
     GUI_IMPORT___(GetClipCursor);
     GUI_IMPORT___(GetCursorPos);
     GUI_IMPORT___(SetCursorPos);
+	GUI_IMPORT___(Sleep);
+	GUI_IMPORT___(SleepEx);
+	GUI_IMPORT___(GetTickCount);
+	GUI_IMPORT___(GetTickCount64);
+	GUI_IMPORT___(QueryUnbiasedInterruptTime);
+	GUI_IMPORT___(QueryPerformanceCounter);
 
     GUI_IMPORT___(MsgWaitForMultipleObjects);
     GUI_IMPORT_AW(PeekMessage);

--- a/Sandboxie/core/dll/gui_p.h
+++ b/Sandboxie/core/dll/gui_p.h
@@ -100,6 +100,22 @@ typedef void (*P_SwitchToThisWindow)(HWND hWnd, BOOL fAlt);
 
 typedef HWND(*P_SetActiveWindow)(HWND hWnd);
 
+typedef DWORD(*P_GetTickCount)();
+
+typedef ULONGLONG (*P_GetTickCount64)();
+
+typedef BOOL(*P_QueryUnbiasedInterruptTime)(
+	PULONGLONG UnbiasedTime
+	);
+
+typedef void(*P_Sleep)(DWORD dwMiSecond);
+
+typedef DWORD(*P_SleepEx)(DWORD dwMiSecond, BOOL bAlert);
+
+typedef BOOL (*P_QueryPerformanceCounter)(
+	LARGE_INTEGER* lpPerformanceCount
+);
+
 typedef BOOL (*P_GetCursorPos)(LPPOINT lpPoint);
 
 typedef BOOL (*P_SetCursorPos)(int x, int y);
@@ -617,6 +633,13 @@ GUI_SYS_VAR_2(SendNotifyMessage)
 GUI_SYS_VAR_2(PostMessage)
 GUI_SYS_VAR_2(PostThreadMessage)
 GUI_SYS_VAR_2(DispatchMessage)
+
+GUI_SYS_VAR(Sleep)
+GUI_SYS_VAR(SleepEx)
+GUI_SYS_VAR(GetTickCount)
+GUI_SYS_VAR(QueryUnbiasedInterruptTime)
+GUI_SYS_VAR(GetTickCount64)
+GUI_SYS_VAR(QueryPerformanceCounter)
 
 GUI_SYS_VAR(MapWindowPoints)
 GUI_SYS_VAR(ClientToScreen)

--- a/Sandboxie/core/dll/gui_p.h
+++ b/Sandboxie/core/dll/gui_p.h
@@ -116,6 +116,13 @@ typedef BOOL (*P_QueryPerformanceCounter)(
 	LARGE_INTEGER* lpPerformanceCount
 );
 
+typedef UINT_PTR (*P_SetTimer)(
+	 HWND      hWnd,
+	           UINT_PTR  nIDEvent,
+	          UINT      uElapse,
+	 TIMERPROC lpTimerFunc
+);
+
 typedef BOOL (*P_GetCursorPos)(LPPOINT lpPoint);
 
 typedef BOOL (*P_SetCursorPos)(int x, int y);
@@ -640,6 +647,7 @@ GUI_SYS_VAR(GetTickCount)
 GUI_SYS_VAR(QueryUnbiasedInterruptTime)
 GUI_SYS_VAR(GetTickCount64)
 GUI_SYS_VAR(QueryPerformanceCounter)
+GUI_SYS_VAR(SetTimer)
 
 GUI_SYS_VAR(MapWindowPoints)
 GUI_SYS_VAR(ClientToScreen)

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -311,7 +311,7 @@ _FX BOOLEAN Gui_InitMisc(HMODULE module)
 
         SBIEDLL_HOOK(Gui_, SetThreadExecutionState);
     }
-	if (SbieApi_QueryConfBool(NULL, "UseChangeSpeed", FALSE))
+	if (SbieApi_QueryConfBool(NULL, L"UseChangeSpeed", FALSE))
 	{
 		module = Dll_Kernel32;
 		SBIEDLL_HOOK(Gui_, GetTickCount);
@@ -1731,33 +1731,33 @@ _FX void Gui_SwitchToThisWindow(HWND hWnd, BOOL fAlt)
 }
 
 _FX DWORD Gui_GetTickCount() {
-	return __sys_GetTickCount() * SbieApi_QueryConfNumber(NULL, "AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL, "LowTickSpeed", 1);
+	return __sys_GetTickCount() * SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL,L"LowTickSpeed", 1);
 }
 
 _FX ULONGLONG Gui_GetTickCount64() {
-	return __sys_GetTickCount64() * SbieApi_QueryConfNumber(NULL, "AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL, "LowTickSpeed", 1);
+	return __sys_GetTickCount64() * SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
 }
 
 _FX BOOL Gui_QueryUnbiasedInterruptTime(
 	PULONGLONG UnbiasedTime
 ) {
 	BOOL rtn = __sys_QueryUnbiasedInterruptTime(UnbiasedTime);
-	*UnbiasedTime *= SbieApi_QueryConfNumber(NULL, "AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL, "LowTickSpeed", 1);
+	*UnbiasedTime *= SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
 	return rtn;
 }
 
 _FX void Gui_Sleep(DWORD dwMiSecond) {
-	__sys_Sleep(dwMiSecond * SbieApi_QueryConfNumber(NULL, "AddSleepSpeed", 1) / SbieApi_QueryConfNumber(NULL, "LowSleepSpeed", 1));
+	__sys_Sleep(dwMiSecond * SbieApi_QueryConfNumber(NULL, L"AddSleepSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowSleepSpeed", 1));
 }
 
 _FX DWORD Gui_SleepEx(DWORD dwMiSecond, BOOL bAlert) {
-	return __sys_SleepEx(dwMiSecond * SbieApi_QueryConfNumber(NULL, "AddSleepSpeed", 1) / SbieApi_QueryConfNumber(NULL, "LowSleepSpeed", 1),bAlert);
+	return __sys_SleepEx(dwMiSecond * SbieApi_QueryConfNumber(NULL, L"AddSleepSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowSleepSpeed", 1),bAlert);
 }
 
 _FX BOOL Gui_QueryPerformanceCounter(
 	LARGE_INTEGER* lpPerformanceCount
 ) {
 	BOOL rtn = __sys_QueryPerformanceCounter(lpPerformanceCount);
-	lpPerformanceCount->QuadPart = lpPerformanceCount->QuadPart*SbieApi_QueryConfNumber(NULL, "AddTickSpeed", 1)/ SbieApi_QueryConfNumber(NULL, "LowTickSpeed", 1);
+	lpPerformanceCount->QuadPart = lpPerformanceCount->QuadPart*SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1)/ SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
 	return rtn;
 }

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -319,7 +319,9 @@ _FX BOOLEAN Gui_InitMisc(HMODULE module)
 	if (SbieApi_QueryConfBool(NULL, L"UseChangeSpeed", FALSE))
 	{
 		module = current;
-		SBIEDLL_HOOK(Gui_, SetTimer);
+		P_SetTimer SetTimer = Ldr_GetProcAddrNew(DllName_user32, "SetTimer", "SetTimer");
+		if (SetTimer)
+			SBIEDLL_HOOK(Gui_, SetTimer);
 		module = Dll_Kernel32;
 		SBIEDLL_HOOK(Gui_, GetTickCount);
 		P_GetTickCount64 GetTickCount64 = Ldr_GetProcAddrNew(Dll_Kernel32, "GetTickCount64", "GetTickCount64");

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -1772,9 +1772,7 @@ _FX BOOL Gui_QueryUnbiasedInterruptTime(
 _FX void Gui_Sleep(DWORD dwMiSecond) {
 	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddSleepSpeed", 1), low = SbieApi_QueryConfNumber(NULL, L"LowSleepSpeed", 1);
 	if (add != 0 && low != 0)
-		return __sys_Sleep(dwMiSecond * add / low);
-	else
-		return 0;
+		__sys_Sleep(dwMiSecond * add / low);
 }
 
 _FX DWORD Gui_SleepEx(DWORD dwMiSecond, BOOL bAlert) {

--- a/Sandboxie/core/dll/guimisc.c
+++ b/Sandboxie/core/dll/guimisc.c
@@ -1741,34 +1741,57 @@ _FX void Gui_SwitchToThisWindow(HWND hWnd, BOOL fAlt)
 }
 
 _FX DWORD Gui_GetTickCount() {
-	return __sys_GetTickCount() * SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL,L"LowTickSpeed", 1);
+	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1), low = SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
+	if (low != 0)
+		return __sys_GetTickCount() * add / low;
+	else
+		return __sys_GetTickCount() * add;
 }
 
 _FX ULONGLONG Gui_GetTickCount64() {
-	return __sys_GetTickCount64() * SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
+	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1), low = SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
+	if (low != 0)
+		return __sys_GetTickCount64() * add / low;
+	else
+		return __sys_GetTickCount64() * add;
 }
 
 _FX BOOL Gui_QueryUnbiasedInterruptTime(
 	PULONGLONG UnbiasedTime
 ) {
 	BOOL rtn = __sys_QueryUnbiasedInterruptTime(UnbiasedTime);
-	*UnbiasedTime *= SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
+	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1), low = SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
+	if (low != 0)
+		*UnbiasedTime *= add / low;
+	else
+		*UnbiasedTime *= add;
+	
 	return rtn;
 }
 
 _FX void Gui_Sleep(DWORD dwMiSecond) {
-	__sys_Sleep(dwMiSecond * SbieApi_QueryConfNumber(NULL, L"AddSleepSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowSleepSpeed", 1));
+	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddSleepSpeed", 1), low = SbieApi_QueryConfNumber(NULL, L"LowSleepSpeed", 1);
+	if (add != 0 && low != 0)
+		return __sys_Sleep(dwMiSecond * add / low);
+	else
+		return 0;
 }
 
 _FX DWORD Gui_SleepEx(DWORD dwMiSecond, BOOL bAlert) {
-	return __sys_SleepEx(dwMiSecond * SbieApi_QueryConfNumber(NULL, L"AddSleepSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowSleepSpeed", 1),bAlert);
+	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddSleepSpeed", 1), low = SbieApi_QueryConfNumber(NULL, L"LowSleepSpeed", 1);
+	if (add != 0 && low != 0)
+		return __sys_SleepEx(dwMiSecond * add / low, bAlert);
+	else
+		return 0;
 }
 
 _FX BOOL Gui_QueryPerformanceCounter(
 	LARGE_INTEGER* lpPerformanceCount
 ) {
+	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1),low= SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
 	BOOL rtn = __sys_QueryPerformanceCounter(lpPerformanceCount);
-	lpPerformanceCount->QuadPart = lpPerformanceCount->QuadPart*SbieApi_QueryConfNumber(NULL, L"AddTickSpeed", 1)/ SbieApi_QueryConfNumber(NULL, L"LowTickSpeed", 1);
+	if(add!=0&&low!=0)
+	lpPerformanceCount->QuadPart = lpPerformanceCount->QuadPart*add /low ;
 	return rtn;
 }
 
@@ -1779,5 +1802,9 @@ _FX UINT_PTR Gui_SetTimer(
 	TIMERPROC lpTimerFunc
 )
 {
-	return __sys_SetTimer(hWnd, nIDEvent, uElapse * SbieApi_QueryConfNumber(NULL, L"AddTimerSpeed", 1) / SbieApi_QueryConfNumber(NULL, L"LowTimerSpeed", 1), lpTimerFunc);
+	ULONG add = SbieApi_QueryConfNumber(NULL, L"AddTimerSpeed", 1), low = SbieApi_QueryConfNumber(NULL, L"LowTimerSpeed", 1);
+	if (add != 0 && low != 0)
+		return __sys_SetTimer(hWnd, nIDEvent, uElapse * add / low, lpTimerFunc);
+	else
+		return 0;
 }

--- a/Sandboxie/core/svc/GuiServer.cpp
+++ b/Sandboxie/core/svc/GuiServer.cpp
@@ -1095,8 +1095,20 @@ HANDLE GuiServer::GetJobObjectForAssign(const WCHAR *boxname)
                         JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobELInfo = {0};
                         jobELInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_BREAKAWAY_OK
                                                                    | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK;
-                    
-                        ok = SetInformationJobObject(hJobObject, JobObjectExtendedLimitInformation, &jobELInfo, sizeof(jobELInfo));
+						ULONG TotalMemoryLimit = SbieApi_QueryConfNumber(boxname, L"TotalMemoryLimit", 0), ProcessNumberLimit = SbieApi_QueryConfNumber(boxname, L"ProcessNumberLimit", 0), ProcessMemoryLimit = SbieApi_QueryConfNumber(boxname, L"ProcessMemoryLimit", 0);
+						if (TotalMemoryLimit != 0) {
+							jobELInfo.JobMemoryLimit = TotalMemoryLimit;
+							jobELInfo.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
+						}
+						if (ProcessNumberLimit != 0) {
+							jobELInfo.BasicLimitInformation.ActiveProcessLimit = ProcessNumberLimit;
+							jobELInfo.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
+						}
+						if (ProcessMemoryLimit != 0) {
+							jobELInfo.ProcessMemoryLimit = ProcessMemoryLimit;
+							jobELInfo.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+						}
+						ok = SetInformationJobObject(hJobObject, JobObjectExtendedLimitInformation, &jobELInfo, sizeof(jobELInfo));
                     }
                 }
                 if (! ok) {


### PR DESCRIPTION
The main content of this push is to realize the optional control of the number of processes in the sandbox and the limit of the total memory occupied by the sandbox through the job object.