### PR TITLE
Add BLOB handling for HOSTENT in DNS filtering for legacy APIs

### DIFF
--- a/Sandboxie/core/dll/dns_filter.c
+++ b/Sandboxie/core/dll/dns_filter.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2022 David Xanatos, xanasoft.com
  *
  * This program is free software: you can redistribute it and/or modify
@@ -17,6 +17,13 @@
 
 //---------------------------------------------------------------------------
 // DNS Filter
+//
+// IMPORTANT: HOSTENT structures in BLOB format use RELATIVE POINTERS (offsets)
+//            not absolute pointers. All pointer-typed fields in HOSTENT contain
+//            offset values from the HOSTENT base address. Consumer code must
+//            convert these offsets to absolute pointers using ABS_PTR before
+//            dereferencing. This is required by Windows BLOB specification for
+//            relocatable data structures.
 //---------------------------------------------------------------------------
 
 #define NOGDI
@@ -85,7 +92,7 @@ typedef struct _IP_ENTRY
 } IP_ENTRY;
 
 typedef struct _WSA_LOOKUP {
-    LIST* pEntries;
+    LIST* pEntries;          // THREAD SAFETY: Read-only after initialization; safe for concurrent reads
     BOOLEAN NoMore;
     WCHAR* DomainName;       // Request Domain
     GUID* ServiceClassId;    // Request Class ID
@@ -134,7 +141,60 @@ _FX BOOLEAN WSA_IsIPv6Query(LPGUID lpServiceClassId)
 }
 
 //---------------------------------------------------------------------------
+// Helper macros for alignment and relative pointers
+//---------------------------------------------------------------------------
+
+// Static assertion to ensure pointer size matches uintptr_t (required for offset storage)
+// This validates our assumption that offsets can be safely stored in pointer-typed fields
+#if defined(_WIN64)
+static_assert(sizeof(void*) == sizeof(uintptr_t) && sizeof(void*) == 8, "64-bit pointer size mismatch");
+#else
+static_assert(sizeof(void*) == sizeof(uintptr_t) && sizeof(void*) == 4, "32-bit pointer size mismatch");
+#endif
+
+// Align pointer up to specified boundary (must be power of 2)
+#define ALIGN_UP(ptr, align) (BYTE*)((((UINT_PTR)(ptr)) + ((align)-1)) & ~((UINT_PTR)((align)-1)))
+
+// Relative pointer helpers for HOSTENT blob
+// Windows BLOB format uses offsets (not absolute pointers) from the base address
+// This is required for the HOSTENT structure to be relocatable in memory
+#define REL_OFFSET(base, ptr) ((uintptr_t)((BYTE*)(ptr) - (BYTE*)(base)))
+#define ABS_PTR(base, rel)    ((void*)(((BYTE*)(base)) + (uintptr_t)(rel)))
+
+// Extract offset value from a pointer-typed field that actually contains a relative offset
+// Use this when reading HOSTENT blob relative pointers stored in pointer-typed fields
+// NOTE: This extracts the stored offset value, not a pointer - do not dereference the result
+static inline uintptr_t GET_REL_FROM_PTR(void* p) {
+    return (uintptr_t)(p);
+}
+
+// Debug buffer bounds checking (only in debug builds)
+#ifdef _DEBUG
+#define CHECK_BUFFER_SPACE(ptr, size, end) \
+    do { if ((BYTE*)(ptr) + (size) > (BYTE*)(end)) { \
+        SetLastError(WSAEFAULT); \
+        return FALSE; \
+    } } while(0)
+#else
+#define CHECK_BUFFER_SPACE(ptr, size, end) ((void)0)
+#endif
+
+//---------------------------------------------------------------------------
 // WSA_FillResponseStructure
+//
+// Builds a complete WSAQUERYSETW structure with DNS results in a single buffer.
+// Memory layout: WSAQUERYSETW | ServiceInstanceName | QueryString | CSADDR_INFO[] | 
+//                SOCKADDR[] | BLOB | HOSTENT | h_name | h_aliases | h_addr_list | IPs
+//
+// IMPORTANT: The HOSTENT structure uses RELATIVE pointers (offsets from hostentBase)
+//            as per Windows BLOB specification for relocatable data structures.
+//
+// Encoding: Domain names are converted from WCHAR to ANSI (CP_ACP) for HOSTENT
+//           compatibility with Windows host resolution APIs.
+//
+// Thread Safety: This function reads from shared pLookup->pEntries list but does
+//                not modify it. Concurrent calls are safe if the list is immutable
+//                after initialization. Each call writes to caller-provided buffer.
 //---------------------------------------------------------------------------
 
 _FX BOOLEAN WSA_FillResponseStructure(
@@ -142,7 +202,8 @@ _FX BOOLEAN WSA_FillResponseStructure(
     LPWSAQUERYSETW lpqsResults,
     LPDWORD lpdwBufferLength)
 {
-    if (!pLookup || !pLookup->pEntries)
+    // Validate input parameters
+    if (!pLookup || !pLookup->pEntries || !lpqsResults || !lpdwBufferLength)
         return FALSE;
 
     if (!pLookup->DomainName)
@@ -150,13 +211,26 @@ _FX BOOLEAN WSA_FillResponseStructure(
 
     BOOLEAN isIPv6Query = WSA_IsIPv6Query(pLookup->ServiceClassId);
 
+    // Cache string length to avoid repeated wcslen calls
+    SIZE_T domainChars = wcslen(pLookup->DomainName);
+    
+    // Convert domain name to narrow string (ANSI - CP_ACP) for HOSTENT
+    // NOTE: Using CP_ACP encoding as Windows HOSTENT APIs expect ANSI strings
+    // Pre-compute converted length for accurate size calculation
+    int hostNameBytesNeeded = WideCharToMultiByte(CP_ACP, 0, pLookup->DomainName, (int)(domainChars + 1), NULL, 0, NULL, NULL);
+    if (hostNameBytesNeeded <= 0) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
     // Calc buffer size needed
-    DWORD neededSize = sizeof(WSAQUERYSETW);
-    DWORD domainNameLen = (wcslen(pLookup->DomainName) + 1) * sizeof(WCHAR);
-    neededSize += domainNameLen;
+    SIZE_T neededSize = sizeof(WSAQUERYSETW);
+    SIZE_T domainNameLen = (domainChars + 1) * sizeof(WCHAR);
+    neededSize += domainNameLen;  // for lpszServiceInstanceName
+    neededSize += domainNameLen;  // for lpszQueryString
 
     // Calc IP size
-    DWORD ipCount = 0;
+    SIZE_T ipCount = 0;
     IP_ENTRY* entry;
 
     // Filter IP by type
@@ -172,10 +246,16 @@ _FX BOOLEAN WSA_FillResponseStructure(
         return FALSE;
     }
 
-    DWORD csaddrSize = sizeof(CSADDR_INFO) * ipCount;
+    // Defensive: ensure ipCount fits in DWORD before casting (extremely large rule lists)
+    if (ipCount > 0xFFFFFFFFUL) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    SIZE_T csaddrSize = (SIZE_T)ipCount * sizeof(CSADDR_INFO);
     neededSize += csaddrSize;
 
-    DWORD sockaddrSize = 0;
+    SIZE_T sockaddrSize = 0;
     for (entry = (IP_ENTRY*)List_Head(pLookup->pEntries); entry; entry = (IP_ENTRY*)List_Next(entry)) {
         if ((isIPv6Query && entry->Type == AF_INET6) ||
             (!isIPv6Query && entry->Type == AF_INET)) {
@@ -187,9 +267,31 @@ _FX BOOLEAN WSA_FillResponseStructure(
     }
     neededSize += sockaddrSize;
 
+    // Add BLOB size for HOSTENT structure
+    // NOTE: Windows BLOB format requires relative offsets (not absolute pointers) for relocatable data
+    // HOSTENT structure + converted domain name + h_aliases NULL + h_addr_list entries + final NULL + IP addresses
+    SIZE_T addrSize = isIPv6Query ? 16 : 4;  // IPv6 or IPv4 address size
+    SIZE_T blobSize = sizeof(HOSTENT) + 
+                      (SIZE_T)hostNameBytesNeeded +                    // Narrow string (ANSI)
+                      (sizeof(void*) - 1) +                             // Worst-case padding before h_aliases
+                      sizeof(PCHAR) +                                   // h_aliases NULL terminator
+                      (sizeof(void*) - 1) +                             // Worst-case padding before h_addr_list
+                      (ipCount * sizeof(PCHAR)) + sizeof(PCHAR) +       // h_addr_list array + NULL terminator
+                      (ipCount * addrSize);                             // actual IP addresses
+    
+    // Account for alignment padding before BLOB structure
+    neededSize = (neededSize + (sizeof(void*) - 1)) & ~(sizeof(void*) - 1);
+    neededSize += sizeof(BLOB) + blobSize;
+
+    // Check for overflow (DWORD is 32-bit unsigned)
+    if (neededSize > 0xFFFFFFFF) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
     // Buffer not enough, return error
-    if (*lpdwBufferLength < neededSize) {
-        *lpdwBufferLength = neededSize;
+    if (*lpdwBufferLength < (DWORD)neededSize) {
+        *lpdwBufferLength = (DWORD)neededSize;
         SetLastError(WSAEFAULT);
         return FALSE;
     }
@@ -200,20 +302,31 @@ _FX BOOLEAN WSA_FillResponseStructure(
     lpqsResults->dwNameSpace = pLookup->Namespace;
 
     BYTE* currentPtr = (BYTE*)lpqsResults + sizeof(WSAQUERYSETW);
+    
+#ifdef _DEBUG
+    // Debug: set buffer end for bounds checking
+    BYTE* bufferEnd = (BYTE*)lpqsResults + *lpdwBufferLength;
+#endif
 
+    // Copy ServiceInstanceName (wide string)
+    CHECK_BUFFER_SPACE(currentPtr, domainNameLen, bufferEnd);
     lpqsResults->lpszServiceInstanceName = (LPWSTR)currentPtr;
     wcscpy(lpqsResults->lpszServiceInstanceName, pLookup->DomainName);
     currentPtr += domainNameLen;
 
+    // Copy QueryString (wide string)
+    CHECK_BUFFER_SPACE(currentPtr, domainNameLen, bufferEnd);
     lpqsResults->lpszQueryString = (LPWSTR)currentPtr;
     wcscpy(lpqsResults->lpszQueryString, pLookup->DomainName);
     currentPtr += domainNameLen;
 
-    lpqsResults->dwNumberOfCsAddrs = ipCount;
+    // CSADDR_INFO array
+    CHECK_BUFFER_SPACE(currentPtr, csaddrSize, bufferEnd);
+    lpqsResults->dwNumberOfCsAddrs = (DWORD)ipCount;  // Safe: already verified ipCount fits in buffer
     lpqsResults->lpcsaBuffer = (PCSADDR_INFO)currentPtr;
     currentPtr += csaddrSize;
 
-    DWORD i = 0;
+    SIZE_T i = 0;
     for (entry = (IP_ENTRY*)List_Head(pLookup->pEntries); entry; entry = (IP_ENTRY*)List_Next(entry)) {
         if ((isIPv6Query && entry->Type != AF_INET6) ||
             (!isIPv6Query && entry->Type != AF_INET)) {
@@ -223,12 +336,13 @@ _FX BOOLEAN WSA_FillResponseStructure(
         PCSADDR_INFO csaInfo = &lpqsResults->lpcsaBuffer[i++];
 
         if (entry->Type == AF_INET) {
+            CHECK_BUFFER_SPACE(currentPtr, sizeof(SOCKADDR_IN) * 2, bufferEnd);
             SOCKADDR_IN* remoteAddr = (SOCKADDR_IN*)currentPtr;
             currentPtr += sizeof(SOCKADDR_IN);
             memset(remoteAddr, 0, sizeof(SOCKADDR_IN));
 
             remoteAddr->sin_family = AF_INET;
-            remoteAddr->sin_port = 0x3500;
+            remoteAddr->sin_port = 0x3500;  // DNS port 53 in network byte order (big-endian)
             remoteAddr->sin_addr.S_un.S_addr = entry->IP.Data32[3];
 
             csaInfo->RemoteAddr.lpSockaddr = (LPSOCKADDR)remoteAddr;
@@ -250,12 +364,13 @@ _FX BOOLEAN WSA_FillResponseStructure(
             csaInfo->iProtocol = IPPROTO_UDP;
         }
         else if (entry->Type == AF_INET6) {
+            CHECK_BUFFER_SPACE(currentPtr, sizeof(SOCKADDR_IN6_LH) * 2, bufferEnd);
             SOCKADDR_IN6_LH* remoteAddr = (SOCKADDR_IN6_LH*)currentPtr;
             currentPtr += sizeof(SOCKADDR_IN6_LH);
             memset(remoteAddr, 0, sizeof(SOCKADDR_IN6_LH));
 
             remoteAddr->sin6_family = AF_INET6;
-            remoteAddr->sin6_port = 0x3500;
+            remoteAddr->sin6_port = 0x3500;  // DNS port 53 in network byte order (big-endian)
             memcpy(remoteAddr->sin6_addr.u.Byte, entry->IP.Data, 16);
 
             csaInfo->RemoteAddr.lpSockaddr = (LPSOCKADDR)remoteAddr;
@@ -277,6 +392,86 @@ _FX BOOLEAN WSA_FillResponseStructure(
             // magic number returned by Windows
             csaInfo->iProtocol = 23;
         }
+    }
+
+    // Create BLOB with HOSTENT structure
+    // Align currentPtr to pointer boundary before BLOB
+    currentPtr = ALIGN_UP(currentPtr, sizeof(void*));
+    
+    CHECK_BUFFER_SPACE(currentPtr, sizeof(BLOB) + blobSize, bufferEnd);
+    lpqsResults->lpBlob = (LPBLOB)currentPtr;
+    memset(lpqsResults->lpBlob, 0, sizeof(BLOB));  // Zero BLOB structure
+    currentPtr += sizeof(BLOB);
+
+    lpqsResults->lpBlob->cbSize = (DWORD)blobSize;
+    lpqsResults->lpBlob->pBlobData = currentPtr;
+
+    HOSTENT* hostent = (HOSTENT*)currentPtr;
+    memset(hostent, 0, sizeof(HOSTENT));  // Zero HOSTENT structure
+    BYTE* hostentBase = currentPtr;
+    currentPtr += sizeof(HOSTENT);
+
+    // Set address type and length
+    hostent->h_addrtype = isIPv6Query ? AF_INET6 : AF_INET;
+    hostent->h_length = isIPv6Query ? 16 : 4;
+
+    // Set h_name (relative offset - stored as pointer type but contains offset from base)
+    // IMPORTANT: This is a RELATIVE OFFSET, not an absolute pointer
+    hostent->h_name = (char*)(uintptr_t)REL_OFFSET(hostentBase, currentPtr);
+    
+    // Convert WCHAR domain name to narrow ANSI string for HOSTENT
+    int converted = WideCharToMultiByte(CP_ACP, 0, pLookup->DomainName, (int)(domainChars + 1), 
+                                        (LPSTR)currentPtr, hostNameBytesNeeded, NULL, NULL);
+    if (converted <= 0) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+    currentPtr += converted;
+
+    // Align for h_aliases pointer array
+    currentPtr = ALIGN_UP(currentPtr, sizeof(void*));
+    
+    // Set h_aliases (relative offset to NULL-terminated pointer array)
+    hostent->h_aliases = (char**)(uintptr_t)REL_OFFSET(hostentBase, currentPtr);
+    *(PCHAR*)currentPtr = 0;  // NULL terminator
+    currentPtr += sizeof(PCHAR);
+
+    // Align for h_addr_list pointer array
+    currentPtr = ALIGN_UP(currentPtr, sizeof(void*));
+    
+    // Set h_addr_list (relative offset to pointer array)
+    hostent->h_addr_list = (char**)(uintptr_t)REL_OFFSET(hostentBase, currentPtr);
+    PCHAR* addrList = (PCHAR*)currentPtr;
+    currentPtr += (ipCount + 1) * sizeof(PCHAR);  // Array of pointers + NULL terminator
+
+    // Fill IP addresses
+    SIZE_T addrIdx = 0;
+    for (entry = (IP_ENTRY*)List_Head(pLookup->pEntries); entry; entry = (IP_ENTRY*)List_Next(entry)) {
+        if ((isIPv6Query && entry->Type != AF_INET6) ||
+            (!isIPv6Query && entry->Type != AF_INET)) {
+            continue;
+        }
+
+        // Set address pointer (relative offset from hostentBase - stored as pointer but contains offset)
+        addrList[addrIdx] = (char*)(uintptr_t)REL_OFFSET(hostentBase, currentPtr);
+
+        // Copy IP address
+        if (isIPv6Query) {
+            memcpy(currentPtr, entry->IP.Data, 16);
+            currentPtr += 16;
+        } else {
+            *(DWORD*)currentPtr = entry->IP.Data32[3];
+            currentPtr += 4;
+        }
+        addrIdx++;
+    }
+    addrList[addrIdx] = 0;  // NULL terminator
+
+    // Final sanity check: ensure we didn't overrun the buffer (even in release builds)
+    // This is a lightweight failsafe in case size calculations were wrong
+    if ((BYTE*)currentPtr > ((BYTE*)lpqsResults + *lpdwBufferLength)) {
+        SetLastError(WSAEFAULT);
+        return FALSE;
     }
 
     return TRUE;
@@ -307,7 +502,7 @@ _FX BOOLEAN WSA_InitNetDnsFilter(HMODULE module)
         if (!NT_SUCCESS(status))
             break;
 
-        ULONG level = -1;
+        ULONG level = (ULONG)-1;
         WCHAR* value = Config_MatchImageAndGetValue(conf_buf, Dll_ImageName, &level);
         if (!value)
             continue;
@@ -343,15 +538,19 @@ _FX BOOLEAN WSA_InitNetDnsFilter(HMODULE module)
             if (!HasV6) {
 
                 //
-                // when there are no IPv6 entries create mapped once from the v4 ips
+                // When there are no IPv6 entries, create IPv4-mapped IPv6 addresses
+                // Format: ::ffff:a.b.c.d (RFC 4291 section 2.5.5.2)
+                // This ensures IPv6 queries can resolve IPv4-only domains
                 //
 
-                for (IP_ENTRY* entry = (IP_ENTRY*)List_Head(entries); entry && entry->Type == AF_INET; entry = (IP_ENTRY*)List_Next(entry)) {
+                for (IP_ENTRY* entry = (IP_ENTRY*)List_Head(entries); entry; entry = (IP_ENTRY*)List_Next(entry)) {
+                    if (entry->Type != AF_INET)
+                        continue;
 
                     IP_ENTRY* entry6 = (IP_ENTRY*)Dll_Alloc(sizeof(IP_ENTRY));
                     entry6->Type = AF_INET6;
 
-                    // IPv4 to IPv6 map
+                    // IPv4-mapped IPv6 address: first 80 bits zero, next 16 bits 0xFFFF, then IPv4 address
                     memset(entry6->IP.Data, 0, 10);
                     entry6->IP.Data[10] = 0xFF;
                     entry6->IP.Data[11] = 0xFF;
@@ -446,7 +645,10 @@ _FX int WSA_WSALookupServiceBeginW(
 
                 pLookup->DomainName = Dll_Alloc((path_len + 1) * sizeof(WCHAR));
                 if (pLookup->DomainName) {
-                    wcscpy(pLookup->DomainName, lpqsRestrictions->lpszServiceInstanceName);
+                    wcscpy_s(pLookup->DomainName, path_len + 1, lpqsRestrictions->lpszServiceInstanceName);
+                }
+                else {
+                    SbieApi_Log(2205, L"NetworkDnsFilter: Failed to allocate domain name");
                 }
 
                 pLookup->Namespace = lpqsRestrictions->dwNameSpace;
@@ -455,6 +657,9 @@ _FX int WSA_WSALookupServiceBeginW(
                     pLookup->ServiceClassId = Dll_Alloc(sizeof(GUID));
                     if (pLookup->ServiceClassId) {
                         memcpy(pLookup->ServiceClassId, lpqsRestrictions->lpServiceClassId, sizeof(GUID));
+                    }
+                    else {
+                        SbieApi_Log(2205, L"NetworkDnsFilter: Failed to allocate service class ID");
                     }
                 }
 
@@ -475,7 +680,7 @@ _FX int WSA_WSALookupServiceBeginW(
                 }
 
                 WCHAR msg[512];
-                Sbie_snwprintf(msg, 512, L"DNS Request Intercepted: %s%s (NS: %d, Type: %s, Hdl: 0x%x) - Using filtered response",
+                Sbie_snwprintf(msg, 512, L"DNS Request Intercepted: %s%s (NS: %d, Type: %s, Hdl: %p) - Using filtered response",
                     lpqsRestrictions->lpszServiceInstanceName, ClsId, lpqsRestrictions->dwNameSpace,
                     WSA_IsIPv6Query(lpqsRestrictions->lpServiceClassId) ? L"IPv6" : L"IPv4", fakeHandle);
                 SbieApi_MonitorPutMsg(MONITOR_DNS | MONITOR_DENY, msg);
@@ -501,7 +706,7 @@ _FX int WSA_WSALookupServiceBeginW(
 
         WCHAR msg[512];
         BOOLEAN isIPv6 = WSA_IsIPv6Query(lpqsRestrictions->lpServiceClassId);
-        Sbie_snwprintf(msg, 512, L"DNS Request Begin: %s%s, NS: %d, Type: %s, Hdl: 0x%x, Err: %d)",
+        Sbie_snwprintf(msg, 512, L"DNS Request Begin: %s%s, NS: %d, Type: %s, Hdl: %p, Err: %d)",
             lpqsRestrictions->lpszServiceInstanceName ? lpqsRestrictions->lpszServiceInstanceName : L"Unnamed",
             ClsId, lpqsRestrictions->dwNameSpace, isIPv6 ? L"IPv6" : L"IPv4",
             lphLookup ? *lphLookup : NULL, ret == SOCKET_ERROR ? GetLastError() : 0);
@@ -539,14 +744,15 @@ _FX int WSA_WSALookupServiceNextW(
 
                 if (WSA_DnsTraceFlag) {
                     WCHAR msg[2048];
-                    Sbie_snwprintf(msg, 512, L"DNS Filtered Response: %s (NS: %d, Type: %s, Hdl: 0x%x)",
+                    Sbie_snwprintf(msg, ARRAYSIZE(msg), L"DNS Filtered Response: %s (NS: %d, Type: %s, Hdl: %p)",
                         pLookup->DomainName, lpqsResults->dwNameSpace,
                         WSA_IsIPv6Query(pLookup->ServiceClassId) ? L"IPv6" : L"IPv4", hLookup);
 
                     for (DWORD i = 0; i < lpqsResults->dwNumberOfCsAddrs; i++) {
                         IP_ADDRESS ip;
-                        if (WSA_GetIP(lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr,
-                            lpqsResults->lpcsaBuffer[i].RemoteAddr.iSockaddrLength, &ip))
+                        if (lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr &&
+                            WSA_GetIP(lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr,
+                                lpqsResults->lpcsaBuffer[i].RemoteAddr.iSockaddrLength, &ip))
                             WSA_DumpIP(lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr->sa_family, &ip, msg);
                     }
 
@@ -606,15 +812,23 @@ _FX int WSA_WSALookupServiceNextW(
             HOSTENT* hp = (HOSTENT*)lpqsResults->lpBlob->pBlobData;
             if (hp->h_addrtype == AF_INET6 || hp->h_addrtype == AF_INET) {
 
-                for (PCHAR* Addr = (PCHAR*)(((UINT_PTR)hp->h_addr_list + (UINT_PTR)hp)); *Addr; Addr++) {
+                // Convert relative pointer to absolute using ABS_PTR helper
+                // HOSTENT uses relative offsets (not absolute pointers) in BLOB format
+                // Extract offset from pointer-typed field (stored as offset value, not real pointer)
+                uintptr_t addrListOffset = GET_REL_FROM_PTR(hp->h_addr_list);
+                PCHAR* addrArray = (PCHAR*)ABS_PTR(hp, addrListOffset);
+                
+                for (PCHAR* Addr = addrArray; *Addr; Addr++) {
 
                     for (; entry && entry->Type != hp->h_addrtype; entry = (IP_ENTRY*)List_Next(entry)); // skip to an entry of the right type
-                    if (!entry) { // no more entries clear remaining results
+                    if (!entry) { // no more entries, clear remaining results
                         *Addr = 0;
-                        continue;
+                        break;  // No point continuing - all remaining addresses will be NULL
                     }
 
-                    PCHAR ptr = (PCHAR)(((UINT_PTR)*Addr + (UINT_PTR)hp));
+                    // Convert relative offset to absolute pointer (extract offset, then convert)
+                    uintptr_t ipOffset = GET_REL_FROM_PTR(*Addr);
+                    PCHAR ptr = (PCHAR)ABS_PTR(hp, ipOffset);
                     if (hp->h_addrtype == AF_INET6)
                         memcpy(ptr, entry->IP.Data, 16);
                     else if (hp->h_addrtype == AF_INET)
@@ -630,12 +844,14 @@ _FX int WSA_WSALookupServiceNextW(
 
     if (WSA_DnsTraceFlag && ret == NO_ERROR) {
         WCHAR msg[2048];
-        Sbie_snwprintf(msg, 512, L"DNS Request Found: %s (NS: %d, Hdl: 0x%x)",
+        Sbie_snwprintf(msg, ARRAYSIZE(msg), L"DNS Request Found: %s (NS: %d, Hdl: %p)",
             lpqsResults->lpszServiceInstanceName, lpqsResults->dwNameSpace, hLookup);
 
         for (DWORD i = 0; i < lpqsResults->dwNumberOfCsAddrs; i++) {
             IP_ADDRESS ip;
-            if (WSA_GetIP(lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr, lpqsResults->lpcsaBuffer[i].RemoteAddr.iSockaddrLength, &ip))
+            if (lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr &&
+                WSA_GetIP(lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr, 
+                    lpqsResults->lpcsaBuffer[i].RemoteAddr.iSockaddrLength, &ip))
                 WSA_DumpIP(lpqsResults->lpcsaBuffer[i].RemoteAddr.lpSockaddr->sa_family, &ip, msg);
         }
 
@@ -646,9 +862,16 @@ _FX int WSA_WSALookupServiceNextW(
                 WSA_DumpIP(hp->h_addrtype, NULL, msg);
             }
             else if (hp->h_addr_list) {
-                for (PCHAR* Addr = (PCHAR*)(((UINT_PTR)hp->h_addr_list + (UINT_PTR)hp)); *Addr; Addr++) {
+                // Convert relative pointer to absolute using ABS_PTR helper
+                // Extract offset from pointer-typed field (stored as offset value, not real pointer)
+                uintptr_t addrListOffset = GET_REL_FROM_PTR(hp->h_addr_list);
+                PCHAR* addrArray = (PCHAR*)ABS_PTR(hp, addrListOffset);
+                
+                for (PCHAR* Addr = addrArray; *Addr; Addr++) {
 
-                    PCHAR ptr = (PCHAR)(((UINT_PTR)*Addr + (UINT_PTR)hp));
+                    // Convert relative offset to absolute pointer (extract offset, then convert)
+                    uintptr_t ipOffset = GET_REL_FROM_PTR(*Addr);
+                    PCHAR ptr = (PCHAR)ABS_PTR(hp, ipOffset);
 
                     IP_ADDRESS ip;
                     if (hp->h_addrtype == AF_INET6)
@@ -690,7 +913,7 @@ _FX int WSA_WSALookupServiceEnd(HANDLE hLookup)
 
             if (WSA_DnsTraceFlag) {
                 WCHAR msg[256];
-                Sbie_snwprintf(msg, 256, L"DNS Filtered Request End (Hdl: 0x%x)", hLookup);
+                Sbie_snwprintf(msg, 256, L"DNS Filtered Request End (Hdl: %p)", hLookup);
                 SbieApi_MonitorPutMsg(MONITOR_DNS, msg);
             }
 
@@ -702,7 +925,7 @@ _FX int WSA_WSALookupServiceEnd(HANDLE hLookup)
 
     if (WSA_DnsTraceFlag) {
         WCHAR msg[256];
-        Sbie_snwprintf(msg, 256, L"DNS Request End (Hdl: 0x%x)", hLookup);
+        Sbie_snwprintf(msg, 256, L"DNS Request End (Hdl: %p)", hLookup);
         SbieApi_MonitorPutMsg(MONITOR_DNS, msg);
     }
 


### PR DESCRIPTION
Implemented support for serialized (BLOB) HOSTENT structures in DNS filtering. This maintains compatibility with legacy name-resolution APIs such as gethostbyname, as well as older applications depending on their behavior.