### PR TITLE
Update Sandboxie-Plus.iss

### DIFF
--- a/Installer/Sandboxie-Plus.iss
+++ b/Installer/Sandboxie-Plus.iss
@@ -137,6 +137,7 @@ Filename: "{app}\Start.exe"; Parameters: "open_agent:sandman.exe"; Description: 
 
 [UninstallDelete]
 Type: dirifempty; Name: "{app}"
+Type: files; Name: "{localappdata}\{#MyAppName}\addons.json"
 Type: dirifempty; Name: "{localappdata}\{#MyAppName}"
 
 


### PR DESCRIPTION
The addons.json file remains in %localappdata% after uninstallation, so this pull request allows its deletion. If there are any reasons it should be kept as a remnant, please let me know.