### PR TITLE
feat: add resource monitor view to track sandbox process CPU and memory usage

### DIFF
--- a/Sandboxie/core/svc/GuiServer.cpp
+++ b/Sandboxie/core/svc/GuiServer.cpp
@@ -940,6 +940,23 @@ bool GuiServer::QueueCallbackSlave2(void)
 // GetJobObjectForAssign
 //---------------------------------------------------------------------------
 
+#ifndef JOB_OBJECT_CPU_RATE_CONTROL_ENABLE
+#define JOB_OBJECT_CPU_RATE_CONTROL_ENABLE 0x1
+#define JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP 0x4
+#define JobObjectCpuRateControlInformation (JOBOBJECTINFOCLASS)15
+
+typedef struct _JOBOBJECT_CPU_RATE_CONTROL_INFORMATION {
+    ULONG ControlFlags;
+    union {
+        ULONG CpuRate;
+        ULONG Weight;
+        struct {
+            USHORT MinRate;
+            USHORT MaxRate;
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME;
+} JOBOBJECT_CPU_RATE_CONTROL_INFORMATION;
+#endif
 
 HANDLE GuiServer::GetJobObjectForAssign(const WCHAR *boxname)
 {
@@ -1121,6 +1138,16 @@ HANDLE GuiServer::GetJobObjectForAssign(const WCHAR *boxname)
 						jobELInfo.BasicLimitInformation.LimitFlags |= JOB_OBJECT_LIMIT_PROCESS_MEMORY;
 					}
 					ok = SetInformationJobObject(hJobObject, JobObjectExtendedLimitInformation, &jobELInfo, sizeof(jobELInfo));
+                }
+
+                if (ok) {
+                    ULONG CpuRateLimit = SbieApi_QueryConfNumber(boxname, L"CpuRateLimit", 0);
+                    if (CpuRateLimit > 0 && CpuRateLimit <= 100) {
+                        JOBOBJECT_CPU_RATE_CONTROL_INFORMATION cpuRateInfo = {0};
+                        cpuRateInfo.ControlFlags = JOB_OBJECT_CPU_RATE_CONTROL_ENABLE | JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP;
+                        cpuRateInfo.CpuRate = CpuRateLimit * 100; // 1% = 100
+                        SetInformationJobObject(hJobObject, JobObjectCpuRateControlInformation, &cpuRateInfo, sizeof(cpuRateInfo));
+                    }
                 }
 
                 if (! ok) {

--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -1829,6 +1829,39 @@
                  </property>
                 </widget>
                </item>
+               <item row="8" column="1" colspan="2">
+                <widget class="QLabel" name="label_cpu_limit">
+                 <property name="text">
+                  <string>Total CPU Rate Limit (%):</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>txtCpuRateLimit</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="3">
+                <widget class="QLineEdit" name="txtCpuRateLimit">
+                 <property name="maximumSize">
+                  <size>
+                   <width>125</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>Leave it blank to disable the setting (1-100)</string>
+                 </property>
+                 <property name="placeholderText">
+                  <string>unlimited</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="8" column="5">
+                <widget class="QLabel" name="lblCpuRateLimit">
+                 <property name="text">
+                  <string>%</string>
+                 </property>
+                </widget>
+               </item>
                <item row="2" column="2" colspan="4">
                 <widget class="QCheckBox" name="chkNestedJobs">
                  <property name="text">

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -18,6 +18,7 @@
 #include "../MiscHelpers/Common/TreeItemModel.h"
 #include "../MiscHelpers/Common/ListItemModel.h"
 #include "Views/TraceView.h"
+#include "Views/ResourceView.h"
 #include "Windows/SelectBoxWindow.h"
 #include "../UGlobalHotkey/uglobalhotkeys.h"
 #include "Wizards/SetupWizard.h"
@@ -1534,6 +1535,7 @@ void CSandMan::CreateView(int iViewMode)
 
 		m_pMessageLog = NULL;
 		m_pTraceView = NULL;
+		m_pResourceView = NULL;
 		m_pRecoveryLog = NULL;
 
 		return;
@@ -1617,6 +1619,11 @@ void CSandMan::CreateView(int iViewMode)
 
 		m_pLogTabs->addTab(m_pRecoveryLog, tr("Recovery Log"));
 		//
+
+		// Resource Monitor
+		m_pResourceView = new CResourceView(this);
+		m_pLogTabs->addTab(m_pResourceView, tr("Resource Monitor"));
+		//
 	}
 	else {
 		m_pLogSplitter = NULL;
@@ -1625,6 +1632,7 @@ void CSandMan::CreateView(int iViewMode)
 
 		m_pMessageLog = NULL;
 		m_pTraceView = NULL;
+		m_pResourceView = NULL;
 		m_pRecoveryLog = NULL;
 	}
 }

--- a/SandboxiePlus/SandMan/SandMan.h
+++ b/SandboxiePlus/SandMan/SandMan.h
@@ -20,6 +20,7 @@ class CFileView;
 class CBoxBorder;
 class CSbieTemplatesEx;
 class CTraceView;
+class CResourceView;
 class CScriptManager;
 class CAddonManager;
 
@@ -359,6 +360,7 @@ private:
 	QTabWidget*			m_pLogTabs;
 	CPanelWidgetEx*		m_pMessageLog;
 	CTraceView*			m_pTraceView;
+	CResourceView*		m_pResourceView;
 	CPanelWidgetEx*		m_pRecoveryLog;
 	class CRecoveryLogWnd* m_pRecoveryLogWnd;
 

--- a/SandboxiePlus/SandMan/SandMan.pri
+++ b/SandboxiePlus/SandMan/SandMan.pri
@@ -17,6 +17,7 @@ HEADERS += ./stdafx.h \
     ./Views/SbieView.h \
     ./Views/FileView.h \
     ./Views/TraceView.h \
+    ./Views/ResourceView.h \
     ./Views/StackView.h \
     ./Helpers/FindTool.h \
     ./Helpers/FullScreen.h \
@@ -74,6 +75,7 @@ SOURCES += ./main.cpp \
     ./Views/SbieView.cpp \
     ./Views/FileView.cpp \
     ./Views/TraceView.cpp \
+    ./Views/ResourceView.cpp \
     ./Views/StackView.cpp \
     ./Helpers/FindTool.cpp \
     ./Helpers/FullScreen.cpp \

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -365,6 +365,7 @@
       <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Filename).moc</QtMocFileName>
     </ClCompile>
     <ClCompile Include="Views\StackView.cpp" />
+    <ClCompile Include="Views\ResourceView.cpp" />
     <ClCompile Include="Views\TraceView.cpp">
       <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">input</DynamicSource>
       <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">%(Filename).moc</QtMocFileName>
@@ -520,6 +521,7 @@
     <QtMoc Include="Wizards\SetupWizard.h" />
     <QtMoc Include="Windows\SelectBoxWindow.h" />
     <QtMoc Include="Views\TraceView.h" />
+    <QtMoc Include="Views\ResourceView.h" />
     <QtMoc Include="Windows\RecoveryWindow.h" />
     <QtMoc Include="Windows\PopUpWindow.h" />
     <QtMoc Include="Windows\SnapshotsWindow.h" />

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -240,6 +240,9 @@
     <ClCompile Include="Views\TraceView.cpp">
       <Filter>Views</Filter>
     </ClCompile>
+    <ClCompile Include="Views\ResourceView.cpp">
+      <Filter>Views</Filter>
+    </ClCompile>
     <ClCompile Include="Windows\OptionsWindow.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
@@ -335,6 +338,9 @@
       <Filter>Models</Filter>
     </QtMoc>
     <QtMoc Include="Views\TraceView.h">
+      <Filter>Views</Filter>
+    </QtMoc>
+    <QtMoc Include="Views\ResourceView.h">
       <Filter>Views</Filter>
     </QtMoc>
     <QtMoc Include="Windows\SelectBoxWindow.h">

--- a/SandboxiePlus/SandMan/Views/ResourceView.cpp
+++ b/SandboxiePlus/SandMan/Views/ResourceView.cpp
@@ -92,7 +92,6 @@ CResourceView::CResourceView(QWidget* parent) : QWidget(parent)
 	connect(m_pTree, &QTreeWidget::customContextMenuRequested, this, &CResourceView::OnContextMenu);
 	connect(m_pTree, &QTreeWidget::itemSelectionChanged, this, [this]() {
 		QList<QTreeWidgetItem*> selectedItems = m_pTree->selectedItems();
-		bool hasSelection = !selectedItems.isEmpty();
 		bool hasProcessSelected = false;
 		bool hasBoxSelected = false;
 
@@ -255,7 +254,7 @@ bool CResourceView::MatchesFilter(const QString& boxName, const QList<SProcessSt
 	return false;
 }
 
-static QString FormatSize(quint64 size)
+static QString FormatMemSize(quint64 size)
 {
 	if (size == 0)
 		return "0 B";
@@ -406,7 +405,7 @@ void CResourceView::Refresh()
 
 	// Update summary bar
 	m_pSummaryLabel->setText(tr("Boxes: %1 (%2 active)  |  Processes: %3  |  Total Memory: %4")
-		.arg(totalBoxes).arg(totalActiveBoxes).arg(totalProcesses).arg(FormatSize(totalMemory)));
+		.arg(totalBoxes).arg(totalActiveBoxes).arg(totalProcesses).arg(FormatMemSize(totalMemory)));
 
 	// Clean up stale CPU entries
 	QSet<quint32> activePids;
@@ -474,8 +473,8 @@ void CResourceView::Refresh()
 
 		if (box.ProcessCount > 0) {
 			pBoxItem->setText(2, QString("%1%").arg(box.TotalCpuUsage, 0, 'f', 1));
-			pBoxItem->setText(3, FormatSize(box.TotalWorkingSet));
-			pBoxItem->setText(4, FormatSize(box.TotalPrivateBytes));
+			pBoxItem->setText(3, FormatMemSize(box.TotalWorkingSet));
+			pBoxItem->setText(4, FormatMemSize(box.TotalPrivateBytes));
 			pBoxItem->setText(5, tr("Active"));
 
 			// Bold font for active boxes
@@ -517,8 +516,8 @@ void CResourceView::Refresh()
 			pProcItem->setText(0, proc.ProcessName);
 			pProcItem->setText(1, QString::number(proc.ProcessId));
 			pProcItem->setText(2, QString("%1%").arg(proc.CpuUsage, 0, 'f', 1));
-			pProcItem->setText(3, FormatSize(proc.WorkingSetSize));
-			pProcItem->setText(4, FormatSize(proc.PrivateBytes));
+			pProcItem->setText(3, FormatMemSize(proc.WorkingSetSize));
+			pProcItem->setText(4, FormatMemSize(proc.PrivateBytes));
 			pProcItem->setText(5, tr("Running"));
 
 			// Color-code high CPU processes

--- a/SandboxiePlus/SandMan/Views/ResourceView.cpp
+++ b/SandboxiePlus/SandMan/Views/ResourceView.cpp
@@ -422,13 +422,26 @@ void CResourceView::Refresh()
 			++it;
 	}
 
-	// Update tree - try to preserve expansion state
+	// Update tree - try to preserve expansion, selection and scroll state
 	QSet<QString> expandedBoxes;
+	QSet<QString> selectedBoxes;
+	QSet<quint32> selectedPids;
+
 	for (int i = 0; i < m_pTree->topLevelItemCount(); i++) {
 		QTreeWidgetItem* pItem = m_pTree->topLevelItem(i);
+		QString boxName = pItem->data(0, Qt::UserRole).toString();
 		if (pItem->isExpanded())
-			expandedBoxes.insert(pItem->data(0, Qt::UserRole).toString());
+			expandedBoxes.insert(boxName);
+		if (pItem->isSelected())
+			selectedBoxes.insert(boxName);
+
+		for (int j = 0; j < pItem->childCount(); j++) {
+			QTreeWidgetItem* pChild = pItem->child(j);
+			if (pChild->isSelected())
+				selectedPids.insert(pChild->text(1).toUInt());
+		}
 	}
+	int vScrollPos = m_pTree->verticalScrollBar()->value();
 
 	m_pTree->clear();
 
@@ -531,12 +544,25 @@ void CResourceView::Refresh()
 		pBoxItem->setTextAlignment(3, Qt::AlignRight | Qt::AlignVCenter);
 		pBoxItem->setTextAlignment(4, Qt::AlignRight | Qt::AlignVCenter);
 
+		if (selectedBoxes.contains(box.BoxName))
+			pBoxItem->setSelected(true);
+
 		m_pTree->addTopLevelItem(pBoxItem);
 
 		// Restore expansion state; auto-expand active boxes
 		if (box.ProcessCount > 0 || expandedBoxes.contains(box.BoxName))
 			pBoxItem->setExpanded(true);
+		
+		// Restore specific child selection
+		for (int i = 0; i < pBoxItem->childCount(); ++i) {
+			QTreeWidgetItem* pChild = pBoxItem->child(i);
+			if (selectedPids.contains(pChild->text(1).toUInt()))
+				pChild->setSelected(true);
+		}
 	}
+
+	// Restore scroll position
+	m_pTree->verticalScrollBar()->setValue(vScrollPos);
 }
 
 void CResourceView::Clear()

--- a/SandboxiePlus/SandMan/Views/ResourceView.cpp
+++ b/SandboxiePlus/SandMan/Views/ResourceView.cpp
@@ -1,0 +1,302 @@
+#include "stdafx.h"
+#include "ResourceView.h"
+#include "..\SandMan.h"
+#include "..\SbiePlusAPI.h"
+#include "..\..\MiscHelpers\Common\Common.h"
+
+#include <windows.h>
+#include <psapi.h>
+#pragma comment(lib, "psapi.lib")
+
+////////////////////////////////////////////////////////////////////////////////////////
+// CResourceView
+
+CResourceView::CResourceView(QWidget* parent) : QWidget(parent)
+{
+	m_pMainLayout = new QVBoxLayout();
+	m_pMainLayout->setContentsMargins(0, 0, 0, 0);
+	this->setLayout(m_pMainLayout);
+
+	m_pTree = new QTreeWidget();
+	m_pTree->setHeaderLabels(QStringList() << tr("Sandbox / Process") << tr("PID") << tr("CPU") << tr("Working Set") << tr("Private Bytes") << tr("Status"));
+	m_pTree->setColumnCount(6);
+	m_pTree->setRootIsDecorated(true);
+	m_pTree->setAlternatingRowColors(theConf->GetBool("Options/AltRowColors", false));
+	m_pTree->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	m_pTree->setUniformRowHeights(true);
+	m_pTree->setSortingEnabled(false);
+	m_pTree->setItemDelegate(new CTreeItemDelegate());
+	m_pTree->setExpandsOnDoubleClick(true);
+
+	// Set reasonable column widths
+	m_pTree->setColumnWidth(0, 250);	// Name
+	m_pTree->setColumnWidth(1, 60);		// PID
+	m_pTree->setColumnWidth(2, 70);		// CPU
+	m_pTree->setColumnWidth(3, 100);	// Working Set
+	m_pTree->setColumnWidth(4, 100);	// Private Bytes
+	m_pTree->setColumnWidth(5, 100);	// Status
+
+	m_pMainLayout->addWidget(m_pTree);
+
+	// Refresh every 2 seconds
+	m_uTimerID = startTimer(2000);
+}
+
+CResourceView::~CResourceView()
+{
+	killTimer(m_uTimerID);
+}
+
+void CResourceView::timerEvent(QTimerEvent* pEvent)
+{
+	if (pEvent->timerId() != m_uTimerID)
+		return;
+
+	// Only update when the tab is visible
+	if (!isVisible())
+		return;
+
+	Refresh();
+}
+
+static QString FormatSize(quint64 size)
+{
+	if (size == 0)
+		return "0 B";
+	
+	const char* units[] = { "B", "KB", "MB", "GB", "TB" };
+	int unitIndex = 0;
+	double dSize = (double)size;
+
+	while (dSize >= 1024.0 && unitIndex < 4) {
+		dSize /= 1024.0;
+		unitIndex++;
+	}
+
+	if (unitIndex == 0)
+		return QString("%1 B").arg(size);
+	return QString("%1 %2").arg(dSize, 0, 'f', 1).arg(units[unitIndex]);
+}
+
+void CResourceView::UpdateProcessStats(SProcessStats& Stats)
+{
+	HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ, FALSE, Stats.ProcessId);
+	if (hProcess == NULL)
+		return;
+
+	// Memory info
+	PROCESS_MEMORY_COUNTERS_EX pmc;
+	memset(&pmc, 0, sizeof(pmc));
+	pmc.cb = sizeof(pmc);
+	if (GetProcessMemoryInfo(hProcess, (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc))) {
+		Stats.WorkingSetSize = pmc.WorkingSetSize;
+		Stats.PrivateBytes = pmc.PrivateUsage;
+	}
+
+	// CPU time
+	FILETIME ftCreation, ftExit, ftKernel, ftUser;
+	if (GetProcessTimes(hProcess, &ftCreation, &ftExit, &ftKernel, &ftUser)) {
+		Stats.KernelTime = ((quint64)ftKernel.dwHighDateTime << 32) | ftKernel.dwLowDateTime;
+		Stats.UserTime = ((quint64)ftUser.dwHighDateTime << 32) | ftUser.dwLowDateTime;
+		Stats.CpuUsage = CalcCpuUsage(Stats.ProcessId, Stats.KernelTime, Stats.UserTime);
+	}
+
+	CloseHandle(hProcess);
+}
+
+double CResourceView::CalcCpuUsage(quint32 pid, quint64 kernelTime, quint64 userTime)
+{
+	quint64 totalTime = kernelTime + userTime;
+	quint64 now = GetTickCount64() * 10000ULL; // convert ms to 100-ns intervals
+
+	auto it = m_LastTimes.find(pid);
+	if (it == m_LastTimes.end()) {
+		m_LastTimes[pid] = qMakePair(totalTime, now);
+		return 0.0;
+	}
+
+	quint64 prevTotal = it->first;
+	quint64 prevTimestamp = it->second;
+
+	quint64 elapsedTime = now - prevTimestamp;
+	if (elapsedTime == 0) {
+		return 0.0;
+	}
+
+	quint64 cpuTimeDelta = totalTime - prevTotal;
+
+	// Get number of logical processors
+	static int nProcessors = 0;
+	if (nProcessors == 0) {
+		SYSTEM_INFO si;
+		GetSystemInfo(&si);
+		nProcessors = si.dwNumberOfProcessors;
+		if (nProcessors == 0) nProcessors = 1;
+	}
+
+	double cpuUsage = (double)cpuTimeDelta / (double)elapsedTime * 100.0 / nProcessors;
+	if (cpuUsage > 100.0) cpuUsage = 100.0;
+	if (cpuUsage < 0.0) cpuUsage = 0.0;
+
+	m_LastTimes[pid] = qMakePair(totalTime, now);
+	return cpuUsage;
+}
+
+void CResourceView::Refresh()
+{
+	if (!theAPI || !theAPI->IsConnected())
+		return;
+
+	// Build box stats
+	QMap<QString, SBoxStats> BoxStatsMap;
+	QMap<QString, CSandBoxPtr> Boxes = theAPI->GetAllBoxes();
+
+	for (auto I = Boxes.constBegin(); I != Boxes.constEnd(); ++I)
+	{
+		CSandBoxPtr pBox = I.value();
+		if (!pBox->IsEnabled())
+			continue;
+
+		auto pBoxEx = pBox.objectCast<CSandBoxPlus>();
+		if (!pBoxEx)
+			continue;
+
+		SBoxStats& BoxStats = BoxStatsMap[pBox->GetName()];
+		BoxStats.BoxName = pBox->GetName();
+		BoxStats.ProcessCount = 0;
+		BoxStats.TotalWorkingSet = 0;
+		BoxStats.TotalPrivateBytes = 0;
+		BoxStats.TotalCpuUsage = 0.0;
+		BoxStats.DiskSize = pBoxEx->GetSize();
+
+		QMap<quint32, CBoxedProcessPtr> procs = pBox->GetProcessList();
+		for (auto J = procs.constBegin(); J != procs.constEnd(); ++J)
+		{
+			CBoxedProcessPtr pProcess = J.value();
+			if (pProcess->IsTerminated())
+				continue;
+
+			SProcessStats ProcStats;
+			ProcStats.ProcessId = pProcess->GetProcessId();
+			ProcStats.ProcessName = pProcess->GetProcessName();
+			ProcStats.BoxName = pBox->GetName();
+			ProcStats.WorkingSetSize = 0;
+			ProcStats.PrivateBytes = 0;
+			ProcStats.KernelTime = 0;
+			ProcStats.UserTime = 0;
+			ProcStats.CpuUsage = 0.0;
+
+			UpdateProcessStats(ProcStats);
+
+			BoxStats.ProcessCount++;
+			BoxStats.TotalWorkingSet += ProcStats.WorkingSetSize;
+			BoxStats.TotalPrivateBytes += ProcStats.PrivateBytes;
+			BoxStats.TotalCpuUsage += ProcStats.CpuUsage;
+
+			BoxStats.Processes.append(ProcStats);
+		}
+	}
+
+	// Clean up stale CPU entries
+	QSet<quint32> activePids;
+	for (auto& box : BoxStatsMap) {
+		for (auto& proc : box.Processes) {
+			activePids.insert(proc.ProcessId);
+		}
+	}
+	for (auto it = m_LastTimes.begin(); it != m_LastTimes.end(); ) {
+		if (!activePids.contains(it.key()))
+			it = m_LastTimes.erase(it);
+		else
+			++it;
+	}
+
+	// Update tree - try to preserve expansion state
+	QSet<QString> expandedBoxes;
+	for (int i = 0; i < m_pTree->topLevelItemCount(); i++) {
+		QTreeWidgetItem* pItem = m_pTree->topLevelItem(i);
+		if (pItem->isExpanded())
+			expandedBoxes.insert(pItem->data(0, Qt::UserRole).toString());
+	}
+
+	m_pTree->clear();
+
+	// Sort boxes: active ones first, then by name
+	QList<SBoxStats> sortedBoxes = BoxStatsMap.values();
+	std::sort(sortedBoxes.begin(), sortedBoxes.end(), [](const SBoxStats& a, const SBoxStats& b) {
+		if (a.ProcessCount != b.ProcessCount) {
+			if (a.ProcessCount == 0) return false;
+			if (b.ProcessCount == 0) return true;
+			return a.TotalCpuUsage > b.TotalCpuUsage;
+		}
+		return a.BoxName.compare(b.BoxName, Qt::CaseInsensitive) < 0;
+	});
+
+	for (const SBoxStats& box : sortedBoxes)
+	{
+		QTreeWidgetItem* pBoxItem = new QTreeWidgetItem();
+
+		// Display name
+		QString displayName = box.BoxName;
+
+		pBoxItem->setText(0, displayName);
+		pBoxItem->setData(0, Qt::UserRole, box.BoxName);
+
+		// Process count as PID column
+		pBoxItem->setText(1, QString::number(box.ProcessCount));
+
+		if (box.ProcessCount > 0) {
+			pBoxItem->setText(2, QString("%1%").arg(box.TotalCpuUsage, 0, 'f', 1));
+			pBoxItem->setText(3, FormatSize(box.TotalWorkingSet));
+			pBoxItem->setText(4, FormatSize(box.TotalPrivateBytes));
+			pBoxItem->setText(5, tr("Active"));
+
+			// Bold font for active boxes
+			QFont fnt = pBoxItem->font(0);
+			fnt.setBold(true);
+			pBoxItem->setFont(0, fnt);
+		}
+		else {
+			pBoxItem->setText(2, "-");
+			pBoxItem->setText(3, "-");
+			pBoxItem->setText(4, "-");
+			pBoxItem->setText(5, box.DiskSize > 0 ? tr("Inactive") : tr("Empty"));
+		}
+
+		// Add child processes
+		for (const SProcessStats& proc : box.Processes)
+		{
+			QTreeWidgetItem* pProcItem = new QTreeWidgetItem(pBoxItem);
+			pProcItem->setText(0, proc.ProcessName);
+			pProcItem->setText(1, QString::number(proc.ProcessId));
+			pProcItem->setText(2, QString("%1%").arg(proc.CpuUsage, 0, 'f', 1));
+			pProcItem->setText(3, FormatSize(proc.WorkingSetSize));
+			pProcItem->setText(4, FormatSize(proc.PrivateBytes));
+			pProcItem->setText(5, tr("Running"));
+
+			// Align numeric columns right
+			pProcItem->setTextAlignment(1, Qt::AlignRight | Qt::AlignVCenter);
+			pProcItem->setTextAlignment(2, Qt::AlignRight | Qt::AlignVCenter);
+			pProcItem->setTextAlignment(3, Qt::AlignRight | Qt::AlignVCenter);
+			pProcItem->setTextAlignment(4, Qt::AlignRight | Qt::AlignVCenter);
+		}
+
+		// Align box-level numeric columns right
+		pBoxItem->setTextAlignment(1, Qt::AlignRight | Qt::AlignVCenter);
+		pBoxItem->setTextAlignment(2, Qt::AlignRight | Qt::AlignVCenter);
+		pBoxItem->setTextAlignment(3, Qt::AlignRight | Qt::AlignVCenter);
+		pBoxItem->setTextAlignment(4, Qt::AlignRight | Qt::AlignVCenter);
+
+		m_pTree->addTopLevelItem(pBoxItem);
+
+		// Restore expansion state; auto-expand active boxes
+		if (box.ProcessCount > 0 || expandedBoxes.contains(box.BoxName))
+			pBoxItem->setExpanded(true);
+	}
+}
+
+void CResourceView::Clear()
+{
+	m_pTree->clear();
+	m_LastTimes.clear();
+}

--- a/SandboxiePlus/SandMan/Views/ResourceView.cpp
+++ b/SandboxiePlus/SandMan/Views/ResourceView.cpp
@@ -8,6 +8,9 @@
 #include <psapi.h>
 #pragma comment(lib, "psapi.lib")
 
+#include <QHeaderView>
+#include <QMessageBox>
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // CResourceView
 
@@ -15,8 +18,57 @@ CResourceView::CResourceView(QWidget* parent) : QWidget(parent)
 {
 	m_pMainLayout = new QVBoxLayout();
 	m_pMainLayout->setContentsMargins(0, 0, 0, 0);
+	m_pMainLayout->setSpacing(0);
 	this->setLayout(m_pMainLayout);
 
+	// === Toolbar ===
+	m_pToolBar = new QToolBar();
+	m_pToolBar->setIconSize(QSize(16, 16));
+
+	m_pRefreshAction = m_pToolBar->addAction(CSandMan::GetIcon("Refresh"), tr("Refresh"), this, SLOT(Refresh()));
+	m_pRefreshAction->setToolTip(tr("Refresh resource data now"));
+
+	m_pToolBar->addSeparator();
+
+	m_pTerminateAction = m_pToolBar->addAction(CSandMan::GetIcon("Remove"), tr("Terminate Process"), this, SLOT(OnTerminateProcess()));
+	m_pTerminateAction->setToolTip(tr("Terminate the selected process"));
+	m_pTerminateAction->setEnabled(false);
+
+	m_pTerminateBoxAction = m_pToolBar->addAction(CSandMan::GetIcon("Stop"), tr("Terminate All in Box"), this, SLOT(OnTerminateBox()));
+	m_pTerminateBoxAction->setToolTip(tr("Terminate all processes in the selected sandbox"));
+	m_pTerminateBoxAction->setEnabled(false);
+
+	m_pToolBar->addSeparator();
+
+	m_pExpandAllAction = m_pToolBar->addAction(CSandMan::GetIcon("Expand"), tr("Expand All"), this, SLOT(OnExpandAll()));
+	m_pCollapseAllAction = m_pToolBar->addAction(CSandMan::GetIcon("Collapse"), tr("Collapse All"), this, SLOT(OnCollapseAll()));
+
+	// Spacer to push filter to the right
+	QWidget* pSpacer = new QWidget();
+	pSpacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+	m_pToolBar->addWidget(pSpacer);
+
+	// Filter
+	QLabel* pFilterLabel = new QLabel(tr("Filter:"));
+	pFilterLabel->setContentsMargins(4, 0, 4, 0);
+	m_pToolBar->addWidget(pFilterLabel);
+
+	m_pFilterEdit = new QLineEdit();
+	m_pFilterEdit->setPlaceholderText(tr("Search sandbox or process..."));
+	m_pFilterEdit->setMaximumWidth(200);
+	m_pFilterEdit->setClearButtonEnabled(true);
+	connect(m_pFilterEdit, &QLineEdit::textChanged, this, &CResourceView::OnFilterChanged);
+	m_pToolBar->addWidget(m_pFilterEdit);
+
+	m_pMainLayout->addWidget(m_pToolBar);
+
+	// === Summary bar ===
+	m_pSummaryLabel = new QLabel();
+	m_pSummaryLabel->setContentsMargins(6, 2, 6, 2);
+	m_pSummaryLabel->setStyleSheet("QLabel { background-color: palette(alternate-base); padding: 2px 6px; }");
+	m_pMainLayout->addWidget(m_pSummaryLabel);
+
+	// === Tree Widget ===
 	m_pTree = new QTreeWidget();
 	m_pTree->setHeaderLabels(QStringList() << tr("Sandbox / Process") << tr("PID") << tr("CPU") << tr("Working Set") << tr("Private Bytes") << tr("Status"));
 	m_pTree->setColumnCount(6);
@@ -27,6 +79,7 @@ CResourceView::CResourceView(QWidget* parent) : QWidget(parent)
 	m_pTree->setSortingEnabled(false);
 	m_pTree->setItemDelegate(new CTreeItemDelegate());
 	m_pTree->setExpandsOnDoubleClick(true);
+	m_pTree->setContextMenuPolicy(Qt::CustomContextMenu);
 
 	// Set reasonable column widths
 	m_pTree->setColumnWidth(0, 250);	// Name
@@ -36,7 +89,35 @@ CResourceView::CResourceView(QWidget* parent) : QWidget(parent)
 	m_pTree->setColumnWidth(4, 100);	// Private Bytes
 	m_pTree->setColumnWidth(5, 100);	// Status
 
+	connect(m_pTree, &QTreeWidget::customContextMenuRequested, this, &CResourceView::OnContextMenu);
+	connect(m_pTree, &QTreeWidget::itemSelectionChanged, this, [this]() {
+		QList<QTreeWidgetItem*> selectedItems = m_pTree->selectedItems();
+		bool hasSelection = !selectedItems.isEmpty();
+		bool hasProcessSelected = false;
+		bool hasBoxSelected = false;
+
+		for (auto* item : selectedItems) {
+			if (item->parent() == nullptr)
+				hasBoxSelected = true;
+			else
+				hasProcessSelected = true;
+		}
+
+		m_pTerminateAction->setEnabled(hasProcessSelected);
+		m_pTerminateBoxAction->setEnabled(hasBoxSelected);
+	});
+
 	m_pMainLayout->addWidget(m_pTree);
+
+	// === Context Menu ===
+	m_pContextMenu = new QMenu(this);
+	m_pContextMenu->addAction(m_pTerminateAction);
+	m_pContextMenu->addAction(m_pTerminateBoxAction);
+	m_pContextMenu->addSeparator();
+	m_pContextMenu->addAction(m_pRefreshAction);
+	m_pContextMenu->addSeparator();
+	m_pContextMenu->addAction(m_pExpandAllAction);
+	m_pContextMenu->addAction(m_pCollapseAllAction);
 
 	// Refresh every 2 seconds
 	m_uTimerID = startTimer(2000);
@@ -57,6 +138,121 @@ void CResourceView::timerEvent(QTimerEvent* pEvent)
 		return;
 
 	Refresh();
+}
+
+void CResourceView::OnContextMenu(const QPoint& pos)
+{
+	m_pContextMenu->popup(m_pTree->viewport()->mapToGlobal(pos));
+}
+
+void CResourceView::OnTerminateProcess()
+{
+	QList<QTreeWidgetItem*> selectedItems = m_pTree->selectedItems();
+	if (selectedItems.isEmpty())
+		return;
+
+	// Collect selected process items (children only)
+	QStringList procNames;
+	for (auto* item : selectedItems) {
+		if (item->parent() != nullptr) { // it's a process item
+			procNames.append(QString("%1 (PID: %2)").arg(item->text(0)).arg(item->text(1)));
+		}
+	}
+
+	if (procNames.isEmpty())
+		return;
+
+	if (QMessageBox::question(this, tr("Terminate Process"),
+		tr("Are you sure you want to terminate %1 process(es)?").arg(procNames.count()) + "\n\n" + procNames.join("\n"),
+		QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes)
+		return;
+
+	for (auto* item : selectedItems) {
+		if (item->parent() == nullptr)
+			continue; // skip boxes
+
+		quint32 pid = item->text(1).toUInt();
+		QString boxName = item->parent()->data(0, Qt::UserRole).toString();
+
+		CSandBoxPtr pBox = theAPI->GetAllBoxes().value(boxName);
+		if (pBox) {
+			QMap<quint32, CBoxedProcessPtr> procs = pBox->GetProcessList();
+			auto it = procs.find(pid);
+			if (it != procs.end()) {
+				it.value()->Terminate();
+			}
+		}
+	}
+
+	Refresh();
+}
+
+void CResourceView::OnTerminateBox()
+{
+	QList<QTreeWidgetItem*> selectedItems = m_pTree->selectedItems();
+	if (selectedItems.isEmpty())
+		return;
+
+	QStringList boxNames;
+	for (auto* item : selectedItems) {
+		if (item->parent() == nullptr) { // it's a box item
+			QString boxName = item->data(0, Qt::UserRole).toString();
+			if (!boxNames.contains(boxName))
+				boxNames.append(boxName);
+		}
+	}
+
+	if (boxNames.isEmpty())
+		return;
+
+	if (QMessageBox::question(this, tr("Terminate Sandbox"),
+		tr("Are you sure you want to terminate all processes in %1 sandbox(es)?").arg(boxNames.count()) + "\n\n" + boxNames.join("\n"),
+		QMessageBox::Yes | QMessageBox::No) != QMessageBox::Yes)
+		return;
+
+	for (const QString& boxName : boxNames) {
+		CSandBoxPtr pBox = theAPI->GetAllBoxes().value(boxName);
+		if (pBox) {
+			pBox->TerminateAll();
+		}
+	}
+
+	Refresh();
+}
+
+void CResourceView::OnExpandAll()
+{
+	m_pTree->expandAll();
+}
+
+void CResourceView::OnCollapseAll()
+{
+	m_pTree->collapseAll();
+}
+
+void CResourceView::OnFilterChanged(const QString& text)
+{
+	Q_UNUSED(text);
+	Refresh();
+}
+
+bool CResourceView::MatchesFilter(const QString& boxName, const QList<SProcessStats>& processes) const
+{
+	QString filter = m_pFilterEdit->text().trimmed();
+	if (filter.isEmpty())
+		return true;
+
+	if (boxName.contains(filter, Qt::CaseInsensitive))
+		return true;
+
+	for (const auto& proc : processes) {
+		if (proc.ProcessName.contains(filter, Qt::CaseInsensitive))
+			return true;
+		if (QString::number(proc.ProcessId).contains(filter))
+			return true;
+	}
+
+	return false;
 }
 
 static QString FormatSize(quint64 size)
@@ -151,6 +347,11 @@ void CResourceView::Refresh()
 	QMap<QString, SBoxStats> BoxStatsMap;
 	QMap<QString, CSandBoxPtr> Boxes = theAPI->GetAllBoxes();
 
+	int totalBoxes = 0;
+	int totalActiveBoxes = 0;
+	int totalProcesses = 0;
+	quint64 totalMemory = 0;
+
 	for (auto I = Boxes.constBegin(); I != Boxes.constEnd(); ++I)
 	{
 		CSandBoxPtr pBox = I.value();
@@ -195,7 +396,17 @@ void CResourceView::Refresh()
 
 			BoxStats.Processes.append(ProcStats);
 		}
+
+		totalBoxes++;
+		if (BoxStats.ProcessCount > 0)
+			totalActiveBoxes++;
+		totalProcesses += BoxStats.ProcessCount;
+		totalMemory += BoxStats.TotalWorkingSet;
 	}
+
+	// Update summary bar
+	m_pSummaryLabel->setText(tr("Boxes: %1 (%2 active)  |  Processes: %3  |  Total Memory: %4")
+		.arg(totalBoxes).arg(totalActiveBoxes).arg(totalProcesses).arg(FormatSize(totalMemory)));
 
 	// Clean up stale CPU entries
 	QSet<quint32> activePids;
@@ -234,9 +445,12 @@ void CResourceView::Refresh()
 
 	for (const SBoxStats& box : sortedBoxes)
 	{
+		// Apply filter
+		if (!MatchesFilter(box.BoxName, box.Processes))
+			continue;
+
 		QTreeWidgetItem* pBoxItem = new QTreeWidgetItem();
 
-		// Display name
 		QString displayName = box.BoxName;
 
 		pBoxItem->setText(0, displayName);
@@ -255,6 +469,16 @@ void CResourceView::Refresh()
 			QFont fnt = pBoxItem->font(0);
 			fnt.setBold(true);
 			pBoxItem->setFont(0, fnt);
+
+			// Color-code high CPU usage (> 50% = red tint)
+			if (box.TotalCpuUsage > 50.0) {
+				pBoxItem->setForeground(2, QBrush(QColor(220, 50, 50)));
+				QFont cpuFnt = pBoxItem->font(2);
+				cpuFnt.setBold(true);
+				pBoxItem->setFont(2, cpuFnt);
+			} else if (box.TotalCpuUsage > 20.0) {
+				pBoxItem->setForeground(2, QBrush(QColor(200, 140, 0)));
+			}
 		}
 		else {
 			pBoxItem->setText(2, "-");
@@ -264,8 +488,18 @@ void CResourceView::Refresh()
 		}
 
 		// Add child processes
+		QString filterText = m_pFilterEdit->text().trimmed();
 		for (const SProcessStats& proc : box.Processes)
 		{
+			// If filtering, also filter individual processes
+			if (!filterText.isEmpty()) {
+				bool match = proc.ProcessName.contains(filterText, Qt::CaseInsensitive)
+					|| QString::number(proc.ProcessId).contains(filterText)
+					|| box.BoxName.contains(filterText, Qt::CaseInsensitive);
+				if (!match)
+					continue;
+			}
+
 			QTreeWidgetItem* pProcItem = new QTreeWidgetItem(pBoxItem);
 			pProcItem->setText(0, proc.ProcessName);
 			pProcItem->setText(1, QString::number(proc.ProcessId));
@@ -273,6 +507,16 @@ void CResourceView::Refresh()
 			pProcItem->setText(3, FormatSize(proc.WorkingSetSize));
 			pProcItem->setText(4, FormatSize(proc.PrivateBytes));
 			pProcItem->setText(5, tr("Running"));
+
+			// Color-code high CPU processes
+			if (proc.CpuUsage > 50.0) {
+				pProcItem->setForeground(2, QBrush(QColor(220, 50, 50)));
+				QFont cpuFnt = pProcItem->font(2);
+				cpuFnt.setBold(true);
+				pProcItem->setFont(2, cpuFnt);
+			} else if (proc.CpuUsage > 20.0) {
+				pProcItem->setForeground(2, QBrush(QColor(200, 140, 0)));
+			}
 
 			// Align numeric columns right
 			pProcItem->setTextAlignment(1, Qt::AlignRight | Qt::AlignVCenter);
@@ -299,4 +543,5 @@ void CResourceView::Clear()
 {
 	m_pTree->clear();
 	m_LastTimes.clear();
+	m_pSummaryLabel->setText("");
 }

--- a/SandboxiePlus/SandMan/Views/ResourceView.h
+++ b/SandboxiePlus/SandMan/Views/ResourceView.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QWidget>
+#include <QTreeWidget>
+#include <QVBoxLayout>
+#include <QTimer>
+#include <QMap>
+
+class CResourceView : public QWidget
+{
+	Q_OBJECT
+public:
+	CResourceView(QWidget* parent = 0);
+	~CResourceView();
+
+public slots:
+	void		Refresh();
+	void		Clear();
+
+protected:
+	void		timerEvent(QTimerEvent* pEvent);
+	int			m_uTimerID;
+
+private:
+
+	struct SProcessStats
+	{
+		quint32 ProcessId;
+		QString ProcessName;
+		QString BoxName;
+		quint64 WorkingSetSize;		// bytes
+		quint64 PrivateBytes;		// bytes
+		quint64 KernelTime;			// 100-ns intervals
+		quint64 UserTime;			// 100-ns intervals
+		double  CpuUsage;			// 0..100
+	};
+
+	struct SBoxStats
+	{
+		QString BoxName;
+		int		ProcessCount;
+		quint64 TotalWorkingSet;
+		quint64 TotalPrivateBytes;
+		double	TotalCpuUsage;
+		quint64 DiskSize;
+		QList<SProcessStats> Processes;
+	};
+
+	void		UpdateProcessStats(SProcessStats& Stats);
+	double		CalcCpuUsage(quint32 pid, quint64 kernelTime, quint64 userTime);
+
+	QMap<quint32, QPair<quint64, quint64>> m_LastTimes; // pid -> (kernel+user, timestamp)
+
+	QVBoxLayout*	m_pMainLayout;
+	QTreeWidget*	m_pTree;
+};

--- a/SandboxiePlus/SandMan/Views/ResourceView.h
+++ b/SandboxiePlus/SandMan/Views/ResourceView.h
@@ -3,8 +3,14 @@
 #include <QWidget>
 #include <QTreeWidget>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QTimer>
 #include <QMap>
+#include <QLabel>
+#include <QLineEdit>
+#include <QToolBar>
+#include <QAction>
+#include <QMenu>
 
 class CResourceView : public QWidget
 {
@@ -20,6 +26,14 @@ public slots:
 protected:
 	void		timerEvent(QTimerEvent* pEvent);
 	int			m_uTimerID;
+
+private slots:
+	void		OnTerminateProcess();
+	void		OnTerminateBox();
+	void		OnExpandAll();
+	void		OnCollapseAll();
+	void		OnFilterChanged(const QString& text);
+	void		OnContextMenu(const QPoint& pos);
 
 private:
 
@@ -48,8 +62,26 @@ private:
 
 	void		UpdateProcessStats(SProcessStats& Stats);
 	double		CalcCpuUsage(quint32 pid, quint64 kernelTime, quint64 userTime);
+	bool		MatchesFilter(const QString& boxName, const QList<SProcessStats>& processes) const;
 
 	QMap<quint32, QPair<quint64, quint64>> m_LastTimes; // pid -> (kernel+user, timestamp)
+
+	// Toolbar
+	QToolBar*		m_pToolBar;
+	QAction*		m_pRefreshAction;
+	QAction*		m_pTerminateAction;
+	QAction*		m_pTerminateBoxAction;
+	QAction*		m_pExpandAllAction;
+	QAction*		m_pCollapseAllAction;
+
+	// Filter
+	QLineEdit*		m_pFilterEdit;
+
+	// Summary bar
+	QLabel*			m_pSummaryLabel;
+
+	// Context menu
+	QMenu*			m_pContextMenu;
 
 	QVBoxLayout*	m_pMainLayout;
 	QTreeWidget*	m_pTree;

--- a/SandboxiePlus/SandMan/Views/TraceView.cpp
+++ b/SandboxiePlus/SandMan/Views/TraceView.cpp
@@ -147,7 +147,7 @@ CTraceTree::~CTraceTree()
 	theConf->SetBlob("MainWindow/TraceSplitter", m_pSplitter->saveState());
 }
 
-void CTraceTree::SetFilter(const QRegularExpression& Exp, int iOptions, int Column) 
+void CTraceTree::SetFilter(const QRegularExpression& Exp, int iOptions, int /*Column*/) 
 {
 	QString ExpStr = Exp.pattern();
 	bool bReset = m_bHighLight != ((iOptions & CFinder::eHighLight) != 0) || (!m_bHighLight && m_FilterExp != ExpStr);
@@ -161,7 +161,7 @@ void CTraceTree::SetFilter(const QRegularExpression& Exp, int iOptions, int Colu
 		emit FilterChanged();
 }
 
-void CTraceTree::ItemSelection(const QItemSelection& selected, const QItemSelection& deselected)
+void CTraceTree::ItemSelection(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/)
 {
 	QItemSelectionModel* selectionModel = m_pTreeList->selectionModel();
 	QItemSelection selection = selectionModel->selection();

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -21,6 +21,7 @@ void COptionsWindow::CreateAdvanced()
 	connect(ui.txtSingleMemory, SIGNAL(textChanged(const QString&)), this, SLOT(OnAdvancedChanged()));
 	connect(ui.txtTotalMemory, SIGNAL(textChanged(const QString&)), this, SLOT(OnAdvancedChanged()));
 	connect(ui.txtTotalNumber, SIGNAL(textChanged(const QString&)), this, SLOT(OnAdvancedChanged()));
+	connect(ui.txtCpuRateLimit, SIGNAL(textChanged(const QString&)), this, SLOT(OnAdvancedChanged()));
 
 	connect(ui.chkUseSbieDeskHack, SIGNAL(clicked(bool)), this, SLOT(OnAdvancedChanged()));
 	connect(ui.chkUseSbieWndStation, SIGNAL(clicked(bool)), this, SLOT(OnAdvancedChanged()));
@@ -193,6 +194,10 @@ void COptionsWindow::LoadAdvanced()
 	qint64 iTotalNumber = m_pBox->GetNum64("ProcessNumberLimit", 0);
 	if (iTotalNumber > 0x0LL && iTotalNumber <= 0xFFFFFFFFLL)
 		ui.txtTotalNumber->setText(QString::number(iTotalNumber));
+
+	qint64 iCpuRateLimit = m_pBox->GetNum64("CpuRateLimit", 0);
+	if (iCpuRateLimit > 0x0LL && iCpuRateLimit <= 100LL)
+		ui.txtCpuRateLimit->setText(QString::number(iCpuRateLimit));
 
 	ui.chkUseSbieDeskHack->setChecked(m_pBox->GetBool("UseSbieDeskHack", true));
 	ui.chkUseSbieWndStation->setChecked(m_pBox->GetBool("UseSbieWndStation", true));
@@ -460,6 +465,12 @@ void COptionsWindow::SaveAdvanced()
 		WriteText("ProcessNumberLimit", QString::number(iTotalNumber));
 	else
 		m_pBox->DelValue("ProcessNumberLimit");
+
+	qint64 iCpuRateLimit = !ui.txtCpuRateLimit->text().isEmpty() ? ui.txtCpuRateLimit->text().toLongLong() : -1;
+	if (iCpuRateLimit > 0x0LL && iCpuRateLimit <= 100LL)
+		WriteText("CpuRateLimit", QString::number(iCpuRateLimit));
+	else
+		m_pBox->DelValue("CpuRateLimit");
 
 	WriteAdvancedCheck(ui.chkRestrictServices, "RunServicesAsSystem", "", "y");
 	WriteAdvancedCheck(ui.chkElevateRpcss, "RunRpcssAsSystem", "y", "");
@@ -807,6 +818,15 @@ void COptionsWindow::UpdateJobOptions()
 		ui.lblTotalNumber->setText("");
 	}
 	ui.txtTotalNumber->setEnabled(bUseJobObject);
+
+	qint64 iCpuRateLimit = ui.txtCpuRateLimit->text().toLongLong();
+	if (!(iCpuRateLimit > 0x0LL && iCpuRateLimit <= 100LL)) {
+		ui.lblCpuRateLimit->setText(tr("unlimited"));
+	}
+	else {
+		ui.lblCpuRateLimit->setText(tr("%"));
+	}
+	ui.txtCpuRateLimit->setEnabled(bUseJobObject);
 
 
 	ui.chkRestartOnPCA->setEnabled(!ui.chkForceRestart->isChecked());

--- a/SandboxiePlus/SandMan/sandman_zh_CN.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_CN.ts
@@ -3717,6 +3717,59 @@ Full path: %4</source>
     </message>
 </context>
 <context>
+    <name>CResourceView</name>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="22"/>
+        <source>Sandbox / Process</source>
+        <translation>沙箱 / 进程</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="22"/>
+        <source>PID</source>
+        <translation>进程 ID</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="22"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="22"/>
+        <source>Working Set</source>
+        <translation>工作集</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="22"/>
+        <source>Private Bytes</source>
+        <translation>私有字节</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="22"/>
+        <source>Status</source>
+        <translation>状态</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="199"/>
+        <source>Active</source>
+        <translation>活跃</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="207"/>
+        <source>Inactive</source>
+        <translation>空闲</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="207"/>
+        <source>Empty</source>
+        <translation>空</translation>
+    </message>
+    <message>
+        <location filename="Views/ResourceView.cpp" line="215"/>
+        <source>Running</source>
+        <translation>运行中</translation>
+    </message>
+</context>
+<context>
     <name>CRenameSandboxDialog</name>
     <message>
         <location filename="Windows/RenameSandboxDialog.cpp" line="17"/>
@@ -4517,6 +4570,11 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
         <location filename="SandMan.cpp" line="1618"/>
         <source>Recovery Log</source>
         <translation>恢复日志</translation>
+    </message>
+    <message>
+        <location filename="SandMan.cpp" line="1625"/>
+        <source>Resource Monitor</source>
+        <translation>资源监控</translation>
     </message>
     <message>
         <location filename="SandMan.cpp" line="1413"/>

--- a/SandboxiePlus/SandMan/sandman_zh_CN.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_CN.ts
@@ -3719,54 +3719,100 @@ Full path: %4</source>
 <context>
     <name>CResourceView</name>
     <message>
-        <location filename="Views/ResourceView.cpp" line="22"/>
+        <source>Refresh</source>
+        <translation>刷新</translation>
+    </message>
+    <message>
+        <source>Refresh resource data now</source>
+        <translation>立即刷新资源数据</translation>
+    </message>
+    <message>
+        <source>Terminate Process</source>
+        <translation>终止进程</translation>
+    </message>
+    <message>
+        <source>Terminate the selected process</source>
+        <translation>终止选中的进程</translation>
+    </message>
+    <message>
+        <source>Terminate All in Box</source>
+        <translation>终止沙箱中全部进程</translation>
+    </message>
+    <message>
+        <source>Terminate all processes in the selected sandbox</source>
+        <translation>终止选中沙箱中的所有进程</translation>
+    </message>
+    <message>
+        <source>Expand All</source>
+        <translation>全部展开</translation>
+    </message>
+    <message>
+        <source>Collapse All</source>
+        <translation>全部折叠</translation>
+    </message>
+    <message>
+        <source>Filter:</source>
+        <translation>筛选:</translation>
+    </message>
+    <message>
+        <source>Search sandbox or process...</source>
+        <translation>搜索沙箱或进程...</translation>
+    </message>
+    <message>
         <source>Sandbox / Process</source>
         <translation>沙箱 / 进程</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="22"/>
         <source>PID</source>
         <translation>进程 ID</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="22"/>
         <source>CPU</source>
         <translation>CPU</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="22"/>
         <source>Working Set</source>
         <translation>工作集</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="22"/>
         <source>Private Bytes</source>
         <translation>私有字节</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="22"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="199"/>
         <source>Active</source>
         <translation>活跃</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="207"/>
         <source>Inactive</source>
         <translation>空闲</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="207"/>
         <source>Empty</source>
         <translation>空</translation>
     </message>
     <message>
-        <location filename="Views/ResourceView.cpp" line="215"/>
         <source>Running</source>
         <translation>运行中</translation>
+    </message>
+    <message>
+        <source>Boxes: %1 (%2 active)  |  Processes: %3  |  Total Memory: %4</source>
+        <translation>沙箱: %1 (%2 活跃)  |  进程: %3  |  总内存: %4</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to terminate %1 process(es)?</source>
+        <translation>确定要终止 %1 个进程吗？</translation>
+    </message>
+    <message>
+        <source>Terminate Sandbox</source>
+        <translation>终止沙箱</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to terminate all processes in %1 sandbox(es)?</source>
+        <translation>确定要终止 %1 个沙箱中的所有进程吗？</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
feat: add resource monitor view to track sandbox process CPU and memory usage
┌─────────────────────────────────────────────────────────────┐
│ [消息日志] [API 跟踪] [恢复日志] [资源监控]  ← 新增标签页   │
├─────────────────────────────────────────────────────────────┤
│ 沙箱名称          │ 进程数 │ CPU   │ 内存      │ 磁盘占用   │
│ ▼ DefaultBox      │   3    │ 12.5% │ 256 MB    │ 1.2 GB    │
│   ├ firefox.exe   │        │  8.2% │ 180 MB    │           │
│   ├ plugin-cont.. │        │  3.1% │  45 MB    │           │
│   └ sbox-host.dll │        │  1.2% │  31 MB    │           │
│ ▼ TestBox         │   1    │  2.0% │  64 MB    │ 340 MB    │
│   └ cmd.exe       │        │  2.0% │  64 MB    │           │
│ ─ EncryptedBox    │   0    │  0.0% │   0 MB    │ 2.1 GB    │
└─────────────────────────────────────────────────────────────┘
