### PR TITLE
Fix missing `__cdecl` on `_vsnprintf`/`_vsnwprintf` function pointers

### DIFF
--- a/Sandboxie/common/my_ntdll.c
+++ b/Sandboxie/common/my_ntdll.c
@@ -37,8 +37,8 @@ typedef long NTSTATUS;
 // Alternatively we could link all the required functions dynamically from InitMyNtDll
 //
 
-int(*P_vsnwprintf)(wchar_t *_Buffer, size_t Count, const wchar_t * const, va_list Args) = NULL;
-int(*P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args) = NULL;
+int(__cdecl *P_vsnwprintf)(wchar_t *_Buffer, size_t Count, const wchar_t * const, va_list Args) = NULL;
+int(__cdecl *P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args) = NULL;
 
 void InitMyNtDll(HMODULE Ntdll)
 {

--- a/Sandboxie/core/dll/debug.c
+++ b/Sandboxie/core/dll/debug.c
@@ -487,7 +487,7 @@ void DbgPrint(const char* format, ...)
     
     char tmp1[510];
 
-    extern int(*P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
+    extern int(__cdecl *P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
     P_vsnprintf(tmp1, sizeof(tmp1), format, va_args);
 
     OutputDebugStringA(tmp1);
@@ -510,7 +510,7 @@ void DbgTrace(const char* format, ...)
     char tmp1[510];
     WCHAR tmp2[510];
 
-    extern int(*P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
+    extern int(__cdecl *P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
     P_vsnprintf(tmp1, sizeof(tmp1), format, va_args);
 
     Sbie_snwprintf((WCHAR *)tmp2, sizeof(tmp2)/sizeof(WCHAR), L"%S", tmp1);

--- a/Sandboxie/core/dll/sbieapi.c
+++ b/Sandboxie/core/dll/sbieapi.c
@@ -61,7 +61,7 @@ int __CRTDECL Sbie_snwprintf(wchar_t *_Buffer, size_t Count, const wchar_t * con
 	int _Result;
 	va_list _ArgList;
 
-	extern int(*P_vsnwprintf)(wchar_t *_Buffer, size_t Count, const wchar_t * const, va_list Args);
+	extern int(__cdecl *P_vsnwprintf)(wchar_t *_Buffer, size_t Count, const wchar_t * const, va_list Args);
 
 	va_start(_ArgList, _Format);
 	_Result = P_vsnwprintf(_Buffer, Count, _Format, _ArgList);
@@ -78,7 +78,7 @@ int __CRTDECL Sbie_snprintf(char *_Buffer, size_t Count, const char * const _For
 	int _Result;
 	va_list _ArgList;
 
-	extern int(*P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
+	extern int(__cdecl *P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
 
 	va_start(_ArgList, _Format);
 	_Result = P_vsnprintf(_Buffer, Count, _Format, _ArgList);
@@ -382,7 +382,7 @@ _FX LONG SbieApi_vLogEx(
     tmp2 = (UCHAR *)tmp1 + API_LOG_MESSAGE_MAX_LEN * 2 - 510;
     if (format) {
 
-        extern int(*P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
+        extern int(__cdecl *P_vsnprintf)(char *_Buffer, size_t Count, const char * const, va_list Args);
 
         Sbie_snprintf(tmp1, 510, "%S", format);
         P_vsnprintf(tmp2, 510, tmp1, va_args);


### PR DESCRIPTION
Declare `P_vsnprintf` and `P_vsnwprintf` with explicit `__cdecl`.

On 32-bit x86 builds, `/Gz` makes unspecified function pointers default to `__stdcall`. Since `ntdll!_vsnprintf` and `ntdll!_vsnwprintf` are `__cdecl` CRT functions, calling them through mismatched pointer types corrupts the stack. This fixes garbled trace output and startup crashes in 32-bit processes.