### PR TITLE
Fix the issue with switching sandbox sorting in the view

### DIFF
--- a/SandboxiePlus/SandMan/Views/SbieView.h
+++ b/SandboxiePlus/SandMan/Views/SbieView.h
@@ -83,6 +83,7 @@ private slots:
 	void						OnToolTipCallback(const QVariant& ID, QString& ToolTip);
 
 	void						OnCustomSortByColumn(int column);
+	void                        OnHeaderChange();
 
 	void						OnDoubleClicked(const QModelIndex& index);
 	void						OnClicked(const QModelIndex& index);


### PR DESCRIPTION
Implemented sorting by sandbox name in descending order, and fixed the issue with header state restoration.

![test](https://github.com/user-attachments/assets/cfa2f8a8-71ce-4f93-a23b-c6c73ecc450f)
