### PR TITLE
fix two errors in Sandboxie about time speeding and add two time function hook

### DIFF
--- a/Sandboxie/core/dll/dll.h
+++ b/Sandboxie/core/dll/dll.h
@@ -350,6 +350,7 @@ extern const WCHAR *DllName_secur32;
 extern const WCHAR *DllName_sspicli;
 extern const WCHAR *DllName_mscoree;
 extern const WCHAR *DllName_ntmarta;
+extern const WCHAR *DllName_winmm;
 
 
 #define DllName_ole32_or_combase \

--- a/Sandboxie/core/dll/dllmain.c
+++ b/Sandboxie/core/dll/dllmain.c
@@ -150,6 +150,7 @@ const WCHAR *DllName_secur32    = L"secur32.dll";
 const WCHAR *DllName_sspicli    = L"sspicli.dll";
 const WCHAR *DllName_mscoree    = L"mscoree.dll";
 const WCHAR *DllName_ntmarta    = L"ntmarta.dll";
+const WCHAR *DllName_winmm      = L"winmm.dll";
 
 
 //---------------------------------------------------------------------------

--- a/Sandboxie/core/dll/gui_p.h
+++ b/Sandboxie/core/dll/gui_p.h
@@ -25,6 +25,7 @@
 
 
 #include <windows.h>
+#include <mmsystem.h>
 #include "common/win32_ntddk.h"
 #include "dll.h"
 
@@ -106,6 +107,13 @@ typedef UINT_PTR (*P_SetTimer)(
      UINT uElapse,
 	 TIMERPROC lpTimerFunc
 );
+
+
+typedef DWORD (*P_timeGetTime)();
+
+typedef MMRESULT (*P_timeSetEvent)(
+    UINT uDelay, UINT uResolution, LPTIMECALLBACK lpTimeProc,
+    DWORD_PTR dwUser, UINT fuEvent);
 
 typedef BOOL (*P_GetCursorPos)(LPPOINT lpPoint);
 
@@ -626,6 +634,8 @@ GUI_SYS_VAR_2(PostThreadMessage)
 GUI_SYS_VAR_2(DispatchMessage)
 
 GUI_SYS_VAR(SetTimer)
+GUI_SYS_VAR(timeGetTime)
+GUI_SYS_VAR(timeSetEvent)
 
 GUI_SYS_VAR(MapWindowPoints)
 GUI_SYS_VAR(ClientToScreen)


### PR DESCRIPTION
1. In the Gui_SetTimer and Kernel_SleepEx，the time parameter multiplied by add/low will be larger, because the value of add/low is greater than 1 from Kernel_GetTickCount. But we need to reduce the real time cost.
2. Add two hook functions, timeGetTime and timeSetEvent. They are as commonly used as GetTickCount and SetTimer.
