### PR TITLE
UI Custom Font

### DIFF
--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -181,6 +181,7 @@ CSandMan::CSandMan(QWidget *parent)
 	connect(theAPI, SIGNAL(StatusChanged()), this, SLOT(OnStatusChanged()));
 
 	connect(theAPI, SIGNAL(BoxAdded(const CSandBoxPtr&)), this, SLOT(OnBoxAdded(const CSandBoxPtr&)));
+	connect(theAPI, SIGNAL(BoxOpened(const CSandBoxPtr&)), this, SLOT(OnBoxOpened(const CSandBoxPtr&)));
 	connect(theAPI, SIGNAL(BoxClosed(const CSandBoxPtr&)), this, SLOT(OnBoxClosed(const CSandBoxPtr&)));
 	connect(theAPI, SIGNAL(BoxCleaned(CSandBoxPlus*)), this, SLOT(OnBoxCleaned(CSandBoxPlus*)));
 
@@ -2352,6 +2353,11 @@ void CSandMan::OnStartMenuChanged()
 	}
 }
 
+void CSandMan::OnBoxOpened(const CSandBoxPtr& pBox)
+{
+	CSupportDialog::CheckSupport(true);
+}
+
 void CSandMan::OnBoxClosed(const CSandBoxPtr& pBox)
 {
 	foreach(const QString & Value, pBox->GetTextList("OnBoxTerminate", true, false, true)) {
@@ -4244,11 +4250,12 @@ void CSandMan::SetUITheme()
 	CFinder::SetDarkMode(bDark);
 
 
-    QFont font = QApplication::font();
-    if (QString customFont = theConf->GetString("UIConfig/UIFont",""); customFont != ""){
-        font.setFamily(customFont);
-        QApplication::setFont(font);
-    }
+	QFont font = QApplication::font();
+	QString customFontStr = theConf->GetString("UIConfig/UIFont", "");
+	if (customFontStr != "") {
+		font.setFamily(customFontStr);
+		QApplication::setFont(font);
+	}
 	double newFontSize = m_DefaultFontSize * theConf->GetInt("Options/FontScaling", 100) / 100.0;
 	if (newFontSize != font.pointSizeF()) {
 		font.setPointSizeF(newFontSize);

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -181,7 +181,6 @@ CSandMan::CSandMan(QWidget *parent)
 	connect(theAPI, SIGNAL(StatusChanged()), this, SLOT(OnStatusChanged()));
 
 	connect(theAPI, SIGNAL(BoxAdded(const CSandBoxPtr&)), this, SLOT(OnBoxAdded(const CSandBoxPtr&)));
-	connect(theAPI, SIGNAL(BoxOpened(const CSandBoxPtr&)), this, SLOT(OnBoxOpened(const CSandBoxPtr&)));
 	connect(theAPI, SIGNAL(BoxClosed(const CSandBoxPtr&)), this, SLOT(OnBoxClosed(const CSandBoxPtr&)));
 	connect(theAPI, SIGNAL(BoxCleaned(CSandBoxPlus*)), this, SLOT(OnBoxCleaned(CSandBoxPlus*)));
 
@@ -2353,11 +2352,6 @@ void CSandMan::OnStartMenuChanged()
 	}
 }
 
-void CSandMan::OnBoxOpened(const CSandBoxPtr& pBox)
-{
-	CSupportDialog::CheckSupport(true);
-}
-
 void CSandMan::OnBoxClosed(const CSandBoxPtr& pBox)
 {
 	foreach(const QString & Value, pBox->GetTextList("OnBoxTerminate", true, false, true)) {
@@ -4250,7 +4244,11 @@ void CSandMan::SetUITheme()
 	CFinder::SetDarkMode(bDark);
 
 
-	QFont font = QApplication::font();
+    QFont font = QApplication::font();
+    if (QString customFont = theConf->GetString("UIConfig/UIFont",""); customFont != ""){
+        font.setFamily(customFont);
+        QApplication::setFont(font);
+    }
 	double newFontSize = m_DefaultFontSize * theConf->GetInt("Options/FontScaling", 100) / 100.0;
 	if (newFontSize != font.pointSizeF()) {
 		font.setPointSizeF(newFontSize);


### PR DESCRIPTION
This PR implements part of #3772
- Added a config variable `UIConfig/UIFont`
- Added code in `CSandMan::SetUITheme()`, it will now check if `UIConfig/UIFont` is set, and (if Yes) load it as the UI's font
  `UIConfig/UIFont`'s value is treated as the font family name

screenshot
before
(BTW: set system display language as English and Sandboxie Simp-Chinese and you can see the font not loading properly)
<img width="642" alt="default" src="https://github.com/user-attachments/assets/31a73d1e-098c-4a62-8555-70101215f309">

set
<img width="136" alt="setfont" src="https://github.com/user-attachments/assets/da029340-9e99-41bb-b581-c2b2e41e9c9a">

after
<img width="642" alt="customfont" src="https://github.com/user-attachments/assets/90ecfcc3-d65e-4183-8994-6b0d53ab1189">
