### PR TITLE
Change GetArguments parameter from wstring to wstring_view

### DIFF
--- a/SandboxieTools/Common/helpers.cpp
+++ b/SandboxieTools/Common/helpers.cpp
@@ -138,7 +138,7 @@ void DbgPrint(const wchar_t* format, ...)
     va_end(va_args);
 }
 
-std::multimap<std::wstring, std::wstring> GetArguments(const std::wstring& Arguments, wchar_t Separator, wchar_t Assigner, std::wstring* First, bool bLowerKeys, bool bReadEsc)
+std::multimap<std::wstring, std::wstring> GetArguments(const std::wstring_view Arguments, wchar_t Separator, wchar_t Assigner, std::wstring* First, bool bLowerKeys, bool bReadEsc)
 {
     std::multimap<std::wstring, std::wstring> ArgumentList;
 


### PR DESCRIPTION
Replace wstring& with wstring_view to improve security

> Thank you for your contribution to the Sandboxie repository.
>
> Translators are encouraged to look at the localization notes and tips: https://git.io/J9G19
