### PR TITLE
Update Templates.ini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.15.4 / 5.70.4] - 2024-12-??
 
-###
-- Fixed issues with ini section editor in dark mode 
-- Fix deleting sandbox content [#4407](https://github.com/sandboxie-plus/Sandboxie/pull/4407)
+### Added
+- added template for Joplin [#4402](https://github.com/sandboxie-plus/Sandboxie/pull/4402) (thanks offhub)
 
+### Fixed
+- fixed issues with ini section editor in dark mode
+- fixed deleting sandbox content [#4407](https://github.com/sandboxie-plus/Sandboxie/pull/4407) (thanks bot-1450)
+- fixed run unsandboxed no longer working from box picker window [#4403](https://github.com/sandboxie-plus/Sandboxie/issues/4403)
+- fixed Firefox tab crashes when running with `ProtectHostImages=y` enabled [#4394](https://github.com/sandboxie-plus/Sandboxie/issues/4394)
+  - Only default installation locations are considered; Firefox-based browsers installed outside of these locations may still crash.
+  - To prevent this, manually add `DontCopy=<CustomInstallPath>` for custom installation paths to your configuration
 
 
 
@@ -17,14 +23,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - improved ini section editor, it now supports search Ctrl+F
-- added SBIE1321 to log all force process events, can be enabled with "NotifyForceProcessEnabled=y", Improves #4113
+- added SBIE1321 to log all force process events, can be enabled with "NotifyForceProcessEnabled=y", improves [#4113](https://github.com/sandboxie-plus/Sandboxie/issues/4113)
+- added custom font configuration for Sandboxie Plus UI [#4397](https://github.com/sandboxie-plus/Sandboxie/pull/4397) (thanks habatake)
 
 ### Changed
 - improved support notification
+- improved deletion of Sandboxie Plus leftovers [#4374](https://github.com/sandboxie-plus/Sandboxie/pull/4374)
 
 ### Fixed
-- fixed issues with SSL on ARM64 platform, breaking updater and cert retrieval
-
+- fixed issues with SSL on ARM64 platform, breaking updater and certificate retrieval
 
 
 
@@ -47,6 +54,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - validated compatibility with Windows build 27749 and updated DynData
 - when running via drag and drop, now the app's parent folder is used as working directory [#4073](https://github.com/sandboxie-plus/Sandboxie/issues/4073)
+- changed Qt 5 version to Qt 5.15.16 with OpenSSL 3.4.0 [#4370](https://github.com/sandboxie-plus/Sandboxie/pull/4370) (thanks offhub)
 
 ### Fixed
 - fixed Sign the .tmp file that gets dropped when installing or updating Sandboxie Plus [#2643](https://github.com/sandboxie-plus/Sandboxie/issues/2643) [#4343](https://github.com/sandboxie-plus/Sandboxie/issues/4343)
@@ -88,14 +96,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - improved SandboxieCrypto startup
-- improved Sandboxed RPCSS startup
+- improved sandboxed RPCSS startup
 - changed Qt 5 version to Qt 5.15.15 with OpenSSL 3.3.2 [#4223](https://github.com/sandboxie-plus/Sandboxie/pull/4223) (thanks offhub)
 - set tab orders and buddies of UI controls [#4300](https://github.com/sandboxie-plus/Sandboxie/pull/4300) (thanks gexgd0419)
 
 ### Fixed
 - fixed ImDiskApp uninstall key is always written to the registry [#4282](https://github.com/sandboxie-plus/Sandboxie/issues/4282)
 - FIXED SECURITY ISSUE ID-24 by adding new ACLS handling [CVE-2024-49360](https://github.com/sandboxie-plus/Sandboxie/security/advisories/GHSA-4chj-3c28-gvmp)
-  - Note: set LockBoxToUser=y on multi user systems
+  - Note: set 'LockBoxToUser=y' on multi user systems
 
 
 
@@ -261,6 +269,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - this issue was introduced in 1.13.0 and may have affected other use cases causing various issues
 - fixed issue with Misc Options list
 - improved compatibility with Steam running sandboxed
+- fixed compatibility issue with FakeAdminRights [#3989](https://github.com/sandboxie-plus/Sandboxie/pull/3989) (thanks offhub)
 
 
 
@@ -342,10 +351,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added optional extension of the screenshot protection to the UI [#3739](https://github.com/sandboxie-plus/Sandboxie/issues/3739)
 - added a button to edit local/custom templates [#3738](https://github.com/sandboxie-plus/Sandboxie/issues/3738)
 - added adjustable resizing of the "Run Sandboxed" window [#3697](https://github.com/sandboxie-plus/Sandboxie/issues/3697)
-- added Notepad++ template [#3836](https://github.com/sandboxie-plus/Sandboxie/pull/3836)
+- added Notepad++ template [#3836](https://github.com/sandboxie-plus/Sandboxie/pull/3836) (thanks offhub)
 
 ### Changed
-- improved Avast template [#3777](https://github.com/sandboxie-plus/Sandboxie/pull/3777)
+- improved Avast template [#3824](https://github.com/sandboxie-plus/Sandboxie/pull/3824) (thanks offhub)
 - renamed a bunch of experimental options and marked them as experimental in the UI
   - "IsBlockCapture=y" -> "BlockScreenCapture=y"
   - "IsProtectScreen=>" -> "CoverBoxedWindows=y"
@@ -377,7 +386,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - changed Qt 5 version to Qt 5.15.13 with latest security patches [#3694](https://github.com/sandboxie-plus/Sandboxie/pull/3694) (thanks LumitoLuma)
 - moved network restrictions from general restrictions to its own tab on the network page
 - improved certificate retrieval UI messages
-- improved MPC-BE template [#3798](https://github.com/sandboxie-plus/Sandboxie/pull/3798)
+- improved MPC-BE template [#3798](https://github.com/sandboxie-plus/Sandboxie/pull/3798) (thanks offhub)
 
 ### Fixed
  - fixed Virtualization scheme Version 2 causing extremely slow file deletion speeds [#3650](https://github.com/sandboxie-plus/Sandboxie/issues/3650)

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -3877,6 +3877,13 @@ DontCopy=*.wav
 DontCopy=*.webm
 DontCopy=*.wma
 DontCopy=*.wmv
+# For ProtectHostImages=y (issue 4394)
+DontCopy=%ProgramFiles%*\Mozilla Firefox\*
+DontCopy=%ProgramFiles%*\Firefox Nightly\*
+DontCopy=%ProgramFiles%*\Firefox Developer Edition\*
+DontCopy=%ProgramFiles%*\LibreWolf\*
+DontCopy=%ProgramFiles%*\Waterfox\*
+DontCopy=%ProgramFiles%*\Ablaze Floorp\*
 
 [Template_RpcPortBindings]
 Tmpl.Title=#4296


### PR DESCRIPTION
Some `DontCopy` rules have been added to the template to prevent Firefox-based browsers from crashing when the `ProtectHostImages` setting is enabled. Only default locations are considered; browsers installed outside of these locations will still crash.

Resolves #4394 