### PR TITLE
Fix file search crash, add expand/collapse controls, and improve Qt 6.10 filter compatibility

### DIFF
--- a/SandboxiePlus/MiscHelpers/Common/Finder.cpp
+++ b/SandboxiePlus/MiscHelpers/Common/Finder.cpp
@@ -110,6 +110,19 @@ CFinder::CFinder(QObject* pFilterTarget, QWidget *parent, int iOptions)
 	else
 		m_pHighLight = NULL;
 
+	// Expand/Collapse controls for tree navigation
+	m_pExpandAll = new QToolButton();
+	m_pExpandAll->setText("+");
+	m_pExpandAll->setToolTip(tr("Expand all"));
+	m_pSearchLayout->addWidget(m_pExpandAll);
+	connect(m_pExpandAll, SIGNAL(clicked()), this, SLOT(OnExpandAll()));
+
+	m_pCollapseAll = new QToolButton();
+	m_pCollapseAll->setText("-");
+	m_pCollapseAll->setToolTip(tr("Collapse all"));
+	m_pSearchLayout->addWidget(m_pCollapseAll);
+	connect(m_pCollapseAll, SIGNAL(clicked()), this, SLOT(OnCollapseAll()));
+
 	QWidget* pSpacer = new QWidget();
 	pSpacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	m_pSearchLayout->addWidget(pSpacer);
@@ -361,6 +374,18 @@ void CFinder::OnSelectNext()
 		m_pTree->setCurrentIndex(idx);
 	else
 		QApplication::beep();
+}
+
+void CFinder::OnExpandAll()
+{
+	if (m_pTree)
+		m_pTree->expandAll();
+}
+
+void CFinder::OnCollapseAll()
+{
+	if (m_pTree)
+		m_pTree->collapseAll();
 }
 
 void CFinder::SetProgress(int value, int maximum)

--- a/SandboxiePlus/MiscHelpers/Common/Finder.h
+++ b/SandboxiePlus/MiscHelpers/Common/Finder.h
@@ -65,6 +65,8 @@ private slots:
 	void				OnReturn();
 
 	void				OnSelectNext();
+	void				OnExpandAll();
+	void				OnCollapseAll();
 
 protected:
 	bool				GetCaseSensitive() const	{ return m_pCaseSensitive ? m_pCaseSensitive->isChecked() : false; }
@@ -89,6 +91,8 @@ private:
 	QAbstractButton*	m_pRegExp;
 	QComboBox*			m_pColumn;
 	QAbstractButton*	m_pHighLight;
+	QAbstractButton*	m_pExpandAll;
+	QAbstractButton*	m_pCollapseAll;
 	QProgressBar*		m_pProgressBar;
 
 	QRegularExpression	m_RegExp;

--- a/SandboxiePlus/SandMan/Views/FileView.h
+++ b/SandboxiePlus/SandMan/Views/FileView.h
@@ -52,17 +52,28 @@ public:
 	void ClearFilter();
 	void ClearPathFilter() { m_PathFilter.clear(); }
 	void SetRootPath(const QString& path);
+	void RefreshFilter();
 	bool IsFilterActive() const { return m_bFilterActive; }
+
+	void setSourceModel(QAbstractItemModel* sourceModel) override;
+
+signals:
+	void filterUpdated();
 
 public slots:
 	void AddPathFilter(const QString& path);
+	void SetSearchInProgress(bool inProgress) { m_bSearchInProgress = inProgress; }
 
 protected:
 	bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
 
 private:
+	void beginFilterUpdate();
+	void endFilterUpdate();
+
 	QRegularExpression m_SearchPattern;
 	bool m_bFilterActive;
+	bool m_bSearchInProgress = false;
 	QString m_RootPath;
 
 	QSet<QString> m_PathFilter;


### PR DESCRIPTION
Fixes #5166 

- Fixed file search crash
- Fixed Qt6.10 compatibility, begin/end filter change APIs when available.
- Added expand (+) and collapse (-) to finder bar.