### PR TITLE
Add Daemon Tools Shell Helper to lingering processes

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -3782,6 +3782,8 @@ LingerProcess=software_reporter_tool.exe
 # Opera background processes
 LingerProcess=opera_crashreporter.exe
 LingerProcess=opera_autoupdate.exe
+# Daemon Tools Shell Helper
+LingerProcess=DTShellHlp.exe
 
 [Template_BlockPorts]
 Tmpl.Title=#4293


### PR DESCRIPTION
When Daemon Tools is installed on the host and explorer is opened in the sandbox, DTShellHlp will linger after explorer is closed; add it to the list of lingering processes to kill it.