### PR TITLE
CheckSendPostMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.14.7 / 5.69.7] - 2024-0x-xx
 
 ### Added
-- added "RandomRegUID"(bool) which could modify Windows Product Id in the registry to a rand value-
+- added "RandomRegUID"(bool) which could modify Windows Product Id in the registry to a rand value
 - added "HideDiskSerialNumber"(bool) return random value when applications tries to get disk serial number
-
+- added "CheckSendPostMessage"(bool) to check window owner when sandboxed processes tries to send/post window messages
 
 
 ## [1.14.6 / 5.69.6] - 2024-07-30

--- a/Sandboxie/core/svc/GuiServer.cpp
+++ b/Sandboxie/core/svc/GuiServer.cpp
@@ -4134,6 +4134,27 @@ bool GuiServer::AllowSendPostMessage(
             }
         }
 
+		HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, false, pid)
+			,hProcess2= OpenProcess(PROCESS_ALL_ACCESS, false, pidWindow);
+		WCHAR boxname[34] = { L"\0" }, boxname2[34] = { L"\0" };
+		if (hProcess != INVALID_HANDLE_VALUE && SbieApi_QueryProcess(hProcess, boxname, NULL, NULL, NULL)&& SbieApi_QueryProcess(hProcess2, boxname2, NULL, NULL, NULL)) {
+			CloseHandle(hProcess);
+			CloseHandle(hProcess2);
+			if (boxname != NULL) {
+				if (SbieApi_QueryConfBool(boxname, L"CheckSendPostMessage", false)) {
+
+					if (boxname2 == NULL)
+						return false;
+					if (_wcsicmp(boxname, boxname) != 0)
+						return false;
+				}
+			}
+		}
+		else {
+			CloseHandle(hProcess);
+			CloseHandle(hProcess2);
+		}
+
         if (isWindowInExplorer) {
 
             bool blocked = true;


### PR DESCRIPTION
So far, Sandboxie's window filtering except integrity control mainly prevents the program from obtaining the handle of the window outside the sandbox when it is proxied, but it has little effect on some other ways to obtain the handle. The purpose of this pull request is to double-check if the target window is in the same window as the sender when the service forwards the send message request.