### PR TITLE
Skip expensive file access with `OneDrive`'s `On-Demand` feature

### DIFF
--- a/Sandboxie/apps/start/menu.cpp
+++ b/Sandboxie/apps/start/menu.cpp
@@ -671,7 +671,10 @@ _FX void ScanFolder(MENU_DIR *menu, WCHAR *path, UCHAR source)
         BOOLEAN boxed = FALSE;
 
         if (wcscmp(data.cFileName, L".") != 0 &&
-            wcscmp(data.cFileName, L"..") != 0) {
+            wcscmp(data.cFileName, L"..") != 0 &&
+            (data.dwFileAttributes & (
+                FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_RECALL_ON_OPEN | FILE_ATTRIBUTE_OFFLINE
+            )) == 0) {
 
             wcscpy(path_end + 1, data.cFileName);
 

--- a/Sandboxie/apps/start/menu.cpp
+++ b/Sandboxie/apps/start/menu.cpp
@@ -673,7 +673,7 @@ _FX void ScanFolder(MENU_DIR *menu, WCHAR *path, UCHAR source)
         if (wcscmp(data.cFileName, L".") != 0 &&
             wcscmp(data.cFileName, L"..") != 0 &&
             (data.dwFileAttributes & (
-                FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_RECALL_ON_OPEN | FILE_ATTRIBUTE_OFFLINE
+                FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_UNPINNED // OneDrive On-Demand
             )) == 0) {
 
             wcscpy(path_end + 1, data.cFileName);

--- a/Sandboxie/apps/start/menu.cpp
+++ b/Sandboxie/apps/start/menu.cpp
@@ -672,9 +672,13 @@ _FX void ScanFolder(MENU_DIR *menu, WCHAR *path, UCHAR source)
 
         if (wcscmp(data.cFileName, L".") != 0 &&
             wcscmp(data.cFileName, L"..") != 0 &&
-            (data.dwFileAttributes & (
-                FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_UNPINNED // OneDrive On-Demand
-            )) == 0) {
+            // OneDrive On-Demand feature set both FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+            // and FILE_ATTRIBUTE_UNPINNED, to determine an expensive call, it should detect
+            // flags: FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_RECALL_ON_OPEN |
+            // FILE_ATTRIBUTE_OFFLINE.
+            //
+            // This filter only considers the intersection
+            (data.dwFileAttributes & FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS) == 0) {
 
             wcscpy(path_end + 1, data.cFileName);
 


### PR DESCRIPTION
This should fix issue #4663.

Although I believe `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_RECALL_ON_OPEN | FILE_ATTRIBUTE_OFFLINE` should be check, OneDrive set `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS | FILE_ATTRIBUTE_UNPINNED` flags when a file is `Cloud Only` . To avoid further conflict, currently just `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS` got checked.

Here is a screenshot about 2 files managed by OneDrive, `a` is cloud only, `b` is locally available, attribute got from
```python
res=ctypes.windll.kernel32.GetFileAttributesW(path)
```
![image](https://github.com/user-attachments/assets/f77259f8-f6bf-4c82-af80-a97e6f0d0623)

Currently the `Start.exe` when iterates all files, it uses `CreateFile` to get a handle to test if it's a sandboxed file, which will trig `OneDrive`'s `On-Demand` feature. This PR creates a filter before this action to avoid this.

Test can be (**HAS BEEN**)  done by:

1. Get built artifacts from CI builds.
2. Copy & Replace `Start.exe`
3. In `SandMan.exe`, use maintenance tool to disconnect, then exit `SandMan.exe`, then restart `SandMan.exe`.
4. Make a large file on desktop "cloud only" by right clicking on it, select `Free Space` provided by OneDrive.
5. Create shortcut again, this large file will no longer appear on the popup selector, the OnDemand download is not starting

**NEW PROBLEM 1**
However, this blocks all files in cloud to be displayed.

Maybe we can record this with a map, at the end of the folder scan, call `BuildMenu_InsertSeparator`, then add all ignored item in a single group.

Or maybe we can simply change the display name when scanning: if we found cloud only files, we add a prefix `[C]`, skip the `CreateFile` call, and add it to menu as a normal item.

**NEW PROBLEM 2**
By replacing just `Start.exe`, the `SandMan.exe` seems did not realize this executable is replaced, no alerts pop up, this maybe violated the purpose of integrity check.
![image](https://github.com/user-attachments/assets/a3a0d44b-ca3a-4a13-be62-9fd86925ca83)

All this can be simply done, but it's not what this PR needs to do.