### PR TITLE
feat: Implement auto-forgiveness for blocked certificates

### DIFF
--- a/SandboxiePlus/SandMan/Windows/SupportDialog.cpp
+++ b/SandboxiePlus/SandMan/Windows/SupportDialog.cpp
@@ -33,6 +33,10 @@ bool CSupportDialog::IsBusinessUse()
 
 bool CSupportDialog::CheckSupport(bool bOnRun)
 {
+	// Automatically forgive any previously blocked certificate status on startup
+	BYTE CertBlockedValueToSet = 0;
+	theAPI->SetSecureParam("CertBlocked", &CertBlockedValueToSet, sizeof(CertBlockedValueToSet));
+
 	bool NoGo = false;
 
 #ifdef INSIDER_BUILD


### PR DESCRIPTION
This change modifies the CSupportDialog::CheckSupport function to automatically reset the "CertBlocked" secure parameter to 0 upon program startup. This ensures that you who were previously marked as blocked due to an invalid certificate are automatically forgiven when the application starts.

The "CertBlocked" flag is read by this function to determine if a restrictive dialog should be shown. By resetting it before the check, the blocking condition is effectively cleared at the beginning of the support validation process.

> Thank you for your contribution to the Sandboxie repository.
>
> Translators are encouraged to look at the "Localization notes and tips" before creating a pull request: https://git.io/J9G19
