### PR TITLE
Proxy Shell_NotifyIcon for OpenWinClass mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - fixed box rename failing with "The parameter is incorrect" since 1.17.3, caused by multi-line section content being rejected by the new ContainsCRLF check in CIniFile::AddValue
 - fixed renamed sandbox not being re-selected in the UI after a successful rename
+- fixed sandboxed app tray icons not showing with `OpenWinClass=*` by proxying `Shell_NotifyIcon`; can be disabled with `UseShellNotifyIconProxy` (default enabled, supports `process` and `!process` selectors)
 
 
 

--- a/Sandboxie/core/dll/sh.c
+++ b/Sandboxie/core/dll/sh.c
@@ -32,6 +32,7 @@
 #include "common/my_shlwapi.h"
 #include "msgs/msgs.h"
 #include "gui_p.h"
+#include "core/svc/GuiWire.h"
 #include "core/svc/UserWire.h"
 
 //---------------------------------------------------------------------------
@@ -49,6 +50,14 @@ static BOOL SH32_ShellExecuteExW(SHELLEXECUTEINFOW *lpExecInfo);
 
 static BOOL SH32_Shell_NotifyIconW(
     DWORD dwMessage, PNOTIFYICONDATAW lpData);
+
+static ULONG SH32_wcsnlen(const WCHAR *src, ULONG maxChars);
+
+static ULONG SH32_NotifyIconMaxChars(
+    DWORD cbSize, ULONG fieldOffsetBytes, ULONG fieldCapacityChars);
+
+static BOOLEAN SH32_Shell_NotifyIcon_ProxyCall(
+    DWORD dwMessage, PNOTIFYICONDATAW lpData, BOOL *ret);
 
 //static HRESULT SH32_SHGetFolderPathW(
 //    HWND hwnd, int csidl, HANDLE hToken, DWORD dwFlags, LPWSTR pszPath);
@@ -192,6 +201,8 @@ extern P_LdrGetDllHandleEx      __sys_LdrGetDllHandleEx;
 
 
 extern const WCHAR *File_BQQB;
+
+static const WCHAR *SH32_UseShellNotifyIconProxy = L"UseShellNotifyIconProxy";
 
 
 //---------------------------------------------------------------------------
@@ -604,6 +615,130 @@ HICON SH32_BorderToIcon(HICON hIcon, COLORREF color)
 
 
 //---------------------------------------------------------------------------
+// SH32_wcsnlen
+//---------------------------------------------------------------------------
+
+
+static ULONG SH32_wcsnlen(const WCHAR *src, ULONG maxChars)
+{
+    ULONG len = 0;
+
+    if (!src)
+        return 0;
+
+    while (len < maxChars && src[len] != L'\0')
+        ++len;
+
+    return len;
+}
+
+
+//---------------------------------------------------------------------------
+// SH32_NotifyIconMaxChars
+//---------------------------------------------------------------------------
+
+
+static ULONG SH32_NotifyIconMaxChars(
+    DWORD cbSize, ULONG fieldOffsetBytes, ULONG fieldCapacityChars)
+{
+    ULONG chars;
+
+    if (cbSize <= fieldOffsetBytes)
+        return 0;
+
+    chars = (cbSize - fieldOffsetBytes) / sizeof(WCHAR);
+    if (chars > fieldCapacityChars)
+        chars = fieldCapacityChars;
+
+    return chars;
+}
+
+
+//---------------------------------------------------------------------------
+// SH32_Shell_NotifyIcon_ProxyCall
+//---------------------------------------------------------------------------
+
+
+static BOOLEAN SH32_Shell_NotifyIcon_ProxyCall(
+    DWORD dwMessage, PNOTIFYICONDATAW lpData, BOOL *ret)
+{
+    if (! lpData)
+        return FALSE;
+
+    GUI_SHELL_NOTIFY_ICON_REQ *req =
+        (GUI_SHELL_NOTIFY_ICON_REQ *)Dll_AllocTemp(sizeof(GUI_SHELL_NOTIFY_ICON_REQ));
+    if (! req)
+        return FALSE;
+
+    memzero(req, sizeof(*req));
+    req->msgid     = GUI_SHELL_NOTIFY_ICON;
+    req->dwMessage = dwMessage;
+
+    req->cbSize           = lpData->cbSize;
+    req->hWnd             = (ULONG)(ULONG_PTR)lpData->hWnd;
+    req->uID              = lpData->uID;
+    req->uFlags           = lpData->uFlags;
+    req->uCallbackMessage = lpData->uCallbackMessage;
+    req->hIcon            = (ULONG)(ULONG_PTR)lpData->hIcon;
+
+    ULONG tipChars = SH32_NotifyIconMaxChars(
+        lpData->cbSize,
+        FIELD_OFFSET(NOTIFYICONDATAW, szTip),
+        ARRAYSIZE(req->szTip));
+
+    if (tipChars) {
+        wmemcpy(req->szTip, lpData->szTip, tipChars);
+        req->szTip[tipChars - 1] = L'\0';
+    }
+
+    if (lpData->cbSize >= (DWORD)NOTIFYICONDATAW_V2_SIZE) {
+
+        req->dwState     = lpData->dwState;
+        req->dwStateMask = lpData->dwStateMask;
+
+        wmemcpy(req->szInfo, lpData->szInfo, ARRAYSIZE(req->szInfo) - 1);
+        req->szInfo[ARRAYSIZE(req->szInfo) - 1] = L'\0';
+
+        req->uVersion = lpData->uVersion;
+
+        wmemcpy(req->szInfoTitle, lpData->szInfoTitle, ARRAYSIZE(req->szInfoTitle) - 1);
+        req->szInfoTitle[ARRAYSIZE(req->szInfoTitle) - 1] = L'\0';
+
+        req->dwInfoFlags = lpData->dwInfoFlags;
+    }
+
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+    if (lpData->cbSize >= (DWORD)NOTIFYICONDATAW_V3_SIZE) {
+        req->guidItem = lpData->guidItem;
+    }
+
+    if (lpData->cbSize >= (DWORD)(NOTIFYICONDATAW_V3_SIZE + sizeof(HICON))) {
+        req->hBalloonIcon = (ULONG)(ULONG_PTR)lpData->hBalloonIcon;
+    }
+#else
+    if (lpData->cbSize >= (DWORD)(NOTIFYICONDATAW_V2_SIZE + sizeof(GUID))) {
+        req->guidItem = lpData->guidItem;
+    }
+#endif
+
+    GUI_SHELL_NOTIFY_ICON_RPL *rpl =
+        Gui_CallProxy(req, sizeof(*req), sizeof(*rpl));
+
+    Dll_Free(req);
+
+    if (! rpl)
+        return FALSE;
+
+    if (ret)
+        *ret = rpl->result ? TRUE : FALSE;
+
+    SetLastError(rpl->error);
+    Dll_Free(rpl);
+    return TRUE;
+}
+
+
+//---------------------------------------------------------------------------
 // SH32_Shell_NotifyIconW
 //---------------------------------------------------------------------------
 
@@ -611,32 +746,51 @@ HICON SH32_BorderToIcon(HICON hIcon, COLORREF color)
 _FX BOOL SH32_Shell_NotifyIconW(
     DWORD dwMessage, PNOTIFYICONDATAW lpData)
 {
-    BOOL ret;
+    BOOL ret = FALSE;
     HICON icon = NULL;
 
     if (dwMessage == NIM_ADD || dwMessage == NIM_MODIFY)
     {
-        if (!Gui_DisableTitle && lpData && lpData->cbSize >= sizeof(PNOTIFYICONDATAW))
+        if (!Gui_DisableTitle && lpData)
         {
-            ULONG len = wcslen(lpData->szTip);
+            ULONG tipChars = SH32_NotifyIconMaxChars(
+                lpData->cbSize,
+                FIELD_OFFSET(NOTIFYICONDATAW, szTip),
+                ARRAYSIZE(lpData->szTip));
 
-            if (Gui_BoxNameTitleLen != 0 && (len + Gui_BoxNameTitleLen + 2) <= 127)
+            if (tipChars > 1)
             {
-                wmemmove(lpData->szTip + Gui_BoxNameTitleLen + 2, lpData->szTip, len + 1);
-                wmemcpy(lpData->szTip, Gui_BoxNameTitleW, Gui_BoxNameTitleLen);
-                wmemcpy(lpData->szTip + Gui_BoxNameTitleLen, L"\r\n", 2);
-            }
-            else
-            {
-                if (len + 8 > 127) {
-                    lpData->szTip[127 - 8 - 3] = L'\0';
-                    wcscat(lpData->szTip, L"...");
-                    len = 127 - 8;
+                ULONG tipMaxLen = tipChars - 1;
+                ULONG len = SH32_wcsnlen(lpData->szTip, tipMaxLen);
+                lpData->szTip[len] = L'\0';
+
+                if (Gui_BoxNameTitleLen != 0 && (len + Gui_BoxNameTitleLen + 2) <= tipMaxLen)
+                {
+                    wmemmove(lpData->szTip + Gui_BoxNameTitleLen + 2, lpData->szTip, len + 1);
+                    wmemcpy(lpData->szTip, Gui_BoxNameTitleW, Gui_BoxNameTitleLen);
+                    wmemcpy(lpData->szTip + Gui_BoxNameTitleLen, L"\r\n", 2);
                 }
+                else
+                {
+                    if (tipMaxLen >= 8) {
 
-                wmemmove(lpData->szTip + 4, lpData->szTip, len + 1);
-                wmemcpy(lpData->szTip, L"[#] ", 4);
-                wcscat(lpData->szTip, L" [#]");
+                        if (len + 8 > tipMaxLen) {
+                            if (tipMaxLen > 11) {
+                                lpData->szTip[tipMaxLen - 8 - 3] = L'\0';
+                                wcscat(lpData->szTip, L"...");
+                                len = tipMaxLen - 8;
+                            }
+                            else {
+                                lpData->szTip[0] = L'\0';
+                                len = 0;
+                            }
+                        }
+
+                        wmemmove(lpData->szTip + 4, lpData->szTip, len + 1);
+                        wmemcpy(lpData->szTip, L"[#] ", 4);
+                        wcscat(lpData->szTip, L" [#]");
+                    }
+                }
             }
         }
 
@@ -651,7 +805,23 @@ _FX BOOL SH32_Shell_NotifyIconW(
         }
     }
 
-    ret = __sys_Shell_NotifyIconW(dwMessage, lpData);
+    if (Gui_OpenAllWinClasses && Gui_UseProxyService
+        && Config_GetSettingsForImageName_bool(SH32_UseShellNotifyIconProxy, TRUE)) {
+
+        //
+        // When OpenWinClass=* is set, FindWindowW/SendMessageW hooks are not
+        // installed, so Shell_NotifyIconW cannot locate Shell_TrayWnd on the
+        // Sandboxie desktop.  Route the call through the GUI proxy, which
+        // runs on the real desktop and can invoke Shell_NotifyIconW there.
+        //
+
+        if (! SH32_Shell_NotifyIcon_ProxyCall(dwMessage, lpData, &ret))
+            ret = __sys_Shell_NotifyIconW(dwMessage, lpData);
+
+    } else {
+
+        ret = __sys_Shell_NotifyIconW(dwMessage, lpData);
+    }
 
     if (icon) 
     {

--- a/Sandboxie/core/svc/GuiServer.cpp
+++ b/Sandboxie/core/svc/GuiServer.cpp
@@ -30,6 +30,7 @@
 #include "core/drv/api_defs.h"
 #include "common/my_version.h"
 #include <stdlib.h>
+#include <shellapi.h>
 #include <sddl.h>
 #include <aclapi.h>
 #include <dde.h>
@@ -787,6 +788,7 @@ bool GuiServer::CreateQueueSlave(const WCHAR *cmdline)
     m_SlaveFuncs[GUI_GET_CLIPBOARD_METAFILE] = &GuiServer::GetClipboardMetaFileSlave;
     m_SlaveFuncs[GUI_SEND_POST_MESSAGE]     = &GuiServer::SendPostMessageSlave;
     m_SlaveFuncs[GUI_SEND_COPYDATA]         = &GuiServer::SendCopyDataSlave;
+    m_SlaveFuncs[GUI_SHELL_NOTIFY_ICON]     = &GuiServer::ShellNotifyIconSlave;
     m_SlaveFuncs[GUI_CLIP_CURSOR]           = &GuiServer::ClipCursorSlave;
     m_SlaveFuncs[GUI_SET_FOREGROUND_WINDOW] = &GuiServer::SetForegroundWindowSlave;
     m_SlaveFuncs[GUI_MONITOR_FROM_WINDOW]   = &GuiServer::MonitorFromWindowSlave;
@@ -3119,6 +3121,85 @@ ULONG GuiServer::SendCopyDataSlave(SlaveArgs *args)
     rpl->error = GetLastError();
 
     args->rpl_len = sizeof(GUI_SEND_COPYDATA_RPL);
+    return STATUS_SUCCESS;
+}
+
+
+//---------------------------------------------------------------------------
+// ShellNotifyIconSlave
+//---------------------------------------------------------------------------
+
+
+ULONG GuiServer::ShellNotifyIconSlave(SlaveArgs *args)
+{
+    GUI_SHELL_NOTIFY_ICON_REQ *req = (GUI_SHELL_NOTIFY_ICON_REQ *)args->req_buf;
+    GUI_SHELL_NOTIFY_ICON_RPL *rpl = (GUI_SHELL_NOTIFY_ICON_RPL *)args->rpl_buf;
+
+    if (args->req_len < sizeof(GUI_SHELL_NOTIFY_ICON_REQ))
+        return STATUS_INFO_LENGTH_MISMATCH;
+
+    //
+    // resolve Shell_NotifyIconW dynamically to avoid a static shell32 dependency
+    //
+
+    typedef BOOL (WINAPI *P_Shell_NotifyIconW)(DWORD, PNOTIFYICONDATAW);
+    static P_Shell_NotifyIconW fnShellNotifyIconW = NULL;
+    if (!fnShellNotifyIconW) {
+        HMODULE hShell32 = GetModuleHandleW(L"shell32.dll");
+        if (!hShell32)
+            hShell32 = LoadLibraryW(L"shell32.dll");
+        if (hShell32)
+            fnShellNotifyIconW = (P_Shell_NotifyIconW)GetProcAddress(hShell32, "Shell_NotifyIconW");
+    }
+
+    if (!fnShellNotifyIconW) {
+        rpl->error  = ERROR_PROC_NOT_FOUND;
+        rpl->result = 0;
+        args->rpl_len = sizeof(*rpl);
+        return STATUS_SUCCESS;
+    }
+
+    //
+    // reconstruct NOTIFYICONDATAW from the platform-neutral wire format
+    //
+
+    NOTIFYICONDATAW nid;
+    memset(&nid, 0, sizeof(nid));
+    nid.cbSize = req->cbSize;
+    if (nid.cbSize < (DWORD)NOTIFYICONDATAW_V1_SIZE)
+        nid.cbSize = (DWORD)NOTIFYICONDATAW_V1_SIZE;
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+    if (nid.cbSize > (DWORD)sizeof(nid))
+        nid.cbSize = (DWORD)sizeof(nid);
+#else
+    if (nid.cbSize > (DWORD)NOTIFYICONDATAW_V2_SIZE)
+        nid.cbSize = (DWORD)NOTIFYICONDATAW_V2_SIZE;
+#endif
+    nid.hWnd             = (HWND)(ULONG_PTR)req->hWnd;
+    nid.uID              = req->uID;
+    nid.uFlags           = req->uFlags;
+    nid.uCallbackMessage = req->uCallbackMessage;
+    nid.hIcon            = (HICON)(ULONG_PTR)req->hIcon;
+    wmemcpy(nid.szTip, req->szTip, ARRAYSIZE(nid.szTip) - 1);
+    nid.szTip[ARRAYSIZE(nid.szTip) - 1] = L'\0';
+    nid.dwState          = req->dwState;
+    nid.dwStateMask      = req->dwStateMask;
+    wmemcpy(nid.szInfo, req->szInfo, ARRAYSIZE(nid.szInfo) - 1);
+    nid.szInfo[ARRAYSIZE(nid.szInfo) - 1] = L'\0';
+    nid.uVersion         = req->uVersion;
+    wmemcpy(nid.szInfoTitle, req->szInfoTitle, ARRAYSIZE(nid.szInfoTitle) - 1);
+    nid.szInfoTitle[ARRAYSIZE(nid.szInfoTitle) - 1] = L'\0';
+    nid.dwInfoFlags      = req->dwInfoFlags;
+    nid.guidItem         = req->guidItem;
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+    nid.hBalloonIcon     = (HICON)(ULONG_PTR)req->hBalloonIcon;
+#endif
+
+    BOOL result = fnShellNotifyIconW(req->dwMessage, &nid);
+
+    rpl->error  = GetLastError();
+    rpl->result = result ? 1 : 0;
+    args->rpl_len = sizeof(*rpl);
     return STATUS_SUCCESS;
 }
 

--- a/Sandboxie/core/svc/GuiServer.h
+++ b/Sandboxie/core/svc/GuiServer.h
@@ -148,6 +148,8 @@ protected:
 
     ULONG SendCopyDataSlave(SlaveArgs *args);
 
+    ULONG ShellNotifyIconSlave(SlaveArgs *args);
+
     ULONG ClipCursorSlave(SlaveArgs *args);
 
     ULONG SetForegroundWindowSlave(SlaveArgs *args);

--- a/Sandboxie/core/svc/GuiWire.h
+++ b/Sandboxie/core/svc/GuiWire.h
@@ -63,6 +63,7 @@ enum {
     GUI_WND_HOOK_NOTIFY,
     GUI_WND_HOOK_REGISTER,
     GUI_KILL_JOB,
+    GUI_SHELL_NOTIFY_ICON,
     GUI_MAX_REQUEST_CODE
 };
 
@@ -769,6 +770,44 @@ struct tagGUI_KILL_JOB_REQ
 };
 
 typedef struct tagGUI_KILL_JOB_REQ GUI_KILL_JOB_REQ;
+
+//---------------------------------------------------------------------------
+// Shell Notify Icon (tray icon proxy for OpenWinClass=* mode)
+//---------------------------------------------------------------------------
+
+// Platform-neutral representation of NOTIFYICONDATAW fields
+struct tagGUI_SHELL_NOTIFY_ICON_REQ
+{
+    ULONG msgid;
+    ULONG dwMessage;        // NIM_ADD, NIM_MODIFY, NIM_DELETE, etc.
+    ULONG cbSize;           // original cbSize from caller
+    ULONG hWnd;             // HWND as 32-bit (user handles fit in 32 bits)
+    ULONG uID;
+    ULONG uFlags;
+    ULONG uCallbackMessage;
+    ULONG hIcon;            // HICON as 32-bit (user handles fit in 32 bits)
+    WCHAR szTip[128];
+    DWORD dwState;
+    DWORD dwStateMask;
+    WCHAR szInfo[256];
+    UINT  uVersion;
+    WCHAR szInfoTitle[64];
+    DWORD dwInfoFlags;
+    GUID  guidItem;
+    ULONG hBalloonIcon;     // HICON as 32-bit
+    ULONG pad;
+};
+
+struct tagGUI_SHELL_NOTIFY_ICON_RPL
+{
+    ULONG status;
+    ULONG error;
+    ULONG result;           // BOOL return value from Shell_NotifyIconW
+    ULONG pad;
+};
+
+typedef struct tagGUI_SHELL_NOTIFY_ICON_REQ GUI_SHELL_NOTIFY_ICON_REQ;
+typedef struct tagGUI_SHELL_NOTIFY_ICON_RPL GUI_SHELL_NOTIFY_ICON_RPL;
 
 //---------------------------------------------------------------------------
 

--- a/Sandboxie/install/SbieSettings.ini
+++ b/Sandboxie/install/SbieSettings.ini
@@ -6472,6 +6472,19 @@ Syntax=[sn]=[bY]
 Description=Enables or disables the use of Sandboxie’s custom UAC (User Account Control)\n handling for elevation prompts instead of the standard Windows UAC dialog.
 
 
+[UseShellNotifyIconProxy]
+AddedVersion=1.17.5
+RemovedVersion=
+ReAddedVersion=
+RenamedVersion=
+SupersededBy=
+Category=c
+Context=
+Requirements=<OpenWinClass=*>
+Syntax=[sn]=[process,][bY]
+Description=Routes [code]Shell_NotifyIcon[/code] calls through Sandboxie’s GUI proxy when [code]OpenWinClass=*[/code] is used.\nEnabled by default, but can be disabled globally or per image for compatibility.\nSupports negated image selectors with [code]!process[/code].
+
+
 [UseSbieDeskHack]
 AddedVersion=1.1.2
 RemovedVersion=


### PR DESCRIPTION
Resolves #826, resolves #4684

Route `Shell_NotifyIconW` calls through the GUI proxy when `OpenWinClass=*` is used so sandboxed apps' tray icons are visible.
   - Adds a UseShellNotifyIconProxy setting (enabled by default, supports process and !process selectors) and documents it in `SbieSettings.ini` and `CHANGELOG`.
   - Implements platform-neutral wire structs in GuiWire, a GuiServer slave to reconstruct and call `Shell_NotifyIconW` on the real desktop, and client-side marshaling and safe string/size handling in `sh.c` with a fallback to the native call.
