### PR TITLE
fix get_openssl.cmd

### DIFF
--- a/Installer/get_openssl.cmd
+++ b/Installer/get_openssl.cmd
@@ -3,7 +3,7 @@ IF "%~3" == "" ( set "ghSsl_repo=openssl-builds" ) ELSE ( set "ghSsl_repo=%~3" )
 IF "%~2" == "" ( set "ghSsl_user=xanasoft" ) ELSE ( set "ghSsl_user=%~2" )
 IF "%~1" == "" ( set "openssl_version=3.3.1" ) ELSE ( set "openssl_version=%~1" )
 
-set "openssl_version_underscore=%openssl_version:.=_%"
+set "openssl_version_underscore=%openssl_version:.=-%"
 
 mkdir %~dp0\OpenSSL
 


### PR DESCRIPTION
Due to the change of the target download address, the synchronization is changed.

Latest download address:
``https://github.com/xanasoft/openssl-builds/releases/download/openssl-3.3.1/openssl-3.3.1.zip``
