### PR TITLE
fix: Heap Buffer Over-Read in Sxs_Generate due to unbounded string parsing

### DIFF
--- a/Sandboxie/apps/com/RpcSs/sxs.c
+++ b/Sandboxie/apps/com/RpcSs/sxs.c
@@ -95,7 +95,7 @@ ULONG Sxs_Thread(void *arg);
 static void Sxs_Request(
     UCHAR *data, ULONG data_len, UCHAR **rsp_data, ULONG *rsp_len);
 
-static void Sxs_Generate(UCHAR *buf, HANDLE *hSection);
+static void Sxs_Generate(UCHAR *buf, ULONG buf_len, HANDLE *hSection);
 
 static IUnknown *Sxs_CreateStreamFromBuffer(UCHAR *Text);
 
@@ -333,7 +333,7 @@ _FX void Sxs_Request(
     UCHAR *data, ULONG data_len, UCHAR **rsp_data, ULONG *rsp_len)
 {
     HANDLE hSection = NULL;
-    Sxs_Generate(data, &hSection);
+    Sxs_Generate(data, data_len, &hSection);
 
     if (hSection == (HANDLE)(ULONG_PTR)-1) {
 
@@ -383,11 +383,15 @@ _FX void Sxs_Request(
 //---------------------------------------------------------------------------
 
 
-_FX void Sxs_Generate(UCHAR *buf, HANDLE *hSection)
+_FX void Sxs_Generate(UCHAR *buf, ULONG buf_len, HANDLE *hSection)
 {
     ULONG *ptr4;
     WCHAR *ptr2;
     UCHAR *ptr1;
+    UCHAR *buf_end;
+    SIZE_T remaining_w;
+    SIZE_T remaining_b;
+    SIZE_T slen;
 
     ULONG ArchId;
     ULONG LangId;
@@ -404,6 +408,26 @@ _FX void Sxs_Generate(UCHAR *buf, HANDLE *hSection)
 
     *hSection = NULL;
 
+    //
+    // minimum header size: signature ULONG + pad ULONG + ArchId ULONG
+    // + LangId ULONG = 16 bytes
+    //
+
+    if (buf_len < 16)
+        return;
+
+    //
+    // force null termination at the end of the buffer so that even if
+    // the producer omitted terminators, the string scans below cannot
+    // read past the allocation
+    //
+
+    buf[buf_len - 1] = '\0';
+    if (buf_len >= 2)
+        buf[buf_len - 2] = '\0';
+
+    buf_end = buf + buf_len;
+
     ptr4 = (ULONG *)buf;
     if (*ptr4 != 'xobs')        // signature
         return;
@@ -417,37 +441,57 @@ _FX void Sxs_Generate(UCHAR *buf, HANDLE *hSection)
     ++ptr4;                     // skip ULONG
 
     ptr2 = (WCHAR *)ptr4;
-    if (wcslen(ptr2) > 64)
+
+    remaining_w = ((SIZE_T)(buf_end - (UCHAR *)ptr2)) / sizeof(WCHAR);
+    slen = wcsnlen(ptr2, remaining_w);
+    if (slen >= remaining_w || slen > 64)
         return;
     LangNames = ptr2;
-    ptr2 += wcslen(ptr2) + 1;
+    ptr2 += slen + 1;
 
-    if (wcslen(ptr2) > 1024)
+    remaining_w = ((SIZE_T)(buf_end - (UCHAR *)ptr2)) / sizeof(WCHAR);
+    slen = wcsnlen(ptr2, remaining_w);
+    if (slen >= remaining_w || slen > 1024)
         return;
     lpDirectory = ptr2;
-    ptr2 += wcslen(ptr2) + 1;
+    ptr2 += slen + 1;
 
-    if (wcslen(ptr2) > 1024)
+    remaining_w = ((SIZE_T)(buf_end - (UCHAR *)ptr2)) / sizeof(WCHAR);
+    slen = wcsnlen(ptr2, remaining_w);
+    if (slen >= remaining_w || slen > 1024)
         return;
     lpSourcePath = ptr2;
-    ptr2 += wcslen(ptr2) + 1;
+    ptr2 += slen + 1;
 
-    if (wcslen(ptr2) > 1024)
+    remaining_w = ((SIZE_T)(buf_end - (UCHAR *)ptr2)) / sizeof(WCHAR);
+    slen = wcsnlen(ptr2, remaining_w);
+    if (slen >= remaining_w || slen > 1024)
         return;
     lpConfigPath = ptr2;
-    ptr2 += wcslen(ptr2) + 1;
+    ptr2 += slen + 1;
 
     ptr1 = (UCHAR *)ptr2;
-    if (strlen(ptr1) > SXS_TEXT_LEN)
+
+    if (ptr1 >= buf_end)
+        return;
+    remaining_b = (SIZE_T)(buf_end - ptr1);
+    slen = strnlen(ptr1, remaining_b);
+    if (slen >= remaining_b || slen > SXS_TEXT_LEN)
         return;
     lpManifestText = ptr1;
-    ptr1 += strlen(ptr1) + 1;
+    ptr1 += slen + 1;
 
-    if (strlen(ptr1) > SXS_TEXT_LEN)
+    if (ptr1 >= buf_end)
+        return;
+    remaining_b = (SIZE_T)(buf_end - ptr1);
+    slen = strnlen(ptr1, remaining_b);
+    if (slen >= remaining_b || slen > SXS_TEXT_LEN)
         return;
     lpConfigText = ptr1;
-    ptr1 += strlen(ptr1) + 1;
+    ptr1 += slen + 1;
 
+    if (ptr1 >= buf_end)
+        return;
     if (*ptr1 != '*')
         return;
 


### PR DESCRIPTION
## Summary

Automated security fix for **Heap Buffer Over-Read in Sxs_Generate due to unbounded string parsing** (High).

**CWE**: CWE-CWE-125
**OWASP**: A03:2021-Injection
**Fix Confidence**: high

## What Changed
Fixed heap buffer over-read in Sxs_Generate by:

1. Adding `buf_len` parameter to `Sxs_Generate` and passing `data_len` from `Sxs_Request`.
2. Forcing null-termination of the last two bytes of the buffer before parsing, so that any unterminated strings cannot scan past the allocation.
3. Replacing all unbounded `wcslen`/`strlen` calls with bounded `wcsnlen`/`strnlen` that use the remaining buffer space as the max length.
4. After each scan, verifying the returned length is strictly less than `remaining` (i.e., an actual terminator was found within the buffer), and still enforcing the original upper bounds (64, 1024, SXS_TEXT_LEN).
5. Added bounds check before reading the final '*' sentinel byte.

The forward declaration and the single call site in `Sxs_Request` were updated. No other callers exist.

## Caveats
- Writing the last 1-2 bytes of the input buffer to NUL to guarantee termination mutates the caller's buffer. Since the buffer is owned by the request handler and freed via SbieDll_FreeMem after processing, this is safe.
- wcsnlen/strnlen are available on modern Windows CRTs; the project already targets Vista+ as seen in Sxs_Init.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
