### PR TITLE
fix: update 7-Zip source and privacy templates

### DIFF
--- a/Installer/get_7zip.cmd
+++ b/Installer/get_7zip.cmd
@@ -1,11 +1,14 @@
 @echo off
 setlocal
+setlocal enabledelayedexpansion
 
 set "RELEASE_VERSION=26.00"
 set "PACKAGE_VERSION=2600"
 set "SEVENZIP_DIR=%~dp0\7-Zip"
 set "SEVENZIP_WIN32=%SEVENZIP_DIR%\7z%PACKAGE_VERSION%.exe"
 set "SEVENZIP_X64=%SEVENZIP_DIR%\7z%PACKAGE_VERSION%-x64.exe"
+set "SEVENZIP_HASH_WIN32=d605eb609aa67796dca7cfe26d7e28792090bb8048302d6e05ede16e8e33145c"
+set "SEVENZIP_HASH_X64=6fe18d5b3080e39678cabfa6cef12cfb25086377389b803a36a3c43236a8a82c"
 
 mkdir "%SEVENZIP_DIR%" 2>nul
 mkdir "%SEVENZIP_DIR%\7-Zip-Win32" 2>nul
@@ -13,8 +16,12 @@ mkdir "%SEVENZIP_DIR%\7-Zip-x64" 2>nul
 
 curl -fL --url https://github.com/ip7z/7zip/releases/download/%RELEASE_VERSION%/7z%PACKAGE_VERSION%.exe -o "%SEVENZIP_WIN32%" --ssl-no-revoke
 if errorlevel 1 exit /b %errorlevel%
+call :verify_hash "%SEVENZIP_WIN32%" "%SEVENZIP_HASH_WIN32%"
+if errorlevel 1 exit /b %errorlevel%
 
 curl -fL --url https://github.com/ip7z/7zip/releases/download/%RELEASE_VERSION%/7z%PACKAGE_VERSION%-x64.exe -o "%SEVENZIP_X64%" --ssl-no-revoke
+if errorlevel 1 exit /b %errorlevel%
+call :verify_hash "%SEVENZIP_X64%" "%SEVENZIP_HASH_X64%"
 if errorlevel 1 exit /b %errorlevel%
 
 "C:\Program Files\7-Zip\7z.exe" x -y -aoa -bd -o"%SEVENZIP_DIR%\7-Zip-Win32" "%SEVENZIP_WIN32%"
@@ -23,5 +30,29 @@ if errorlevel 1 exit /b %errorlevel%
 "C:\Program Files\7-Zip\7z.exe" x -y -aoa -bd -o"%SEVENZIP_DIR%\7-Zip-x64" "%SEVENZIP_X64%"
 if errorlevel 1 exit /b %errorlevel%
 
-endlocal
+endlocal & endlocal
+exit /b 0
+
+:verify_hash
+set "FILE_PATH=%~1"
+set "EXPECTED_HASH=%~2"
+set "ACTUAL_HASH="
+
+for /f %%i in ('powershell -NoProfile -Command "$hash = Get-FileHash -Algorithm SHA256 -LiteralPath \"%FILE_PATH%\"; $hash.Hash.ToLowerInvariant()"') do (
+	set "ACTUAL_HASH=%%i"
+)
+
+if not defined ACTUAL_HASH (
+	echo Failed to compute SHA256 for "%FILE_PATH%".
+	exit /b 1
+)
+
+if /i not "!ACTUAL_HASH!"=="%EXPECTED_HASH%" (
+	echo SHA256 mismatch for "%FILE_PATH%".
+	echo Expected: %EXPECTED_HASH%
+	echo Actual:   !ACTUAL_HASH!
+	exit /b 1
+)
+
+exit /b 0
 

--- a/Installer/get_7zip.cmd
+++ b/Installer/get_7zip.cmd
@@ -1,4 +1,27 @@
-mkdir %~dp0\7-Zip
-curl -L --url https://github.com/DavidXanatos/7z/releases/download/23.01/7z2301.zip -o %~dp0\7-Zip\7z2301.zip --ssl-no-revoke
-"C:\Program Files\7-Zip\7z.exe" x -bd -o%~dp0\7-Zip\ %~dp0\7-Zip\7z2301.zip
+@echo off
+setlocal
+
+set "RELEASE_VERSION=26.00"
+set "PACKAGE_VERSION=2600"
+set "SEVENZIP_DIR=%~dp0\7-Zip"
+set "SEVENZIP_WIN32=%SEVENZIP_DIR%\7z%PACKAGE_VERSION%.exe"
+set "SEVENZIP_X64=%SEVENZIP_DIR%\7z%PACKAGE_VERSION%-x64.exe"
+
+mkdir "%SEVENZIP_DIR%" 2>nul
+mkdir "%SEVENZIP_DIR%\7-Zip-Win32" 2>nul
+mkdir "%SEVENZIP_DIR%\7-Zip-x64" 2>nul
+
+curl -fL --url https://github.com/ip7z/7zip/releases/download/%RELEASE_VERSION%/7z%PACKAGE_VERSION%.exe -o "%SEVENZIP_WIN32%" --ssl-no-revoke
+if errorlevel 1 exit /b %errorlevel%
+
+curl -fL --url https://github.com/ip7z/7zip/releases/download/%RELEASE_VERSION%/7z%PACKAGE_VERSION%-x64.exe -o "%SEVENZIP_X64%" --ssl-no-revoke
+if errorlevel 1 exit /b %errorlevel%
+
+"C:\Program Files\7-Zip\7z.exe" x -y -aoa -bd -o"%SEVENZIP_DIR%\7-Zip-Win32" "%SEVENZIP_WIN32%"
+if errorlevel 1 exit /b %errorlevel%
+
+"C:\Program Files\7-Zip\7z.exe" x -y -aoa -bd -o"%SEVENZIP_DIR%\7-Zip-x64" "%SEVENZIP_X64%"
+if errorlevel 1 exit /b %errorlevel%
+
+endlocal
 

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -1010,6 +1010,14 @@ Tmpl.Title=#4338,Mozilla Firefox
 Tmpl.Class=WebBrowser
 OpenFilePath=firefox.exe,%Tmpl.Firefox%\*
 
+[Template_Firefox_Profile_Data_Protection_Compatibility]
+Tmpl.Title=#4342,Mozilla Firefox
+Tmpl.Class=WebBrowser
+; Allows privacy-mode boxes to locate host profiles without granting direct
+; write access to the profile data.
+NormalFilePath=firefox.exe,%AppData%\Mozilla\Firefox\profiles.ini
+NormalFilePath=firefox.exe,%AppData%\Mozilla\Firefox\installs.ini
+
 [Template_Firefox_Separator]
 Tmpl.Title=-
 Tmpl.Class=WebBrowser
@@ -1057,6 +1065,14 @@ Tmpl.Title=#4338,Waterfox
 Tmpl.Class=WebBrowser
 OpenFilePath=waterfox.exe,%Tmpl.Waterfox%\*
 
+[Template_Waterfox_Profile_Data_Protection_Compatibility]
+Tmpl.Title=#4342,Waterfox
+Tmpl.Class=WebBrowser
+; Allows privacy-mode boxes to locate host profiles without granting direct
+; write access to the profile data.
+NormalFilePath=waterfox.exe,%AppData%\Waterfox\profiles.ini
+NormalFilePath=waterfox.exe,%AppData%\Waterfox\installs.ini
+
 [Template_Waterfox_Separator]
 Tmpl.Title=-
 Tmpl.Class=WebBrowser
@@ -1102,6 +1118,13 @@ OpenFilePath=palemoon.exe,%Tmpl.PaleMoon%\cert9.db
 Tmpl.Title=#4338,Pale Moon
 Tmpl.Class=WebBrowser
 OpenFilePath=palemoon.exe,%Tmpl.PaleMoon%\*
+
+[Template_PaleMoon_Profile_Data_Protection_Compatibility]
+Tmpl.Title=#4342,Pale Moon
+Tmpl.Class=WebBrowser
+; Allows privacy-mode boxes to locate host profiles without granting direct
+; write access to the profile data.
+NormalFilePath=palemoon.exe,%AppData%\Moonchild Productions\Pale Moon\profiles.ini
 
 [Template_PaleMoon_Separator]
 Tmpl.Title=-
@@ -1150,6 +1173,13 @@ Tmpl.Title=#4338,SeaMonkey
 Tmpl.Class=WebBrowser
 OpenFilePath=seamonkey.exe,%Tmpl.SeaMonkey%\*
 
+[Template_SeaMonkey_Profile_Data_Protection_Compatibility]
+Tmpl.Title=#4342,SeaMonkey
+Tmpl.Class=WebBrowser
+; Allows privacy-mode boxes to locate host profiles without granting direct
+; write access to the profile data.
+NormalFilePath=seamonkey.exe,%AppData%\Mozilla\SeaMonkey\profiles.ini
+
 [Template_SeaMonkey_Separator]
 Tmpl.Title=-
 Tmpl.Class=WebBrowser
@@ -1196,6 +1226,14 @@ OpenFilePath=librewolf.exe,%Local AppData%\LibreWolf\Profiles\*\safebrowsing*
 Tmpl.Title=#4338,LibreWolf
 Tmpl.Class=WebBrowser
 OpenFilePath=librewolf.exe,%Tmpl.LibreWolf%\*
+
+[Template_LibreWolf_Profile_Data_Protection_Compatibility]
+Tmpl.Title=#4342,LibreWolf
+Tmpl.Class=WebBrowser
+; Allows privacy-mode boxes to locate host profiles without granting direct
+; write access to the profile data.
+NormalFilePath=librewolf.exe,%AppData%\LibreWolf\profiles.ini
+NormalFilePath=librewolf.exe,%AppData%\LibreWolf\installs.ini
 
 #
 # Firefox Add-ons


### PR DESCRIPTION
## Summary
- switch the Windows 7-Zip fetch script to the official ip7z releases and fail fast when downloads or extraction fail
- add privacy-mode compatibility templates for Firefox, Waterfox, Pale Moon, SeaMonkey, and LibreWolf so they can locate host profile metadata without direct write access

## Test Plan
- run Installer/get_7zip.cmd and confirm Installer/7-Zip/7-Zip-Win32/7z.dll and Installer/7-Zip/7-Zip-x64/7z.dll are extracted
- verify the new *_Profile_Data_Protection_Compatibility templates are present in Sandboxie/install/Templates.ini