### PR TITLE
Fix race condition BSOD during driver unload

### DIFF
--- a/Sandboxie/core/drv/driver.c
+++ b/Sandboxie/core/drv/driver.c
@@ -832,6 +832,14 @@ _FX void SbieDrv_DriverUnload(DRIVER_OBJECT *DriverObject)
 {
     Driver_Unloading = TRUE;
 
+    // Make sure notify callbacks bail out immediately during unload.
+    Process_ReadyToSandbox = FALSE;
+    KeMemoryBarrier();
+
+    // Unregister process/image notify callbacks before tearing down
+    // subsystems that may be touched from process create/delete paths.
+    Process_Unload(FALSE);
+
     //
     // unload just the hooks, in case this is a partial unload
     //
@@ -843,7 +851,6 @@ _FX void SbieDrv_DriverUnload(DRIVER_OBJECT *DriverObject)
     File_Unload();
     Obj_Unload();
     Thread_Unload();
-    Process_Unload(FALSE);
 
     //
     // if this is a full unload, then we can now unload everything else


### PR DESCRIPTION
Fix race condition BSOD during driver unload (`ExReleaseResourceLite` NULL)

## Issue

During driver unload via `Driver_Api_Unload`, `SbieDrv_DriverUnload` tore down subsystems (`File_Unload`, `Key_Unload`, etc.) before unregistering process/image notify callbacks via `Process_Unload(FALSE)`. This created a race window where a callback already dispatched on another CPU could access freed resources.

In the crash, `git.exe` was being created on CPU 4 while the unload ran on another CPU. The callback was already deep inside `File_TranslateReparsePoints_2` when `File_Unload` freed `File_ReparsePointsLock`. The callback then called `ExReleaseResourceLite(NULL)`, causing a page fault at address `0x1A` -> `SYSTEM_SERVICE_EXCEPTION (3b)`.

Old unload order in `SbieDrv_DriverUnload`:
  1. `File_Unload()`           <- frees `File_ReparsePointsLock`
  2. `Key_Unload()`
  3. `Obj_Unload()`
  4. `Thread_Unload()`
  5. `Process_Unload(FALSE)`   <- unregisters callbacks (too late)

## Fix

Reorder the unload sequence so that notify callbacks are unregistered before any subsystem teardown begins:

  1. `Process_ReadyToSandbox = FALSE` + `KeMemoryBarrier()` (early bail-out for newly dispatched callbacks)
  2. `Process_Unload(FALSE)` (kernel drains all in-flight callbacks before returning)
  3. `File_Unload()`, `Key_Unload()`, `Obj_Unload()`, `Thread_Unload()` (now safe, no callback can be touching these resources)