### PR TITLE
Hook QueryDosDeviceW and guard VMware crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 
+
+
+## [1.17.7 / 5.72.7] - 2026-05-??
+
+### Fixed
+- fixed VMware Workstation Pro 26H1 QueryDosDevice crash [#5390](https://github.com/sandboxie-plus/Sandboxie/issues/5390)
+
+
+
 ## [1.17.6 / 5.72.6] - 2026-05-17
 
 ### Added

--- a/Sandboxie/common/win32_ntddk.h
+++ b/Sandboxie/common/win32_ntddk.h
@@ -2797,6 +2797,11 @@ typedef BOOL (*P_DefineDosDevice)(
     void *DeviceName,
     void *TargetPath);
 
+typedef ULONG (*P_QueryDosDevice)(
+    const WCHAR *DeviceName,
+    WCHAR *TargetPath,
+    ULONG Max);
+
 typedef HMODULE (*P_LoadLibraryEx)(
     const void *lpFileName, HANDLE hFile, DWORD dwFlags);
 

--- a/Sandboxie/core/dll/file_init.c
+++ b/Sandboxie/core/dll/file_init.c
@@ -280,6 +280,13 @@ _FX BOOLEAN File_Init(void)
         if (DefineDosDeviceW) {
             SBIEDLL_HOOK(File_,DefineDosDeviceW);
         }
+
+        void *QueryDosDeviceW =
+            GetProcAddress(Dll_KernelBase ? Dll_KernelBase : Dll_Kernel32,
+                "QueryDosDeviceW");
+        if (QueryDosDeviceW) {
+            SBIEDLL_HOOK(File_,QueryDosDeviceW);
+        }
     }
 
     if (Dll_OsBuild >= 8400 && Dll_IsSystemSid) {

--- a/Sandboxie/core/dll/file_misc.c
+++ b/Sandboxie/core/dll/file_misc.c
@@ -50,6 +50,11 @@ static void File_ReplaceFileW_3(
 static BOOL File_DefineDosDeviceW(
     ULONG Flags, void *DevName, void *TargetPath);
 
+static ULONG File_QueryDosDeviceW(
+    const WCHAR *DeviceName, WCHAR *TargetPath, ULONG Max);
+
+static ULONG File_BuildSafeDosDeviceList(WCHAR *TargetPath, ULONG Max);
+
 static BOOL File_GetVolumeInformationW(
     const WCHAR *lpRootPathName,
     WCHAR *lpVolumeNameBuffer, ULONG nVolumeNameSize,
@@ -73,6 +78,8 @@ static P_MoveFileWithProgress       __sys_MoveFileWithProgressW     = NULL;
 static P_MoveFileWithProgress       __sys_MoveFileWithProgressA     = NULL;
 static P_ReplaceFile                __sys_ReplaceFileW              = NULL;
 static P_DefineDosDevice            __sys_DefineDosDeviceW          = NULL;
+typedef ULONG (*P_QueryDosDevice)(const WCHAR *DeviceName, WCHAR *TargetPath, ULONG Max);
+static P_QueryDosDevice             __sys_QueryDosDeviceW           = NULL;
 
 static P_GetVolumeInformation       __sys_GetVolumeInformationW     = NULL;
 static P_WriteProcessMemory         __sys_WriteProcessMemory        = NULL;
@@ -376,6 +383,68 @@ _FX BOOL File_DefineDosDeviceW(ULONG Flags, void *DevName, void *TargetPath)
 {
     SetLastError(ERROR_ACCESS_DENIED);
     return FALSE;
+}
+
+
+//---------------------------------------------------------------------------
+// File_QueryDosDeviceW
+//---------------------------------------------------------------------------
+
+
+_FX ULONG File_QueryDosDeviceW(const WCHAR *DeviceName, WCHAR *TargetPath, ULONG Max)
+{
+    // VMware 26 can crash in QueryDosDeviceW during host SCSI device discovery.
+    // Guard the native call and provide a safe fallback when it faults.
+    if (_wcsicmp(Dll_ImageName, L"vmware.exe") == 0) {
+        __try {
+            return __sys_QueryDosDeviceW(DeviceName, TargetPath, Max);
+        } __except (EXCEPTION_EXECUTE_HANDLER) {
+            if (!DeviceName)
+                return File_BuildSafeDosDeviceList(TargetPath, Max);
+
+            SetLastError(ERROR_FILE_NOT_FOUND);
+            return 0;
+        }
+    }
+
+    return __sys_QueryDosDeviceW(DeviceName, TargetPath, Max);
+}
+
+
+//---------------------------------------------------------------------------
+// File_BuildSafeDosDeviceList
+//---------------------------------------------------------------------------
+
+
+_FX ULONG File_BuildSafeDosDeviceList(WCHAR *TargetPath, ULONG Max)
+{
+    ULONG needed = 1; // final extra null terminator
+    DWORD drives = GetLogicalDrives();
+    int i;
+
+    for (i = 0; i < 26; ++i) {
+        if (drives & (1u << i))
+            needed += 3; // "X:" + null
+    }
+
+    if (!TargetPath || Max < needed) {
+        SetLastError(ERROR_INSUFFICIENT_BUFFER);
+        return 0;
+    }
+
+    {
+        WCHAR *p = TargetPath;
+        for (i = 0; i < 26; ++i) {
+            if (drives & (1u << i)) {
+                *p++ = (WCHAR)(L'A' + i);
+                *p++ = L':';
+                *p++ = L'\0';
+            }
+        }
+        *p = L'\0';
+    }
+
+    return needed;
 }
 
 

--- a/Sandboxie/core/dll/file_misc.c
+++ b/Sandboxie/core/dll/file_misc.c
@@ -78,7 +78,6 @@ static P_MoveFileWithProgress       __sys_MoveFileWithProgressW     = NULL;
 static P_MoveFileWithProgress       __sys_MoveFileWithProgressA     = NULL;
 static P_ReplaceFile                __sys_ReplaceFileW              = NULL;
 static P_DefineDosDevice            __sys_DefineDosDeviceW          = NULL;
-typedef ULONG (*P_QueryDosDevice)(const WCHAR *DeviceName, WCHAR *TargetPath, ULONG Max);
 static P_QueryDosDevice             __sys_QueryDosDeviceW           = NULL;
 
 static P_GetVolumeInformation       __sys_GetVolumeInformationW     = NULL;

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -328,6 +328,8 @@ OpenWinClass=MdiClass
 OpenWinClass=Logitech Wingman Internal Message Router
 # devldr32 sound card driver
 OpenWinClass=devldr
+# VMware Workstation Pro 26H1 (issue #5390)
+OpenWinClass=vmware.exe,MKSEmbedded
 
 
 #


### PR DESCRIPTION
Resolves #5390 

Add `QueryDosDeviceW` hook and a safe wrapper to prevent crashes triggered by VMware Workstation Pro 26H1.
  - `file_init.c` registers the `QueryDosDeviceW` hook.
  - `file_misc.c` adds `File_QueryDosDeviceW` which uses `SEH` to catch faults when running under `vmware.exe` and returns a safe fallback:
    - when `DeviceName` is `NULL` it builds a minimal DOS device list from logical drives via `File_BuildSafeDosDeviceList`;
    - when a specific device faults it sets `ERROR_FILE_NOT_FOUND`.