### PR TITLE
Resolve potentially loosing pointer with realloc

### DIFF
--- a/SandboxieTools/Common/WebUtils.cpp
+++ b/SandboxieTools/Common/WebUtils.cpp
@@ -34,7 +34,15 @@ void GetWebPayload(PVOID RequestHandle, PSTR* pData, ULONG* pDataLength)
 		if (allocatedLength < dataLength + returnLength)
 		{
 			allocatedLength *= 2;
-			*pData = (PSTR)realloc(*pData, allocatedLength);
+			PSTR pTemp = (PSTR)realloc(*pData, newAllocatedLength);
+        
+            if (!pTemp) {
+                free(*pData);
+                *pData = NULL;
+                return;
+            }
+            *pData = pTemp;
+            allocatedLength = newAllocatedLength;
 		}
 
 		memcpy(*pData + dataLength, buffer, returnLength);


### PR DESCRIPTION
If realloc fails due to lack of memory, the original pointer is lost (causing a memory leak) and the application crashes on the next write attempt.

> Thank you for your contribution to the Sandboxie repository.
>
> Translators are encouraged to look at the localization notes and tips: https://git.io/J9G19
