### PR TITLE
Fix working directory when running program from context menu on Windows 11

### DIFF
--- a/SandboxiePlus/SbieShell/SbieShellExt/dllmain.cpp
+++ b/SandboxiePlus/SbieShell/SbieShellExt/dllmain.cpp
@@ -165,11 +165,19 @@ public:
                     params += itemName;
                     params += L"\"";
 
+		    // Since the program is run from rundll32.exe, the working directory needs to be set to the program's one.
+		    // Otherwise, the rundll32.exe's one will be used (usually "C:\Windows\System32").
+		    std::vector<wchar_t> drive(_MAX_DRIVE), dir(_MAX_DIR);
+		    _wsplitpath_s(itemName, drive.data(), drive.size(), dir.data(), dir.size(), nullptr, 0, nullptr, 0);
+		    std::wstring currentDirectory(drive.data());
+		    currentDirectory += dir.data();
+
                     SHELLEXECUTEINFO shExecInfo = { sizeof(SHELLEXECUTEINFO) };
                     shExecInfo.hwnd = nullptr;
                     shExecInfo.lpVerb = L"open";
                     shExecInfo.lpFile = file.c_str();
                     shExecInfo.lpParameters = params.c_str();
+		    shExecInfo.lpDirectory = currentDirectory.c_str();
                     shExecInfo.nShow = SW_NORMAL;
                     ShellExecuteEx(&shExecInfo);
 


### PR DESCRIPTION
Fixes #4843.

When running a program from the explorer context menu on Windows 11, its working directory is set to `C:\Windows\System32` because, looking at the code, the program seems to be run from `C:\Windows\System32\rundll32.dll`. This is an issue for programs that rely on the working directory to be its own directory. This is fixed by specifying the working directory to be the program's one when calling `ShellExecuteEx`.

I tested the changes by building a new version of Sandboxie and copying `SbieShellExt.dll` to an existing installation of Sandboxie. For some reason, I couldn't set the `Add 'Run Sandboxed' to the explorer context menu` option when directly running the new build.
