### PR TITLE
Fix RTL layout for Arabic

### DIFF
--- a/Sandboxie/core/dll/support.c
+++ b/Sandboxie/core/dll/support.c
@@ -350,7 +350,8 @@ _FX ULONG SbieDll_GetLanguage(BOOLEAN *rtl)
     }
 
     if (rtl) {
-        if (lang == 1037)               /* Hebrew */
+        if (lang == 1037 ||             /* Hebrew */
+			lang == 1025)               /* Arabic */
             *rtl = TRUE;
         else
             *rtl = FALSE;


### PR DESCRIPTION
Arabic is not treated as an RTL language in `support.c`. This causes the UAC prompt dialog to fail to apply RTL layout in Arabic.

This PR adds Arabic into the RTL language list.

This would be better when the UAC prompt dialog gets actual Arabic translations.