### PR TITLE
Prevent saving translated protocol string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - improved when Sandboxie.ini is huge, the response speed gets worse [#4573](https://github.com/sandboxie-plus/Sandboxie/issues/4573)
 - fixed Msi install Can`t create AppData\Romaing\Microsoft folder in Data Protection Box [#4711](https://github.com/sandboxie-plus/Sandboxie/issues/4711)
 - fixed two errors in Sandboxie about time speeding and add two time function hook [#4721](https://github.com/sandboxie-plus/Sandboxie/pull/4721) (thanks pwnmelife)
+- fixed an issue where the translation string of the protocol selection was saved in the configuration file
 
 ### Removed
 - removed the not-working "delete content" button [#4720](https://github.com/sandboxie-plus/Sandboxie/pull/4720) (thanks habatake)

--- a/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
@@ -600,6 +600,17 @@ COptionsWindow::ENetWfProt COptionsWindow::GetFwRuleProt(const QString& Value)
 	return eAny;
 }
 
+QString COptionsWindow::GetFwRuleProtStr(ENetWfProt Prot)
+{
+	switch (Prot)
+	{
+	case eTcp:  return "TCP";
+	case eUdp:  return "UDP";
+	case eIcmp: return "ICMP";
+	case eAny:  return "Any";
+	}
+	return "";
+}
 void COptionsWindow::ParseAndAddFwRule(const QString& Value, bool disabled, const QString& Template)
 {
 	QTreeWidgetItem* pItem = new QTreeWidgetItem();
@@ -659,9 +670,10 @@ void COptionsWindow::SaveNetFwRules()
 		ENetWfAction Action = (ENetWfAction)pItem->data(1, Qt::UserRole).toInt();
 		QString Port = pItem->data(2, Qt::UserRole).toString();
 		QString IP = pItem->data(3, Qt::UserRole).toString();
-		QString Prot = pItem->text(4);
+		ENetWfProt Prot = (ENetWfProt)pItem->data(4, Qt::UserRole).toInt();
 
 		QString Temp = GetFwRuleActionStr(Action);
+		QString Protocol = GetFwRuleProtStr(Prot);
 		//if (Program.contains("=") || Program.contains(";") || Program.contains(",")) // todo: make SBIE parses this properly
 		//	Program = "\'" + Program + "\'"; 
 		if (Program.isEmpty())
@@ -670,7 +682,7 @@ void COptionsWindow::SaveNetFwRules()
 		QStringList Tags = QStringList(Temp);
 		if (!Port.isEmpty()) Tags.append("Port=" + Port);
 		if (!IP.isEmpty()) Tags.append("Address=" + IP);
-		if (!Prot.isEmpty()) Tags.append("Protocol=" + Prot);
+		if (!Protocol.isEmpty()) Tags.append("Protocol=" + Protocol);
 
 		if(pItem->checkState(0) == Qt::Checked)
 			Rules.append(Tags.join(";"));

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -466,6 +466,7 @@ protected:
 	void CloseNetFwEdit(bool bSave = true);
 	void CloseNetFwEdit(QTreeWidgetItem* pItem, bool bSave = true);
 	ENetWfProt GetFwRuleProt(const QString& Value);
+	QString GetFwRuleProtStr(ENetWfProt Prot);
 	ENetWfAction GetFwRuleAction(const QString& Value);
 	QString GetFwRuleActionStr(ENetWfAction Action);
 	void LoadNetFwRules();


### PR DESCRIPTION
Fixed an issue where the translation string of the protocol selection was saved in the configuration file.