### PR TITLE
chore: improve hint text while IP or port is empty

### DIFF
--- a/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
@@ -1163,7 +1163,7 @@ void COptionsWindow::SaveNetProxy()
 		QString Bypass = pItem->data(6, Qt::UserRole).toString();
 
 		if (IP.isEmpty() || Port.isEmpty()) {
-			QMessageBox::warning(this, "SandboxiePlus", QString::number(i + 1) + tr(" entry: IP or Port cannot be empty"));
+			QMessageBox::warning(this, "SandboxiePlus", tr("Entry %1 : IP or Port cannot be empty").arg(QString::number(i + 1)));
 			continue;
 		}
 

--- a/SandboxiePlus/SandMan/sandman_ar.ts
+++ b/SandboxiePlus/SandMan/sandman_ar.ts
@@ -2264,8 +2264,9 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> الإدخال: لا يمكن أن يكون عنوان IP أو المنفذ فارغًا</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> الإدخال: لا يمكن أن يكون عنوان IP أو المنفذ فارغًا</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAdvanced.cpp" line="1310"/>

--- a/SandboxiePlus/SandMan/sandman_de.ts
+++ b/SandboxiePlus/SandMan/sandman_de.ts
@@ -2391,8 +2391,9 @@ Bitte wählen Sie einen Ordner, der diese Datei enthält.</translation>
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> Eintrag: IP oder Port dürfen nicht leer sein</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> Eintrag: IP oder Port dürfen nicht leer sein</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAdvanced.cpp" line="1310"/>

--- a/SandboxiePlus/SandMan/sandman_en.ts
+++ b/SandboxiePlus/SandMan/sandman_en.ts
@@ -2235,7 +2235,8 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_es.ts
+++ b/SandboxiePlus/SandMan/sandman_es.ts
@@ -2648,8 +2648,9 @@ Por favor, selecciona una carpeta que contenga este archivo.</translation>
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> entrada: IP o Puerto no pueden estar vacíos</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> entrada: IP o Puerto no pueden estar vacíos</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAdvanced.cpp" line="1310"/>

--- a/SandboxiePlus/SandMan/sandman_fr.ts
+++ b/SandboxiePlus/SandMan/sandman_fr.ts
@@ -2533,8 +2533,9 @@ Remarque : La recherche de mise à jour est souvent en retard par rapport à la 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation>Saisie : l&apos;IP ou le port ne peut pas être vide</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished">Saisie : l&apos;IP ou le port ne peut pas être vide</translation>
     </message>
     <message>
         <source> entry: Address must be IP, not host name</source>

--- a/SandboxiePlus/SandMan/sandman_hu.ts
+++ b/SandboxiePlus/SandMan/sandman_hu.ts
@@ -2259,8 +2259,9 @@ Megjegyzés: a frissítések ellenőrzése gyakran késik a legújabb GitHub-kia
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> bejegyzés: Az IP vagy a Port nem lehet üres</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> bejegyzés: Az IP vagy a Port nem lehet üres</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAdvanced.cpp" line="1310"/>

--- a/SandboxiePlus/SandMan/sandman_id.ts
+++ b/SandboxiePlus/SandMan/sandman_id.ts
@@ -2263,8 +2263,9 @@ Catatan: Pemeriksaan pembaruan seringkali tertinggal dari rilis GitHub terbaru u
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> entri: IP atau Port tidak boleh kosong</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> entri: IP atau Port tidak boleh kosong</translation>
     </message>
     <message>
         <source> entry: Address must be IP, not host name</source>

--- a/SandboxiePlus/SandMan/sandman_it.ts
+++ b/SandboxiePlus/SandMan/sandman_it.ts
@@ -2577,7 +2577,8 @@ Please select a folder which contains this file.</source>
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_ja.ts
+++ b/SandboxiePlus/SandMan/sandman_ja.ts
@@ -2285,7 +2285,8 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_ko.ts
+++ b/SandboxiePlus/SandMan/sandman_ko.ts
@@ -2519,8 +2519,9 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> 엔트리: IP 또는 포트는 비워 둘 수 없습니다</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> 엔트리: IP 또는 포트는 비워 둘 수 없습니다</translation>
     </message>
     <message>
         <source> entry: Address must be IP, not host name</source>

--- a/SandboxiePlus/SandMan/sandman_nl.ts
+++ b/SandboxiePlus/SandMan/sandman_nl.ts
@@ -2357,7 +2357,8 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_pl.ts
+++ b/SandboxiePlus/SandMan/sandman_pl.ts
@@ -2673,8 +2673,9 @@ Wybierz folder, który zawiera ten plik.</translation>
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> Wpis: Adres IP lub numer portu nie mogą być puste</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> Wpis: Adres IP lub numer portu nie mogą być puste</translation>
     </message>
     <message>
         <source> entry: Address must be IP, not host name</source>

--- a/SandboxiePlus/SandMan/sandman_pt_BR.ts
+++ b/SandboxiePlus/SandMan/sandman_pt_BR.ts
@@ -2496,7 +2496,8 @@ Nota: A verificação de atualização geralmente está por trás da versão mai
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"> entrada: IP ou Porta não pode estar vazio</translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_pt_PT.ts
+++ b/SandboxiePlus/SandMan/sandman_pt_PT.ts
@@ -2495,7 +2495,8 @@ Nota: A verificação de actualização geralmente está por trás da versão ma
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"> entrada: IP ou Porta não pode estar vazio</translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_ru.ts
+++ b/SandboxiePlus/SandMan/sandman_ru.ts
@@ -2227,8 +2227,9 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> запись: IP или порт не могут быть пустыми</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> запись: IP или порт не могут быть пустыми</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAdvanced.cpp" line="1310"/>

--- a/SandboxiePlus/SandMan/sandman_sv_SE.ts
+++ b/SandboxiePlus/SandMan/sandman_sv_SE.ts
@@ -2617,8 +2617,9 @@ Notera: Uppdateringskontrollen är ofta bakom senaste GitHub-utgivningen för at
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> entrè: IP eller port kan inte vara tomt</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> entrè: IP eller port kan inte vara tomt</translation>
     </message>
     <message>
         <source> entry: Address must be IP, not host name</source>

--- a/SandboxiePlus/SandMan/sandman_tr.ts
+++ b/SandboxiePlus/SandMan/sandman_tr.ts
@@ -2063,8 +2063,9 @@ Lütfen bu dosyayı içeren bir klasör seçin.</translation>
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation>. giriş: IP veya Bağlantı Noktası boş olamaz</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished">. giriş: IP veya Bağlantı Noktası boş olamaz</translation>
     </message>
     <message>
         <location filename="Windows/OptionsAdvanced.cpp" line="1310"/>

--- a/SandboxiePlus/SandMan/sandman_uk.ts
+++ b/SandboxiePlus/SandMan/sandman_uk.ts
@@ -2351,7 +2351,8 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_vi.ts
+++ b/SandboxiePlus/SandMan/sandman_vi.ts
@@ -2347,7 +2347,8 @@ Ghi chú: Việc kiểm tra bản cập nhật thường nằm sau bản phát h
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/SandboxiePlus/SandMan/sandman_zh_CN.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_CN.ts
@@ -2683,12 +2683,13 @@ Please select a folder which contains this file.</source>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="984"/>
         <source>Please enter IP and Port.</source>
-        <translation>请输入IP地址与端口。</translation>
+        <translation>请输入 IP 地址与端口。</translation>
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation>进入：IP或端口号不能为空</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation>第 %1 项：IP 或端口号不能为空</translation>
     </message>
     <message>
         <source> entry: Address must be IP, not host name</source>

--- a/SandboxiePlus/SandMan/sandman_zh_TW.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_TW.ts
@@ -2504,8 +2504,9 @@ Note: The update check is often behind the latest GitHub release to ensure that 
     </message>
     <message>
         <location filename="Windows/OptionsNetwork.cpp" line="1166"/>
-        <source> entry: IP or Port cannot be empty</source>
-        <translation> 輸入: IP 位址或連接埠不能為空</translation>
+        <source>Entry %1 : IP or Port cannot be empty</source>
+        <oldsource> entry: IP or Port cannot be empty</oldsource>
+        <translation type="unfinished"> 輸入: IP 位址或連接埠不能為空</translation>
     </message>
     <message>
         <source> entry: Address must be IP, not host name</source>


### PR DESCRIPTION
Improve hint text while IP or port is empty while saving net proxy options.
Origin text:
```
1 entry: IP or Port cannot be empty
```
New text:
```
Entry %1 : IP or Port cannot be empty
```
This modification will make the translated text more accurate and natural.