### PR TITLE
Add option to use the new Qt Windows 11 style on SandMan

### DIFF
--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -3310,6 +3310,7 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
   <tabstop>chkSbieAll</tabstop>
   <tabstop>chkWatchConfig</tabstop>
   <tabstop>chkSkipUAC</tabstop>
+  <tabstop>chkUseW11Style</tabstop>
   <tabstop>chkAdminOnly</tabstop>
   <tabstop>chkPassRequired</tabstop>
   <tabstop>btnSetPassword</tabstop>

--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -48,7 +48,7 @@
         <enum>QTabWidget::North</enum>
        </property>
        <property name="currentIndex">
-        <number>8</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="tabGeneral">
         <attribute name="title">
@@ -65,6 +65,45 @@
              <string>General Options</string>
             </attribute>
             <layout class="QGridLayout" name="gridLayout_8">
+             <item row="14" column="3">
+              <spacer name="horizontalSpacer_14">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="14" column="1">
+              <spacer name="verticalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>84</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="14" column="2">
+              <spacer name="horizontalSpacer_8">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>195</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
              <item row="4" column="1" colspan="2">
               <layout class="QHBoxLayout" name="horizontalLayout_3">
                <item>
@@ -79,54 +118,20 @@
                </item>
               </layout>
              </item>
-             <item row="6" column="1" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_6">
-               <item>
-                <widget class="QCheckBox" name="chkPauseForce">
-                 <property name="text">
-                  <string>Hotkey for suspending process/folder forcing:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QKeySequenceEdit" name="keyPauseForce"/>
-               </item>
-              </layout>
-             </item>
-             <item row="11" column="0">
-              <widget class="QLabel" name="lblRecovery">
-               <property name="font">
-                <font>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                 <kerning>true</kerning>
-                </font>
-               </property>
+             <item row="2" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkSandboxUrls">
                <property name="text">
-                <string>Recovery Options</string>
+                <string>Open urls from this ui sandboxed</string>
+               </property>
+               <property name="tristate">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
-             <item row="13" column="1">
-              <spacer name="verticalSpacer_4">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>84</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="1" column="1">
-              <widget class="QComboBox" name="uiLang"/>
-             </item>
-             <item row="8" column="1" colspan="2">
-              <widget class="QCheckBox" name="chkAsyncBoxOps">
+             <item row="9" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkAutoTerminate">
                <property name="text">
-                <string>Run box operations asynchronously whenever possible (like content deletion)</string>
+                <string>Terminate all boxed processes when Sandman exits</string>
                </property>
               </widget>
              </item>
@@ -151,98 +156,7 @@
                </property>
               </widget>
              </item>
-             <item row="5" column="1" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <item>
-                <widget class="QCheckBox" name="chkTop">
-                 <property name="text">
-                  <string>Hotkey for bringing sandman to the top:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QKeySequenceEdit" name="keyTop"/>
-               </item>
-              </layout>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_19">
-               <property name="text">
-                <string>UI Language:</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-               <property name="buddy">
-                <cstring>uiLang</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="1" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QCheckBox" name="chkSuspend">
-                 <property name="text">
-                  <string>Hotkey for suspending all processes:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QKeySequenceEdit" name="keySuspend"/>
-               </item>
-              </layout>
-             </item>
-             <item row="13" column="2">
-              <spacer name="horizontalSpacer_8">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>195</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="13" column="3">
-              <spacer name="horizontalSpacer_14">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="9" column="1" colspan="2">
-              <widget class="QCheckBox" name="chkAutoTerminate">
-               <property name="text">
-                <string>Terminate all boxed processes when Sandman exits</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1" colspan="2">
-              <widget class="QCheckBox" name="chkSandboxUrls">
-               <property name="text">
-                <string>Open urls from this ui sandboxed</string>
-               </property>
-               <property name="tristate">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="1" colspan="2">
-              <widget class="QCheckBox" name="chkSkipUAC">
-               <property name="text">
-                <string>Always run SandMan UI as Admin</string>
-               </property>
-              </widget>
-             </item>
-             <item row="12" column="1">
+             <item row="13" column="1">
               <layout class="QVBoxLayout" name="verticalLayout_3">
                <property name="bottomMargin">
                 <number>0</number>
@@ -269,6 +183,99 @@
                 </widget>
                </item>
               </layout>
+             </item>
+             <item row="12" column="0">
+              <widget class="QLabel" name="lblRecovery">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                 <kerning>true</kerning>
+                </font>
+               </property>
+               <property name="text">
+                <string>Recovery Options</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="1" colspan="2">
+              <layout class="QHBoxLayout" name="horizontalLayout_5">
+               <item>
+                <widget class="QCheckBox" name="chkTop">
+                 <property name="text">
+                  <string>Hotkey for bringing sandman to the top:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QKeySequenceEdit" name="keyTop"/>
+               </item>
+              </layout>
+             </item>
+             <item row="6" column="1" colspan="2">
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item>
+                <widget class="QCheckBox" name="chkPauseForce">
+                 <property name="text">
+                  <string>Hotkey for suspending process/folder forcing:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QKeySequenceEdit" name="keyPauseForce"/>
+               </item>
+              </layout>
+             </item>
+             <item row="8" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkAsyncBoxOps">
+               <property name="text">
+                <string>Run box operations asynchronously whenever possible (like content deletion)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_19">
+               <property name="text">
+                <string>UI Language:</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+               <property name="buddy">
+                <cstring>uiLang</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QComboBox" name="uiLang"/>
+             </item>
+             <item row="7" column="1" colspan="2">
+              <layout class="QHBoxLayout" name="horizontalLayout_2">
+               <item>
+                <widget class="QCheckBox" name="chkSuspend">
+                 <property name="text">
+                  <string>Hotkey for suspending all processes:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QKeySequenceEdit" name="keySuspend"/>
+               </item>
+              </layout>
+             </item>
+             <item row="10" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkSkipUAC">
+               <property name="text">
+                <string>Always run SandMan UI as Admin</string>
+               </property>
+              </widget>
+             </item>
+             <item row="11" column="1">
+              <widget class="QCheckBox" name="chkUseW11Style">
+               <property name="text">
+                <string>Use the new SandMan style on Windows 11</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -342,6 +342,8 @@ CSettingsWindow::CSettingsWindow(QWidget* parent)
 	connect(ui.chkShowRecovery, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
 	connect(ui.chkCheckDelete, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
 	connect(ui.chkRecoveryTop, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
+
+	connect(ui.chkUseW11Style, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
 	//
 
 	// Shell Integration
@@ -1069,6 +1071,8 @@ void CSettingsWindow::LoadSettings()
 	ui.chkMinimize->setChecked(theConf->GetBool("Options/MinimizeToTray", false));
 	ui.chkSingleShow->setChecked(theConf->GetBool("Options/TraySingleClick", false));
 
+	ui.chkUseW11Style->setChecked(theConf->GetBool("Options/UseW11Style", false));
+
 	OnLoadAddon();
 
 	bool bImDiskReady = theGUI->IsImDiskReady();
@@ -1632,6 +1636,8 @@ void CSettingsWindow::SaveSettings()
 	theConf->SetValue("Options/OnClose", ui.cmbOnClose->currentData());
 	theConf->SetValue("Options/MinimizeToTray", ui.chkMinimize->isChecked());
 	theConf->SetValue("Options/TraySingleClick", ui.chkSingleShow->isChecked());
+
+	theConf->SetValue("Options/UseW11Style", ui.chkUseW11Style->isChecked());
 
 	if (theAPI->IsConnected())
 	{

--- a/SandboxiePlus/SandMan/main.cpp
+++ b/SandboxiePlus/SandMan/main.cpp
@@ -81,6 +81,10 @@ int main(int argc, char *argv[])
 	QtSingleApplication app(argc, argv);
 	app.setQuitOnLastWindowClosed(false);
 
+	bool UseW11Style = theConf->GetBool("Options/UseW11Style", false);
+	if (app.style()->name() == "windows11" && !UseW11Style)
+		app.setStyle("windowsvista");
+
 	//InitConsole(false);
 
 	bool IsBoxed = GetModuleHandleW(L"SbieDll.dll") != NULL;


### PR DESCRIPTION
Qt 6.7 introduced a new Windows 11 style which is, in my opinion, a bit broken and doesn't fit well with the rest of the Windows apps. It is the default style for apps running on Windows 11, and does not show on Windows 10.

Thus, I have disabled it by default and added an option to enable it, only on Windows 11.