### PR TITLE
Fix Windows 7 device connection error

### DIFF
--- a/Sandboxie/core/drv/driver.c
+++ b/Sandboxie/core/drv/driver.c
@@ -175,8 +175,9 @@ _FX NTSTATUS DriverEntry(
     IN  UNICODE_STRING *RegistryPath)
 {
     BOOLEAN ok = TRUE;
-
-	ExInitializeDriverRuntime(DrvRtPoolNxOptIn);
+    #if (NTDDI_VERSION >= NTDDI_WIN10)
+    ExInitializeDriverRuntime(DrvRtPoolNxOptIn);
+    #endif
 
     //
     // initialize global driver variables


### PR DESCRIPTION
This is the first time I have submitted code.
I discovered that the v1.16.7 version would encounter device connection issues when using sandbox in the Windows 7 Professional Edition (x64) environment. I identified and resolved the problem of API incompatibility with Windows 7.
<img width="1033" height="567" alt="before" src="https://github.com/user-attachments/assets/14015c1d-7444-4721-9fe7-ea6d359dd498" />
<img width="953" height="675" alt="after" src="https://github.com/user-attachments/assets/baaa956a-509f-44c6-8336-8651cd3a15b8" />
