### PR TITLE
Set tab orders and buddies of UI controls

### DIFF
--- a/SandboxiePlus/SandMan/Forms/BoxImageWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/BoxImageWindow.ui
@@ -36,6 +36,9 @@
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
+       <property name="buddy">
+        <cstring>txtRepeatPassword</cstring>
+       </property>
       </widget>
      </item>
      <item row="7" column="2">
@@ -56,6 +59,9 @@
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
+       <property name="buddy">
+        <cstring>cmbCipher</cstring>
+       </property>
       </widget>
      </item>
      <item row="2" column="0" colspan="2">
@@ -65,6 +71,9 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="buddy">
+        <cstring>txtNewPassword</cstring>
        </property>
       </widget>
      </item>
@@ -137,6 +146,9 @@
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
+       <property name="buddy">
+        <cstring>txtPassword</cstring>
+       </property>
       </widget>
      </item>
      <item row="8" column="2" colspan="3">
@@ -164,6 +176,9 @@
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
+       <property name="buddy">
+        <cstring>txtImageSize</cstring>
+       </property>
       </widget>
      </item>
      <item row="4" column="3">
@@ -177,6 +192,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtPassword</tabstop>
+  <tabstop>txtNewPassword</tabstop>
+  <tabstop>txtRepeatPassword</tabstop>
+  <tabstop>chkShow</tabstop>
+  <tabstop>txtImageSize</tabstop>
+  <tabstop>cmbCipher</tabstop>
+  <tabstop>chkProtect</tabstop>
+  <tabstop>chkAutoLock</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/SandboxiePlus/SandMan/Forms/CompressDialog.ui
+++ b/SandboxiePlus/SandMan/Forms/CompressDialog.ui
@@ -90,6 +90,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>cmbFormat</tabstop>
+  <tabstop>cmbCompression</tabstop>
+  <tabstop>chkSolid</tabstop>
+  <tabstop>chkEncrypt</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/SandboxiePlus/SandMan/Forms/ExtractDialog.ui
+++ b/SandboxiePlus/SandMan/Forms/ExtractDialog.ui
@@ -21,6 +21,9 @@
        <property name="text">
         <string>Box Root Folder</string>
        </property>
+       <property name="buddy">
+        <cstring>cmbRoot</cstring>
+       </property>
       </widget>
      </item>
      <item row="1" column="1">
@@ -44,6 +47,9 @@
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Import Sandbox Name</string>
+       </property>
+       <property name="buddy">
+        <cstring>txtName</cstring>
        </property>
       </widget>
      </item>
@@ -88,6 +94,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>txtName</tabstop>
+  <tabstop>cmbRoot</tabstop>
+  <tabstop>btnRoot</tabstop>
+  <tabstop>chkNoCrypt</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -98,6 +98,9 @@
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbBoxIndicator</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="2" column="0" colspan="3">
@@ -107,6 +110,9 @@
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbBoxBorder</cstring>
                  </property>
                 </widget>
                </item>
@@ -219,6 +225,9 @@
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbBoxType</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="2" column="7">
@@ -228,6 +237,9 @@
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>spinBorderWidth</cstring>
                  </property>
                 </widget>
                </item>
@@ -267,6 +279,9 @@
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbDblClick</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="5" column="3" colspan="4">
@@ -291,6 +306,9 @@
                 <widget class="QLabel" name="lblScheme">
                  <property name="text">
                   <string>Virtualization scheme</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbVersion</cstring>
                  </property>
                 </widget>
                </item>
@@ -1649,6 +1667,9 @@
                  <property name="text">
                   <string>Total Processes Number Limit:</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>txtTotalNumber</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="6" column="3">
@@ -1703,6 +1724,9 @@
                  <property name="text">
                   <string>Single Process Memory Limit:</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>txtSingleMemory</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="7" column="5">
@@ -1745,6 +1769,9 @@
                 <widget class="QLabel" name="label_56">
                  <property name="text">
                   <string>Total Processes Memory Limit:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>txtTotalMemory</cstring>
                  </property>
                 </widget>
                </item>
@@ -3442,6 +3469,9 @@ The process match level has a higher priority than the specificity and describes
                    <property name="text">
                     <string>Set network/internet access for unlisted processes:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>cmbBlockINet</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -3489,6 +3519,9 @@ The process match level has a higher priority than the specificity and describes
                    <property name="text">
                     <string>Test Rules, Program:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>txtProgFwTest</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -3498,6 +3531,9 @@ The process match level has a higher priority than the specificity and describes
                   <widget class="QLabel" name="label_49">
                    <property name="text">
                     <string>Port:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>txtPortFwTest</cstring>
                    </property>
                   </widget>
                  </item>
@@ -3509,6 +3545,9 @@ The process match level has a higher priority than the specificity and describes
                    <property name="text">
                     <string>IP:</string>
                    </property>
+                   <property name="buddy">
+                    <cstring>txtIPFwTest</cstring>
+                   </property>
                   </widget>
                  </item>
                  <item>
@@ -3518,6 +3557,9 @@ The process match level has a higher priority than the specificity and describes
                   <widget class="QLabel" name="label_51">
                    <property name="text">
                     <string>Protocol:</string>
+                   </property>
+                   <property name="buddy">
+                    <cstring>cmbProtFwTest</cstring>
                    </property>
                   </widget>
                  </item>
@@ -5361,6 +5403,9 @@ instead of &quot;*&quot;.</string>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbCategories</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="6" column="4">
@@ -5428,6 +5473,9 @@ instead of &quot;*&quot;.</string>
                 <widget class="QLabel" name="label_15">
                  <property name="text">
                   <string>Text Filter</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>txtTemplates</cstring>
                  </property>
                 </widget>
                </item>
@@ -5743,60 +5791,258 @@ Please note that this values are currently user specific and saved globally for 
   <tabstop>cmbBoxBorder</tabstop>
   <tabstop>btnBorderColor</tabstop>
   <tabstop>spinBorderWidth</tabstop>
-  <tabstop>treeRun</tabstop>
-  <tabstop>btnAddCmd</tabstop>
-  <tabstop>btnDelCmd</tabstop>
+  <tabstop>chkShowForRun</tabstop>
+  <tabstop>chkPinToTray</tabstop>
+  <tabstop>cmbDblClick</tabstop>
+  <tabstop>cmbBoxType</tabstop>
+  <tabstop>cmbVersion</tabstop>
+  <tabstop>chkSeparateUserFolders</tabstop>
+  <tabstop>chkUseVolumeSerialNumbers</tabstop>
+  <tabstop>chkRamBox</tabstop>
+  <tabstop>chkEncrypt</tabstop>
+  <tabstop>btnPassword</tabstop>
+  <tabstop>chkForceProtection</tabstop>
   <tabstop>chkAutoEmpty</tabstop>
   <tabstop>chkProtectBox</tabstop>
-  <tabstop>treeTriggers</tabstop>
-  <tabstop>btnDelAuto</tabstop>
+  <tabstop>chkRawDiskRead</tabstop>
+  <tabstop>chkRawDiskNotify</tabstop>
+  <tabstop>chkCopyLimit</tabstop>
+  <tabstop>txtCopyLimit</tabstop>
+  <tabstop>chkCopyPrompt</tabstop>
+  <tabstop>chkNoCopyWarn</tabstop>
+  <tabstop>chkDenyWrite</tabstop>
+  <tabstop>treeCopy</tabstop>
+  <tabstop>btnAddCopy</tabstop>
+  <tabstop>chkShowCopyTmpl</tabstop>
+  <tabstop>btnDelCopy</tabstop>
+  <tabstop>chkNoCopyMsg</tabstop>
+  <tabstop>chkBlockSpooler</tabstop>
+  <tabstop>chkOpenSpooler</tabstop>
+  <tabstop>chkPrintToFile</tabstop>
+  <tabstop>chkOpenProtectedStorage</tabstop>
+  <tabstop>chkOpenCredentials</tabstop>
+  <tabstop>chkCloseClipBoard</tabstop>
+  <tabstop>chkVmRead</tabstop>
+  <tabstop>chkVmReadNotify</tabstop>
+  <tabstop>chkProtectPower</tabstop>
+  <tabstop>chkUserOperation</tabstop>
+  <tabstop>chkCoverBar</tabstop>
+  <tabstop>chkBlockCapture</tabstop>
+  <tabstop>chkOpenDevCMApi</tabstop>
+  <tabstop>chkOpenSamEndpoint</tabstop>
+  <tabstop>chkOpenLsaEndpoint</tabstop>
+  <tabstop>treeRun</tabstop>
+  <tabstop>btnAddCmd</tabstop>
+  <tabstop>btnCmdUp</tabstop>
+  <tabstop>btnCmdDown</tabstop>
+  <tabstop>btnDelCmd</tabstop>
+  <tabstop>tabsSecurity</tabstop>
+  <tabstop>chkSecurityMode</tabstop>
+  <tabstop>chkLockDown</tabstop>
+  <tabstop>chkRestrictDevices</tabstop>
+  <tabstop>chkDropRights</tabstop>
+  <tabstop>chkFakeElevation</tabstop>
+  <tabstop>chkMsiExemptions</tabstop>
+  <tabstop>chkNoSecurityIsolation</tabstop>
+  <tabstop>chkNoSecurityFiltering</tabstop>
+  <tabstop>chkConfidential</tabstop>
+  <tabstop>chkLessConfidential</tabstop>
+  <tabstop>chkProtectWindow</tabstop>
+  <tabstop>chkAdminOnly</tabstop>
+  <tabstop>treeHostProc</tabstop>
+  <tabstop>btnHostProcessAllow</tabstop>
+  <tabstop>btnHostProcessDeny</tabstop>
+  <tabstop>chkShowHostProcTmpl</tabstop>
+  <tabstop>btnDelHostProcess</tabstop>
+  <tabstop>chkNotifyProtect</tabstop>
+  <tabstop>chkAddToJob</tabstop>
+  <tabstop>chkNestedJobs</tabstop>
+  <tabstop>txtSingleMemory</tabstop>
+  <tabstop>txtTotalMemory</tabstop>
+  <tabstop>txtTotalNumber</tabstop>
+  <tabstop>chkProtectSCM</tabstop>
+  <tabstop>chkRestrictServices</tabstop>
+  <tabstop>chkElevateRpcss</tabstop>
+  <tabstop>chkProtectSystem</tabstop>
+  <tabstop>chkDropPrivileges</tabstop>
+  <tabstop>chkDropConHostIntegrity</tabstop>
+  <tabstop>chkSbieLogon</tabstop>
+  <tabstop>chkCreateToken</tabstop>
   <tabstop>treeGroups</tabstop>
   <tabstop>btnAddGroup</tabstop>
   <tabstop>btnAddProg</tabstop>
+  <tabstop>chkShowGroupTmpl</tabstop>
   <tabstop>btnDelProg</tabstop>
+  <tabstop>tabsForce</tabstop>
+  <tabstop>treeForced</tabstop>
+  <tabstop>btnForceProg</tabstop>
+  <tabstop>btnForceChild</tabstop>
+  <tabstop>btnForceDir</tabstop>
+  <tabstop>chkShowForceTmpl</tabstop>
+  <tabstop>btnDelForce</tabstop>
+  <tabstop>chkDisableForced</tabstop>
+  <tabstop>treeBreakout</tabstop>
+  <tabstop>btnBreakoutProg</tabstop>
+  <tabstop>btnBreakoutDir</tabstop>
+  <tabstop>chkShowBreakoutTmpl</tabstop>
+  <tabstop>btnDelBreakout</tabstop>
+  <tabstop>tabsStop</tabstop>
   <tabstop>treeStop</tabstop>
   <tabstop>btnAddLingering</tabstop>
   <tabstop>chkShowStopTmpl</tabstop>
   <tabstop>btnDelStopProg</tabstop>
+  <tabstop>treeLeader</tabstop>
+  <tabstop>btnAddLeader</tabstop>
+  <tabstop>chkShowLeaderTmpl</tabstop>
+  <tabstop>btnDelLeader</tabstop>
+  <tabstop>chkNoStopWnd</tabstop>
+  <tabstop>chkLingerLeniency</tabstop>
   <tabstop>radStartAll</tabstop>
   <tabstop>radStartExcept</tabstop>
   <tabstop>radStartSelected</tabstop>
   <tabstop>treeStart</tabstop>
   <tabstop>btnAddStartProg</tabstop>
+  <tabstop>chkShowStartTmpl</tabstop>
   <tabstop>btnDelStartProg</tabstop>
   <tabstop>chkStartBlockMsg</tabstop>
+  <tabstop>chkAlertBeforeStart</tabstop>
+  <tabstop>tabsAccess</tabstop>
+  <tabstop>treeFiles</tabstop>
+  <tabstop>btnAddFile</tabstop>
+  <tabstop>chkShowFilesTmpl</tabstop>
+  <tabstop>btnDelFile</tabstop>
+  <tabstop>treeKeys</tabstop>
+  <tabstop>btnAddKey</tabstop>
+  <tabstop>chkShowKeysTmpl</tabstop>
+  <tabstop>btnDelKey</tabstop>
+  <tabstop>treeIPC</tabstop>
+  <tabstop>btnAddIPC</tabstop>
+  <tabstop>chkShowIPCTmpl</tabstop>
+  <tabstop>btnDelIPC</tabstop>
+  <tabstop>treeWnd</tabstop>
+  <tabstop>btnAddWnd</tabstop>
+  <tabstop>chkShowWndTmpl</tabstop>
+  <tabstop>btnDelWnd</tabstop>
+  <tabstop>chkNoWindowRename</tabstop>
+  <tabstop>treeCOM</tabstop>
+  <tabstop>btnAddCOM</tabstop>
+  <tabstop>chkShowCOMTmpl</tabstop>
+  <tabstop>btnDelCOM</tabstop>
+  <tabstop>chkOpenCOM</tabstop>
+  <tabstop>chkPrivacy</tabstop>
+  <tabstop>chkUseSpecificity</tabstop>
+  <tabstop>chkCloseForBox</tabstop>
+  <tabstop>chkNoOpenForBox</tabstop>
+  <tabstop>tabsInternet</tabstop>
+  <tabstop>cmbBlockINet</tabstop>
   <tabstop>chkINetBlockPrompt</tabstop>
   <tabstop>treeINet</tabstop>
   <tabstop>btnAddINetProg</tabstop>
   <tabstop>btnDelINetProg</tabstop>
   <tabstop>chkINetBlockMsg</tabstop>
+  <tabstop>treeNetFw</tabstop>
+  <tabstop>btnAddFwRule</tabstop>
+  <tabstop>chkShowNetFwTmpl</tabstop>
+  <tabstop>btnDelFwRule</tabstop>
+  <tabstop>txtProgFwTest</tabstop>
+  <tabstop>txtPortFwTest</tabstop>
+  <tabstop>txtIPFwTest</tabstop>
+  <tabstop>cmbProtFwTest</tabstop>
+  <tabstop>btnClearFwTest</tabstop>
+  <tabstop>treeDns</tabstop>
+  <tabstop>btnAddDns</tabstop>
+  <tabstop>btnDelDns</tabstop>
+  <tabstop>treeProxy</tabstop>
+  <tabstop>btnAddProxy</tabstop>
+  <tabstop>btnTestProxy</tabstop>
+  <tabstop>btnMoveProxyUp</tabstop>
+  <tabstop>btnMoveProxyDown</tabstop>
+  <tabstop>chkProxyResolveHostnames</tabstop>
+  <tabstop>btnDelProxy</tabstop>
+  <tabstop>chkBlockSamba</tabstop>
+  <tabstop>chkBlockDns</tabstop>
+  <tabstop>chkBlockNetShare</tabstop>
+  <tabstop>chkBlockNetParam</tabstop>
+  <tabstop>tabsRecovery</tabstop>
   <tabstop>treeRecovery</tabstop>
   <tabstop>btnAddRecovery</tabstop>
   <tabstop>chkShowRecoveryTmpl</tabstop>
   <tabstop>btnDelRecovery</tabstop>
+  <tabstop>chkAutoRecovery</tabstop>
+  <tabstop>treeRecIgnore</tabstop>
+  <tabstop>btnAddRecIgnore</tabstop>
+  <tabstop>btnAddRecIgnoreExt</tabstop>
+  <tabstop>chkShowRecIgnoreTmpl</tabstop>
+  <tabstop>btnDelRecIgnore</tabstop>
+  <tabstop>tabsOther</tabstop>
+  <tabstop>chkNoPanic</tabstop>
+  <tabstop>chkPreferExternalManifest</tabstop>
+  <tabstop>chkElevateCreateProcessFix</tabstop>
+  <tabstop>chkUseSbieDeskHack</tabstop>
+  <tabstop>chkUseSbieWndStation</tabstop>
+  <tabstop>chkComTimeout</tabstop>
+  <tabstop>chkForceRestart</tabstop>
+  <tabstop>treeInjectDll</tabstop>
+  <tabstop>chkHostProtect</tabstop>
+  <tabstop>chkHostProtectMsg</tabstop>
   <tabstop>tabsAdvanced</tabstop>
+  <tabstop>treeOptions</tabstop>
+  <tabstop>btnAddOption</tabstop>
+  <tabstop>chkShowOptionsTmpl</tabstop>
+  <tabstop>btnDelOption</tabstop>
+  <tabstop>treeTriggers</tabstop>
+  <tabstop>btnAddAutoExec</tabstop>
+  <tabstop>btnAddAutoRun</tabstop>
+  <tabstop>btnAddAutoSvc</tabstop>
+  <tabstop>btnAddTerminateCmd</tabstop>
+  <tabstop>btnAddRecoveryCmd</tabstop>
+  <tabstop>btnAddDeleteCmd</tabstop>
+  <tabstop>chkShowTriggersTmpl</tabstop>
+  <tabstop>btnDelAuto</tabstop>
+  <tabstop>chkHideFirmware</tabstop>
+  <tabstop>btnDumpFW</tabstop>
+  <tabstop>cmbLangID</tabstop>
+  <tabstop>chkHideSerial</tabstop>
+  <tabstop>chkHideMac</tabstop>
+  <tabstop>chkHideUID</tabstop>
   <tabstop>chkHideOtherBoxes</tabstop>
+  <tabstop>chkHideNonSystemProcesses</tabstop>
+  <tabstop>treeHideProc</tabstop>
   <tabstop>btnAddProcess</tabstop>
+  <tabstop>chkShowHiddenProcTmpl</tabstop>
   <tabstop>btnDelProcess</tabstop>
+  <tabstop>chkBlockWMI</tabstop>
   <tabstop>lstUsers</tabstop>
   <tabstop>btnAddUser</tabstop>
   <tabstop>btnDelUser</tabstop>
   <tabstop>chkMonitorAdminOnly</tabstop>
+  <tabstop>chkDisableMonitor</tabstop>
+  <tabstop>chkCallTrace</tabstop>
   <tabstop>chkFileTrace</tabstop>
   <tabstop>chkPipeTrace</tabstop>
   <tabstop>chkKeyTrace</tabstop>
   <tabstop>chkIpcTrace</tabstop>
   <tabstop>chkGuiTrace</tabstop>
   <tabstop>chkComTrace</tabstop>
+  <tabstop>chkNetFwTrace</tabstop>
+  <tabstop>chkDnsTrace</tabstop>
+  <tabstop>chkHookTrace</tabstop>
   <tabstop>chkDbgTrace</tabstop>
+  <tabstop>chkErrTrace</tabstop>
   <tabstop>scrollArea</tabstop>
-  <tabstop>treeTemplates</tabstop>
+  <tabstop>tabsTemplates</tabstop>
   <tabstop>cmbCategories</tabstop>
   <tabstop>txtTemplates</tabstop>
+  <tabstop>treeTemplates</tabstop>
+  <tabstop>btnAddTemplate</tabstop>
+  <tabstop>btnOpenTemplate</tabstop>
+  <tabstop>btnDelTemplate</tabstop>
+  <tabstop>treeFolders</tabstop>
+  <tabstop>chkScreenReaders</tabstop>
   <tabstop>btnEditIni</tabstop>
-  <tabstop>txtIniSection</tabstop>
   <tabstop>btnSaveIni</tabstop>
   <tabstop>btnCancelEdit</tabstop>
+  <tabstop>txtIniSection</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/SandboxiePlus/SandMan/Forms/RecoveryWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/RecoveryWindow.ui
@@ -70,6 +70,9 @@
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
+         <property name="buddy">
+          <cstring>cmbRecover</cstring>
+         </property>
         </widget>
        </item>
        <item row="6" column="0">
@@ -193,6 +196,14 @@
  </widget>
  <tabstops>
   <tabstop>treeFiles</tabstop>
+  <tabstop>btnDelete</tabstop>
+  <tabstop>cmbRecover</tabstop>
+  <tabstop>btnRecover</tabstop>
+  <tabstop>btnRefresh</tabstop>
+  <tabstop>btnAddFolder</tabstop>
+  <tabstop>chkShowAll</tabstop>
+  <tabstop>btnDeleteAll</tabstop>
+  <tabstop>btnClose</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/SandboxiePlus/SandMan/Forms/SelectBoxWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SelectBoxWindow.ui
@@ -111,6 +111,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>radBoxed</tabstop>
+  <tabstop>treeBoxes</tabstop>
+  <tabstop>radBoxedNew</tabstop>
+  <tabstop>radUnBoxed</tabstop>
+  <tabstop>chkFCP</tabstop>
+  <tabstop>chkAdmin</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -87,6 +87,9 @@
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                </property>
+               <property name="buddy">
+                <cstring>uiLang</cstring>
+               </property>
               </widget>
              </item>
              <item row="1" column="1">
@@ -597,6 +600,9 @@
                <property name="openExternalLinks">
                 <bool>true</bool>
                </property>
+               <property name="buddy">
+                <cstring>cmbIntegrateMenu</cstring>
+               </property>
               </widget>
              </item>
              <item row="11" column="2">
@@ -612,6 +618,9 @@
                </property>
                <property name="openExternalLinks">
                 <bool>true</bool>
+               </property>
+               <property name="buddy">
+                <cstring>cmbIntegrateDesk</cstring>
                </property>
               </widget>
              </item>
@@ -678,6 +687,9 @@
                  <property name="openExternalLinks">
                   <bool>true</bool>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbTrayBoxes</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="1" column="0">
@@ -690,6 +702,9 @@
                  </property>
                  <property name="openExternalLinks">
                   <bool>true</bool>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbSysTray</cstring>
                  </property>
                 </widget>
                </item>
@@ -763,6 +778,9 @@
                 <widget class="QLabel" name="label_28">
                  <property name="text">
                   <string>On main window close:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbOnClose</cstring>
                  </property>
                 </widget>
                </item>
@@ -1113,6 +1131,9 @@
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbDPI</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="2" column="3">
@@ -1129,6 +1150,9 @@
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>txtEditor</cstring>
                  </property>
                 </widget>
                </item>
@@ -1262,6 +1286,9 @@
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbFontScale</cstring>
                  </property>
                 </widget>
                </item>
@@ -1508,6 +1535,9 @@
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>txtRamLimit</cstring>
                  </property>
                 </widget>
                </item>
@@ -1835,6 +1865,9 @@
                  <property name="text">
                   <string>Incremental Updates</string>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbUpdate</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="5" column="2" colspan="2">
@@ -1888,6 +1921,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                  </property>
                  <property name="text">
                   <string>Full Upgrades</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbRelease</cstring>
                  </property>
                 </widget>
                </item>
@@ -1961,6 +1997,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                 <widget class="QLabel" name="label_5">
                  <property name="text">
                   <string>Update Check Interval</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbInterval</cstring>
                  </property>
                 </widget>
                </item>
@@ -2040,6 +2079,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                  <property name="openExternalLinks">
                   <bool>true</bool>
                  </property>
+                 <property name="buddy">
+                  <cstring>regRoot</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="0" column="0">
@@ -2077,6 +2119,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                  <property name="openExternalLinks">
                   <bool>true</bool>
                  </property>
+                 <property name="buddy">
+                  <cstring>fileRoot</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="5" column="2">
@@ -2099,6 +2144,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbDefault</cstring>
                  </property>
                 </widget>
                </item>
@@ -2174,6 +2222,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                  </property>
                  <property name="openExternalLinks">
                   <bool>true</bool>
+                 </property>
+                 <property name="buddy">
+                  <cstring>ipcRoot</cstring>
                  </property>
                 </widget>
                </item>
@@ -2467,6 +2518,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                  </property>
+                 <property name="buddy">
+                  <cstring>cmbUsbSandbox</cstring>
+                 </property>
                 </widget>
                </item>
                <item row="0" column="0" colspan="2">
@@ -2622,6 +2676,9 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
                 <widget class="QLabel" name="label_18">
                  <property name="text">
                   <string>Text Filter</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>txtTemplates</cstring>
                  </property>
                 </widget>
                </item>
@@ -2795,20 +2852,137 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
  </widget>
  <tabstops>
   <tabstop>tabs</tabstop>
+  <tabstop>tabsGeneral</tabstop>
+  <tabstop>uiLang</tabstop>
   <tabstop>chkSandboxUrls</tabstop>
+  <tabstop>chkMonitorSize</tabstop>
+  <tabstop>chkPanic</tabstop>
+  <tabstop>keyPanic</tabstop>
+  <tabstop>chkTop</tabstop>
+  <tabstop>keyTop</tabstop>
+  <tabstop>chkPauseForce</tabstop>
+  <tabstop>keyPauseForce</tabstop>
+  <tabstop>chkSuspend</tabstop>
+  <tabstop>keySuspend</tabstop>
+  <tabstop>chkAsyncBoxOps</tabstop>
+  <tabstop>chkAutoTerminate</tabstop>
+  <tabstop>chkShowRecovery</tabstop>
+  <tabstop>chkCheckDelete</tabstop>
+  <tabstop>chkRecoveryTop</tabstop>
+  <tabstop>chkSilentMode</tabstop>
+  <tabstop>chkCopyProgress</tabstop>
+  <tabstop>chkNotifyRecovery</tabstop>
+  <tabstop>chkNoMessages</tabstop>
+  <tabstop>treeMessages</tabstop>
+  <tabstop>btnAddMessage</tabstop>
+  <tabstop>btnDelMessage</tabstop>
+  <tabstop>tabsShell</tabstop>
+  <tabstop>chkAutoStart</tabstop>
+  <tabstop>chkSvcStart</tabstop>
+  <tabstop>chkShellMenu</tabstop>
+  <tabstop>chkAlwaysDefault</tabstop>
+  <tabstop>chkShellMenu2</tabstop>
+  <tabstop>chkShellMenu3</tabstop>
+  <tabstop>chkShellMenu4</tabstop>
+  <tabstop>chkScanMenu</tabstop>
+  <tabstop>cmbIntegrateMenu</tabstop>
+  <tabstop>cmbIntegrateDesk</tabstop>
+  <tabstop>cmbSysTray</tabstop>
+  <tabstop>cmbTrayBoxes</tabstop>
+  <tabstop>chkCompactTray</tabstop>
+  <tabstop>chkBoxOpsNotify</tabstop>
+  <tabstop>cmbOnClose</tabstop>
+  <tabstop>chkMinimize</tabstop>
+  <tabstop>chkSingleShow</tabstop>
+  <tabstop>treeRun</tabstop>
+  <tabstop>btnAddCmd</tabstop>
+  <tabstop>btnCmdUp</tabstop>
+  <tabstop>btnCmdDown</tabstop>
+  <tabstop>btnDelCmd</tabstop>
+  <tabstop>tabsGUI</tabstop>
+  <tabstop>chkDarkTheme</tabstop>
+  <tabstop>chkFusionTheme</tabstop>
+  <tabstop>chkAltRows</tabstop>
+  <tabstop>chkBackground</tabstop>
+  <tabstop>chkLargeIcons</tabstop>
+  <tabstop>chkNoIcons</tabstop>
+  <tabstop>chkOptTree</tabstop>
+  <tabstop>chkNewLayout</tabstop>
+  <tabstop>chkColorIcons</tabstop>
+  <tabstop>chkOverlayIcons</tabstop>
+  <tabstop>chkHideCore</tabstop>
+  <tabstop>cmbDPI</tabstop>
+  <tabstop>cmbFontScale</tabstop>
+  <tabstop>chkHide</tabstop>
+  <tabstop>btnSelectIniFont</tabstop>
+  <tabstop>btnResetIniFont</tabstop>
+  <tabstop>txtEditor</tabstop>
+  <tabstop>tabsAddons</tabstop>
+  <tabstop>treeAddons</tabstop>
+  <tabstop>btnInstallAddon</tabstop>
+  <tabstop>btnRemoveAddon</tabstop>
+  <tabstop>chkRamDisk</tabstop>
+  <tabstop>txtRamLimit</tabstop>
+  <tabstop>chkRamLetter</tabstop>
+  <tabstop>cmbRamLetter</tabstop>
+  <tabstop>tabsSupport</tabstop>
+  <tabstop>txtCertificate</tabstop>
+  <tabstop>txtSerial</tabstop>
+  <tabstop>btnGetCert</tabstop>
+  <tabstop>chkNoCheck</tabstop>
+  <tabstop>chkAutoUpdate</tabstop>
+  <tabstop>cmbInterval</tabstop>
+  <tabstop>radStable</tabstop>
+  <tabstop>radPreview</tabstop>
+  <tabstop>radInsider</tabstop>
+  <tabstop>cmbUpdate</tabstop>
+  <tabstop>cmbRelease</tabstop>
+  <tabstop>chkUpdateIssues</tabstop>
+  <tabstop>chkUpdateAddons</tabstop>
+  <tabstop>tabsAdvanced</tabstop>
+  <tabstop>cmbDefault</tabstop>
+  <tabstop>chkAutoRoot</tabstop>
   <tabstop>fileRoot</tabstop>
   <tabstop>btnBrowse</tabstop>
   <tabstop>regRoot</tabstop>
   <tabstop>ipcRoot</tabstop>
+  <tabstop>chkWFP</tabstop>
+  <tabstop>chkObjCb</tabstop>
+  <tabstop>chkWin32k</tabstop>
+  <tabstop>chkSbieLogon</tabstop>
+  <tabstop>chkSbieAll</tabstop>
+  <tabstop>chkWatchConfig</tabstop>
+  <tabstop>chkSkipUAC</tabstop>
+  <tabstop>chkAdminOnly</tabstop>
+  <tabstop>chkPassRequired</tabstop>
+  <tabstop>btnSetPassword</tabstop>
+  <tabstop>chkAdminOnlyFP</tabstop>
+  <tabstop>chkClearPass</tabstop>
+  <tabstop>tabsControl</tabstop>
   <tabstop>chkStartBlock</tabstop>
   <tabstop>treeWarnProgs</tabstop>
   <tabstop>btnAddWarnProg</tabstop>
   <tabstop>btnAddWarnFolder</tabstop>
   <tabstop>btnDelWarnProg</tabstop>
+  <tabstop>chkStartBlockMsg</tabstop>
+  <tabstop>chkNotForcedMsg</tabstop>
+  <tabstop>chkSandboxUsb</tabstop>
+  <tabstop>cmbUsbSandbox</tabstop>
+  <tabstop>treeVolumes</tabstop>
+  <tabstop>tabsTemplates</tabstop>
   <tabstop>treeCompat</tabstop>
   <tabstop>btnAddCompat</tabstop>
   <tabstop>btnDelCompat</tabstop>
   <tabstop>chkNoCompat</tabstop>
+  <tabstop>txtTemplates</tabstop>
+  <tabstop>treeTemplates</tabstop>
+  <tabstop>btnAddTemplate</tabstop>
+  <tabstop>btnOpenTemplate</tabstop>
+  <tabstop>btnDelTemplate</tabstop>
+  <tabstop>btnEditIni</tabstop>
+  <tabstop>btnSaveIni</tabstop>
+  <tabstop>btnCancelEdit</tabstop>
+  <tabstop>txtIniSection</tabstop>
  </tabstops>
  <resources>
   <include location="../Resources/SandMan.qrc"/>

--- a/SandboxiePlus/SandMan/Forms/SnapshotsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SnapshotsWindow.ui
@@ -65,6 +65,9 @@
             <property name="text">
              <string>Name:</string>
             </property>
+            <property name="buddy">
+             <cstring>txtName</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="1">
@@ -121,6 +124,9 @@
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+            <property name="buddy">
+             <cstring>txtInfo</cstring>
             </property>
            </widget>
           </item>
@@ -222,11 +228,13 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>btnTake</tabstop>
   <tabstop>treeSnapshots</tabstop>
-  <tabstop>btnRemove</tabstop>
   <tabstop>txtName</tabstop>
+  <tabstop>chkDefault</tabstop>
   <tabstop>txtInfo</tabstop>
+  <tabstop>btnTake</tabstop>
+  <tabstop>btnSelect</tabstop>
+  <tabstop>btnRemove</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This sets the tab orders for most dialogs, so that when the user presses Tab/Shift+Tab, or presses an arrow key on a button, the focus will move from left to right, and from top to bottom. This can make keyboard navigation easier.

Unfortunately, when different tabs are merged by code, their tab orders seem to be lost. The File Recovery and Stop Behaviour tabs still have incorrect tab orders.

This also sets the "buddy" for some labels, if the label contains a description for the following control. This can improve accessibility because screen readers can read the label for the user when entering a text box, for example.

When there are new controls added, their tab orders should be set as well.