### PR TITLE
Track and propagate KEY_WOW64 flags on handles

### DIFF
--- a/Sandboxie/core/dll/handle.h
+++ b/Sandboxie/core/dll/handle.h
@@ -43,6 +43,10 @@ VOID Handle_SetRelocationPath(HANDLE FileHandle, WCHAR* RelocationPath);
 
 WCHAR* Handle_GetRelocationPath(HANDLE FileHandle, ULONG ExtraLength);
 
+VOID Handle_SetKeyWow64Flags(HANDLE FileHandle, ACCESS_MASK Wow64Flags);
+
+ACCESS_MASK Handle_GetKeyWow64Flags(HANDLE FileHandle);
+
 VOID Handle_ExecuteCloseHandler(HANDLE FileHandle, BOOLEAN* DeleteOnClose);
 
 


### PR DESCRIPTION
Fixes #5171 

Add tracking for KEY_WOW64 access flags on handle state and propagate them through handle operations. A KeyWow64Flags field was added to HANDLE_STATE, with Handle_SetKeyWow64Flags and Handle_GetKeyWow64Flags accessors that mask values to KEY_WOW64_32KEY|KEY_WOW64_64KEY and synchronize via Handle_StatusData_CritSec. Duplicate handling now copies the flags to the new handle. In key creation, the code will inherit WOW64 flags from the root directory handle on Win64 when none are explicitly provided, OR the DesiredAccess is updated accordingly, and the resulting flags are stored on the created key handle. This ensures consistent WOW64 registry view behavior across handle duplication and creation.