### PR TITLE
Add Windows 11 On-Screen Keyboard freezing workaround

### DIFF
--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -3995,7 +3995,9 @@ OpenKeyPath=Joplin.exe,HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersi
 [Template_OnScreenKeyboard]
 Tmpl.Title=#4342,On-Screen Keyboard freezing fix for Windows 11
 Tmpl.Class=Misc
-Tmpl.ScanScript=if(system.version().major == 11) return true; return false;
+Tmpl.Scan=s
+Tmpl.ScanFile=C:\Windows\System32\Taskbar.dll
+#Tmpl.ScanScript=if(system.version().major == 11) return true; return false;
 OpenIpcPath=*\BaseNamedObjects*\UIA_CONNECT_EVENT_*
 OpenIpcPath=*\BaseNamedObjects*\UIA_PIPEREADY_EVENT_*
 OpenFilePath=\Device\NamedPipe\UIA_PIPE_*


### PR DESCRIPTION
Resolves #3479, resolves #3732, resolves #4477

Adds compatibility workaround for OSK freezing on Windows 11 by excluding UIA named pipes and IPC events. With these settings, the keyboard works without requiring delay-free trace logging.