### PR TITLE
Correct implemetation of _snwprintf_s

### DIFF
--- a/SandboxieTools/Common/verify.c
+++ b/SandboxieTools/Common/verify.c
@@ -75,7 +75,7 @@ static NTSTATUS MyCreateFile(_Out_ PHANDLE FileHandle, _In_ PCWSTR FileName, _In
     UNICODE_STRING uni;
 	OBJECT_ATTRIBUTES attr;
     WCHAR wszBuffer[MAX_PATH];
-    _snwprintf(wszBuffer, MAX_PATH, L"\\??\\%s", FileName);
+	_snwprintf_s(wszBuffer, _countof(wszBuffer), _TRUNCATE, L"\\??\\%s", FileName);
 	RtlInitUnicodeString(&uni, wszBuffer);
 	InitializeObjectAttributes(&attr, &uni, OBJ_CASE_INSENSITIVE, NULL, 0);
 


### PR DESCRIPTION
Corrected wrong implementation of function:
_snwprintf_s(wszBuffer, _countof(wszBuffer), _TRUNCATE, L"\\??\\%s", FileName);

> Thank you for your contribution to the Sandboxie repository.
>
> Translators are encouraged to look at the localization notes and tips: https://git.io/J9G19
