### PR TITLE
Add sync workflow before WinGet publish

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,9 +1,32 @@
 name: Publish to WinGet
+
 on:
   release:
     types: [released]
+  # Optional: allow manual runs for testing the sync
+  workflow_dispatch:
+
 jobs:
+  # Trigger upstream sync in sandboxie-plus/winget-pkgs (non-default branch)
+  sync-upstream-winget-pkgs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger winget-pkgs sync workflow on upstream_sync branch
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_TOKEN }} # PAT with public_repo and workflow scopes
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "Missing secret WINGET_TOKEN with public_repo + workflow scopes." >&2
+            exit 1
+          fi
+          curl -sS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/sandboxie-plus/winget-pkgs/actions/workflows/sync.yml/dispatches \
+            -d '{"ref":"upstream_sync","inputs":{"sync_test_mode":"false"}}'
+
   publish-plus:
+    needs: sync-upstream-winget-pkgs
     runs-on: windows-latest # action can only be run on Windows
     steps:
       - name: Publish Sandboxie-Plus
@@ -14,6 +37,7 @@ jobs:
           token: ${{ secrets.WINGET_TOKEN }}
 
   publish-classic:
+    needs: sync-upstream-winget-pkgs
     runs-on: windows-latest
     steps:
       - name: Get Sandboxie-Classic version


### PR DESCRIPTION
> [!IMPORTANT]
> No tests have been performed on my side due to time constraints.

### Summary
- Add a job that triggers the upstream sync workflow in sandboxie-plus/winget-pkgs before publishing to WinGet.
- Allow the workflow to be run manually (workflow_dispatch). Manual runs will execute the full pipeline (sync + publish).

### Why
- Ensures the fork sandboxie-plus/winget-pkgs is synchronized before publishing manifests, reducing failures and improving determinism.

### Secrets and permissions
- [ ] In order to achieve it, WINGET_TOKEN should be updated by the PAT owner.
  - Required scopes for classic PAT: `public_repo` and `workflow`.
  - For fine‑grained PATs, grant `Actions: Read and write` and `Contents: Read` on sandboxie-plus/winget-pkgs.
  - The PAT owner must have write access to sandboxie-plus/winget-pkgs.

### How to test
- [ ] Manual trigger (Actions → Publish to WinGet → Run workflow): verifies the sync job and then runs both publish jobs.