### PR TITLE
Strip Win32 BaseNamedObjects prefixes

### DIFF
--- a/Sandboxie/core/dll/sysinfo.c
+++ b/Sandboxie/core/dll/sysinfo.c
@@ -556,6 +556,17 @@ _FX NTSTATUS SysInfo_GetJobName(OBJECT_ATTRIBUTES* ObjectAttributes, WCHAR** Out
     if (ObjectAttributes && ObjectAttributes->ObjectName) {
         objname_len = ObjectAttributes->ObjectName->Length / sizeof(WCHAR);
         objname_buf = ObjectAttributes->ObjectName->Buffer;
+
+        // Normalize Win32 BaseNamedObjects prefixes to plain names before
+        // constructing the sandbox object path.
+        if (objname_len >= 7 && _wcsnicmp(objname_buf, L"Global\\", 7) == 0) {
+            objname_len -= 7;
+            objname_buf += 7;
+        }
+        else if (objname_len >= 6 && _wcsnicmp(objname_buf, L"Local\\", 6) == 0) {
+            objname_len -= 6;
+            objname_buf += 6;
+        }
     } 
     else { // unnamed job
 


### PR DESCRIPTION
Fixes #5281, Fixes #5303  

In SysInfo_GetJobName, normalize Win32 BaseNamedObjects prefixes by removing leading "Global\\" or "Local\\" (case-insensitive) from ObjectAttributes->ObjectName before constructing the sandbox object path. The change adjusts objname_len and objname_buf to skip these prefixes so sandbox object names use plain names, avoiding namespace-qualified duplicates or incorrect path formation.
