### PR TITLE
remove the not-working "delete content" button

### DIFF
--- a/SandboxiePlus/SandMan/SandManRecovery.cpp
+++ b/SandboxiePlus/SandMan/SandManRecovery.cpp
@@ -19,7 +19,7 @@ void CSandMan::OnFileToRecover(const QString& BoxName, const QString& FilePath, 
 			pBoxEx->m_pRecoveryWnd->AddFile(FilePath, BoxPath);
 
 			pBoxEx->m_pRecoveryWnd->setModal(true);
-			pBoxEx->m_pRecoveryWnd->exec();
+			pBoxEx->m_pRecoveryWnd->show();
 		}
 		else
 		{


### PR DESCRIPTION
This PR is intend to **remove** the "delete content" button in "immediate recovery prompt".
It only affects users with option "Enable Immediate Recovery" checked. (`AutoRecover=y` and `InstantRecovery=true`)

Reason:
1. The button does not work. The caller function `CSandMan::OnFileToRecover` does not handle the click.
2. I think for immediate recovery window, the delete content button is not a common-use one. It's ok to just remove it than implement it.

<img width="538" alt="before" src="https://github.com/user-attachments/assets/5126769b-c747-42d7-b52f-f6cb5614780f" />
<img width="632" alt="after" src="https://github.com/user-attachments/assets/5f042364-99c4-4709-8fb9-9651875107a8" />
