### PR TITLE
feat: adjust trace type width based on text

### DIFF
--- a/SandboxiePlus/MiscHelpers/Common/CheckList.h
+++ b/SandboxiePlus/MiscHelpers/Common/CheckList.h
@@ -137,6 +137,28 @@ public:
         return nbChecked == nbRows ? Qt::Checked : nbUnchecked == nbRows ? Qt::Unchecked : Qt::PartiallyChecked;
     }
 
+    /**
+     * @brief Adjust the width based on item text and UI elements
+     */
+    void adjustWidthForItems() {
+        int maxWidth = 0;
+        QFontMetrics fontMetrics(font());
+        for (int i = 0; i < count(); i++) {
+            QString it = itemText(i);
+            int itemWidth = fontMetrics.horizontalAdvance(it);
+            maxWidth = qMax(maxWidth, itemWidth);
+        }
+    
+        const int checkboxWidth = style()->pixelMetric(QStyle::PM_IndicatorWidth);
+        const int scrollBarWidth = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+        const int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth) * 2;
+        const int horizontalMargin = style()->pixelMetric(QStyle::PM_FocusFrameHMargin) * 4;
+    
+        // totalWidtl = text + checkbox + scroll bar + frame + margin + extra safezone
+        maxWidth += checkboxWidth + scrollBarWidth + frameWidth + horizontalMargin + 10;
+        setMinimumWidth(maxWidth);
+    }
+
 protected:
     /*bool eventFilter(QObject* _object, QEvent* _event)
     {

--- a/SandboxiePlus/SandMan/Views/TraceView.cpp
+++ b/SandboxiePlus/SandMan/Views/TraceView.cpp
@@ -288,7 +288,7 @@ CTraceView::CTraceView(bool bStandAlone, QWidget* parent) : QWidget(parent)
 	m_pTraceType->setNoneCheckedText(tr("[All]"));
 	foreach(quint32 type, CTraceEntry::AllTypes()) 
 		m_pTraceType->addCheckItem(CTraceEntry::GetTypeStr(type), type, Qt::Unchecked);
-	m_pTraceType->setMinimumWidth(100);
+	m_pTraceType->adjustWidthForItems();
 	connect(m_pTraceType, SIGNAL(globalCheckStateChanged(int)), this, SLOT(OnSetFilter()));
 	m_pTraceToolBar->addWidget(m_pTraceType);
 


### PR DESCRIPTION
Currently, the `Type` dropdown box on SandMan's `Trace Log` page omits text when zoom is set in Windows. For example, `ApiCall` is displayed as `A...l`. 
This PR introduces a new method to QCheckList (`adjustWidthForItems`), which calculates the actual display width of the largest text by traversing the item list, and dynamically obtains the actual display width of UI elements (e.g., checkboxes, scrollbars) in order to accurately calculate the actual width needed at the moment.

This PR has been tested on `Windows 11 23H2 x64`. The test was conducted on a monitor with a physical resolution of `3840x2160` (4K) and system scaling of `100%` `150%` and `200%`, and it worked fine.