### PR TITLE
Safely replace cfg dump tree widget

### DIFF
--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -159,10 +159,12 @@ void COptionsWindow::CreateAdvanced()
 	connect(ui.chkCfgNoExpand, SIGNAL(clicked(bool)), this, SLOT(OnDumpConfig()));
 
 
-	CPanelWidgetEx* pCfgDump = new CPanelWidgetEx(ui.tabAdvanced);
+	QTreeWidget* pOldCfgDumpTree = ui.treeCfgDump;
+	CPanelWidgetEx* pCfgDump = new CPanelWidgetEx();
 	pCfgDump->GetTree()->setHeaderLabels(tr("Name|Type|Value").split("|"));
-	ui.treeCfgDump->parentWidget()->layout()->replaceWidget(ui.treeCfgDump, pCfgDump);
-	ui.treeCfgDump->deleteLater();
+	pOldCfgDumpTree->parentWidget()->layout()->replaceWidget(pOldCfgDumpTree, pCfgDump);
+	pOldCfgDumpTree->hide();
+	pOldCfgDumpTree->deleteLater();
 	ui.treeCfgDump = pCfgDump->GetTree();
 
 	ui.tabsDebug->setCurrentIndex(0);


### PR DESCRIPTION
fixes #4900 

Store the old cfg dump tree pointer and use it for the layout replacement instead of referencing ui.treeCfgDump after creating the new panel. Instantiate the new CPanelWidgetEx without a parent, hide the old tree before calling deleteLater(), and update ui.treeCfgDump to the new tree. This avoids transient reparenting issues and potential UI glitches/crashes when swapping the widget.