### PR TITLE
Troubleshooting: drop admin rights related SBIE Messages

### DIFF
--- a/SandboxiePlus/SandMan/Troubleshooting/Sandboxing/SBIEMSG/SBIE2214.js
+++ b/SandboxiePlus/SandMan/Troubleshooting/Sandboxing/SBIEMSG/SBIE2214.js
@@ -1,0 +1,16 @@
+/*
+*	group: other
+*	class: sandboxing
+* name: SBIE2214: Request to start service name was denied due to dropped rights
+* description: Request to start service name was denied due to dropped rights
+*/
+
+if (typeof msgCode === 'undefined') {
+  msgCode = 2214;
+}
+
+let message = tr("The message %1 is caused by you selecting to drop rights from administrators/Power Users groups.\nYou may turn off Drop Rights setting to resolve this issue.", msgCode)
+
+invoke("SBIECONF");
+if(typeof boxName === 'undefined') boxName = "";
+openOptions(message, boxName, 'Security');

--- a/SandboxiePlus/SandMan/Troubleshooting/Sandboxing/SBIEMSG/SBIE2217.js
+++ b/SandboxiePlus/SandMan/Troubleshooting/Sandboxing/SBIEMSG/SBIE2217.js
@@ -1,0 +1,17 @@
+/*
+*	group: other
+*	class: sandboxing
+* name: SBIE2217: Request to run as Administrator was denied due to dropped rights
+* description: Request to run as Administrator was denied due to dropped rights
+*
+*/
+
+if (typeof msgCode === 'undefined') {
+  msgCode = 2217;
+}
+
+let message = tr("The message %1 is caused by you selecting to drop rights from administrators/Power Users groups.\nYou may solve the issue by either disabling this setting or make applications think they are running elevated.", msgCode)
+
+invoke("SBIECONF");
+if(typeof boxName === 'undefined') boxName = "";
+openOptions(message, boxName, 'Security');


### PR DESCRIPTION
> Thank you for your contribution to the Sandboxie repository.
>
> In order to reduce the risk of accidental merges, it's highly recommended for beginners to open a new Pull Request in draft state by clicking the button "Create Draft Pull Request", instead of using the default "Create Pull Request" option.
>
> In addition, you can convert an existing pull request to a draft by clicking the "Convert to draft" link in the right sidebar under "Reviewers".
>
> All new translators are encouraged to look at the "Localization notes and tips" before creating a pull request: https://git.io/J9G19

Not confident that fakeadmin won't work for SBIE2214, since I run `sc start` in that condition returns `access is denied` with no message from sandboxie.