### PR TITLE
Include hidden files and folders when listing files for export

### DIFF
--- a/SandboxiePlus/MiscHelpers/Common/OtherFunctions.cpp
+++ b/SandboxiePlus/MiscHelpers/Common/OtherFunctions.cpp
@@ -116,14 +116,14 @@ QStringList	ListDir(const QString& srcDirPath, const QStringList& NameFilter, bo
 	if (!srcDir.exists())
 		return FileList;
 
-	QStringList Files = !NameFilter.isEmpty() ? srcDir.entryList(NameFilter, QDir::Files | QDir::System) : srcDir.entryList(QDir::Files | QDir::System);
+	QStringList Files = !NameFilter.isEmpty() ? srcDir.entryList(NameFilter, QDir::Files | QDir::Hidden | QDir::System) : srcDir.entryList(QDir::Files | QDir::Hidden | QDir::System);
 	foreach (const QString& FileName, Files)
 		FileList.append(FileName);
 
 	if(!bAndSubDirs)
 		return FileList;
 
-	QStringList Dirs = srcDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+	QStringList Dirs = srcDir.entryList(QDir::Dirs | QDir::Hidden | QDir::NoDotAndDotDot);
 	foreach (const QString& DirName, Dirs)
 	{
 		//if (DirName.compare(".") == 0 || DirName.compare("..") == 0)


### PR DESCRIPTION
Fixes #3980 
The hidden attribute is still missing in exported 7z archive although 7z supports it, but in fact all attributes are missing, so that might be a separate problem.