### PR TITLE
Restrict installation on specific Windows 10 versions

### DIFF
--- a/Installer/Sandboxie-Plus.iss
+++ b/Installer/Sandboxie-Plus.iss
@@ -497,6 +497,23 @@ begin
     exit;
   end;
 
+  // Restrict Windows 10 versions between 1507 (build 10240) and 1607 (build 14393).
+  if (Version.Major = 10) and (Version.Minor = 0) and
+     (Version.Build >= 10240) and (Version.Build <= 14393) then
+  begin
+    if MsgBox(
+    'Qt 6 framework does not support Windows 10 versions 1507, 1511, or 1607 (LTSB).' + #13#10 +
+    'Please update to Windows LTSC 2019 (build 17763) or newer.' + #13#10 +
+    'See issue #5079 for details:' + #13#10 +
+    'https://github.com/sandboxie-plus/Sandboxie/issues/5079' + #13#10 +
+    'Do you want to continue with the installation?',
+    mbInformation, MB_YESNO) = IDNO then
+    begin
+    Result := False;
+    exit;
+    end;
+  end;
+
   // Ask to uninstall Sandboxie Classic if found.
   ExecRet := IDYES;
 


### PR DESCRIPTION
Add a restriction for unsupported Windows 10 versions during Sandboxie Plus installation.

> [!IMPORTANT]
> No direct tests have been performed on my side due to time constraints.