### PR TITLE
feat: Improve sandbox deletion confirmation prompt

### DIFF
--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -1164,6 +1164,20 @@ bool CSbieView::TestNameAndWarn(const QString& Name)
 	return true;
 }
 
+QString RenderSandboxNameList_(const QList<CSandBoxPtr>& SandBoxes, int max_displayed = 10)
+{
+	QString name_list = "";
+	for (int i = 0; i < SandBoxes.count() && i < max_displayed; i++)
+	{
+		if (i != 0) name_list.append("<br />");
+		name_list.append("• <b>" + SandBoxes[i]->GetName().replace("_", " ") + "</b>");
+	}
+	if (SandBoxes.count() > max_displayed)
+		name_list.append(tr("<br />• ... and %1 more").arg(SandBoxes.count() - max_displayed));
+		
+	return name_list;
+}
+
 void CSbieView::OnSandBoxAction()
 {
 	OnSandBoxAction(qobject_cast<QAction*>(sender()), m_CurSandBoxes);
@@ -1473,7 +1487,9 @@ void CSbieView::OnSandBoxAction(QAction* Action, const QList<CSandBoxPtr>& SandB
 	}
 	else if (Action == m_pMenuRemove)
 	{
-		if (QMessageBox("Sandboxie-Plus", tr("Do you really want to remove the selected sandbox(es)?<br /><br />Warning: The box content will also be deleted!"), QMessageBox::Warning, QMessageBox::Yes, QMessageBox::No | QMessageBox::Default | QMessageBox::Escape, QMessageBox::NoButton, this).exec() != QMessageBox::Yes)
+		QString message = tr("Do you really want to remove the following sandbox(es)?<br /><br />%1<br /><br />Warning: The box content will also be deleted!")
+			.arg(RenderSandboxNameList_(SandBoxes));
+		if (QMessageBox("Sandboxie-Plus", message, QMessageBox::Warning, QMessageBox::Yes, QMessageBox::No | QMessageBox::Default | QMessageBox::Escape, QMessageBox::NoButton, this).exec() != QMessageBox::Yes)
 			return;
 
 		bool bChanged = false;
@@ -1534,24 +1550,32 @@ void CSbieView::OnSandBoxAction(QAction* Action, const QList<CSandBoxPtr>& SandB
 				if(!theGUI->OpenRecovery(SandBoxes.first(), DeleteSnapshots))
 					return;
 			}
-			else {
-				if (SandBoxes.first()->HasSnapshots()) {
-					if(CCheckableMessageBox::question(this, "Sandboxie-Plus", tr("Do you want to delete the content of the selected sandbox?")
+			else
+			{
+				QString message = tr("Do you want to delete the content of the following sandbox?<br /><br />%1")
+					.arg(RenderSandboxNameList_(SandBoxes));
+				
+				if (SandBoxes.first()->HasSnapshots())
+				{
+					if(CCheckableMessageBox::question(this, "Sandboxie-Plus", message
 					, tr("Also delete all Snapshots"), &DeleteSnapshots, QDialogButtonBox::Yes | QDialogButtonBox::No, QDialogButtonBox::Yes) != QDialogButtonBox::Yes)
 						return;
 				}
-				else {
-					if(QMessageBox::question(this, "Sandboxie-Plus", tr("Do you want to delete the content of the selected sandbox?")
-					, QMessageBox::Yes, QMessageBox::No) != QMessageBox::Yes)
+				else
+				{
+					if(QMessageBox::question(this, "Sandboxie-Plus", message , QMessageBox::Yes, QMessageBox::No) != QMessageBox::Yes)
 						return;
 				}
 			}
-
-			
 		}
-		else if(CCheckableMessageBox::question(this, "Sandboxie-Plus", tr("Do you really want to delete the content of all selected sandboxes?")
-			, tr("Also delete all Snapshots"), &DeleteSnapshots, QDialogButtonBox::Yes | QDialogButtonBox::No, QDialogButtonBox::Yes) != QDialogButtonBox::Yes)
+		else
+		{
+			QString message = tr("Do you really want to delete the content of the following sandboxes?<br /><br />%1")
+				.arg(RenderSandboxNameList_(SandBoxes));
+			if(CCheckableMessageBox::question(this, "Sandboxie-Plus", message
+				, tr("Also delete all Snapshots"), &DeleteSnapshots, QDialogButtonBox::Yes | QDialogButtonBox::No, QDialogButtonBox::Yes) != QDialogButtonBox::Yes)
 				return;
+		}
 
 		foreach(const CSandBoxPtr& pBox, SandBoxes)
 		{

--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -1164,20 +1164,6 @@ bool CSbieView::TestNameAndWarn(const QString& Name)
 	return true;
 }
 
-QString RenderSandboxNameList_(const QList<CSandBoxPtr>& SandBoxes, int max_displayed = 10)
-{
-	QString name_list = "";
-	for (int i = 0; i < SandBoxes.count() && i < max_displayed; i++)
-	{
-		if (i != 0) name_list.append("<br />");
-		name_list.append("• <b>" + SandBoxes[i]->GetName().replace("_", " ") + "</b>");
-	}
-	if (SandBoxes.count() > max_displayed)
-		name_list.append(tr("<br />• ... and %1 more").arg(SandBoxes.count() - max_displayed));
-		
-	return name_list;
-}
-
 void CSbieView::OnSandBoxAction()
 {
 	OnSandBoxAction(qobject_cast<QAction*>(sender()), m_CurSandBoxes);
@@ -1190,6 +1176,20 @@ void CSbieView::OnSandBoxAction(QAction* pAction)
 
 void CSbieView::OnSandBoxAction(QAction* Action, const QList<CSandBoxPtr>& SandBoxes)
 {
+	auto RenderSandboxNameList_ = [&,this](const QList<CSandBoxPtr>& SandBoxes, int max_displayed = 10) -> QString
+	{
+		QString name_list = "";
+		for (int i = 0; i < SandBoxes.count() && i < max_displayed; i++)
+		{
+			if (i != 0) name_list.append("<br />");
+			name_list.append("• <b>" + SandBoxes[i]->GetName().replace("_", " ") + "</b>");
+		}
+		if (SandBoxes.count() > max_displayed)
+			name_list.append(tr("<br />• ... and %1 more").arg(SandBoxes.count() - max_displayed));
+			
+		return name_list;
+	};
+
 	QList<SB_STATUS> Results;
 
 	if (SandBoxes.isEmpty())


### PR DESCRIPTION
Enhance the sandbox deletion / content deletion confirmation prompt by including the name of the sandbox being deleted.

Previously, the prompt only asked whether to delete the selected sandbox without specifying which one. This could lead to confusion, especially when deleting from the system tray context menu—as the menu closes before the confirmation appears, users can no longer see which sandbox they just selected.

Adding the sandbox name ensures users can clearly confirm their action.

![1](https://github.com/user-attachments/assets/a3fb6da3-2543-43b4-8f24-9499c7175a1f)
![2](https://github.com/user-attachments/assets/9bc7d1fe-8748-44c0-abac-27ef3ef9ad8e)
![3](https://github.com/user-attachments/assets/b93a1e19-fa0c-4fad-b213-b2461b95df97)
