### PR TITLE
Preserve SetupAPI/CfgMgr32 failure status in setup hooks

### DIFF
--- a/Sandboxie/core/dll/setup.c
+++ b/Sandboxie/core/dll/setup.c
@@ -151,6 +151,12 @@ static P_CM_Add_Driver_Package_ExW  __sys_CM_Add_Driver_Package_ExW = NULL;
 #define FIND_EP1(x,s) __sys_##x##s = (P_##x) GetProcAddress(module, #x#s)
 #define FIND_EP2(x) FIND_EP1(x,A); FIND_EP1(x,W);
 
+#ifndef CR_ACCESS_DENIED
+#define CR_ACCESS_DENIED 0x00000033
+#endif
+
+#define SETUP_CM_DRIVER_PACKAGE_BLOCKED_STATUS CR_ACCESS_DENIED
+
 
 //---------------------------------------------------------------------------
 // Setup_Init_SetupApi
@@ -177,13 +183,7 @@ _FX BOOLEAN Setup_Init_SetupApi(HMODULE module)
 
 _FX ULONG Setup_VerifyCatalogFile(const WCHAR *CatalogFullPath)
 {
-    // ERROR_AUTHENTICODE_TRUSTED_PUBLISHER     (APPLICATION_ERROR_MASK|ERROR_SEVERITY_ERROR|0x241)
-    ULONG rc = __sys_VerifyCatalogFile(CatalogFullPath);
-    if (rc != 0 && rc != ERROR_AUTHENTICODE_TRUSTED_PUBLISHER) {
-        SetLastError(0);
-        rc = 0;
-    }
-    return rc;
+    return __sys_VerifyCatalogFile(CatalogFullPath);
 }
 
 
@@ -288,7 +288,7 @@ _FX ULONG Setup_CM_Add_Driver_PackageW(
     ULONG_PTR Unknown10)
 {
     SbieApi_Log(2205, L"CM Add Driver Package");
-    return 0;
+    return SETUP_CM_DRIVER_PACKAGE_BLOCKED_STATUS;
 }
 
 
@@ -304,7 +304,7 @@ _FX ULONG Setup_CM_Add_Driver_Package_ExW(
     ULONG_PTR Unknown10, ULONG_PTR Unknown11)
 {
     SbieApi_Log(2205, L"CM Add Driver Package Ex");
-    return 0;
+    return SETUP_CM_DRIVER_PACKAGE_BLOCKED_STATUS;
 }
 
 


### PR DESCRIPTION
## Summary

This PR preserves failure-status semantics in `Sandboxie/core/dll/setup.c`.

Two setup-related hooks currently project failure or blocked behavior as success:

- `Setup_VerifyCatalogFile` calls `VerifyCatalogFile`, but converts most nonzero verification results into `ERROR_SUCCESS`.
- `Setup_CM_Add_Driver_PackageW` and `Setup_CM_Add_Driver_Package_ExW` log `SBIE2205` for an unimplemented driver-package operation, but return `0`, which is the `CR_SUCCESS` shape for CfgMgr32-style status.

This PR changes those paths to preserve boundary semantics:

- return the original `VerifyCatalogFile` status unchanged
- return `CR_ACCESS_DENIED` from blocked `CM_Add_Driver_PackageW` / `CM_Add_Driver_Package_ExW` hooks after logging `SBIE2205`

It does not attempt to implement driver installation inside the sandbox.

## Rationale

A denied or failed device-setup boundary should not be projected as success.

If catalog verification fails, returning success can hide the trust failure from the caller.

If Sandboxie blocks driver-package installation but returns `CR_SUCCESS`, an installer can continue as if the driver package was installed, while host device state was not actually changed.

## Official/API shape

Microsoft documents `VerifyCatalogFile` as returning `ERROR_SUCCESS` only for success, with nonzero verification errors for failed verification cases:

- https://learn.microsoft.com/en-us/windows/win32/devnotes/verifycatalogfile

Microsoft documents SetupAPI as the device-installation API surface:

- https://learn.microsoft.com/en-my/windows-hardware/drivers/install/setupapi

CfgMgr32 APIs use `CONFIGRET`, where `CR_SUCCESS` means success and non-success `CR_*` values represent failure. `CM_MapCrToWin32Err` also confirms callers can map `CONFIGRET` failure status to Win32 errors:

- https://learn.microsoft.com/en-us/windows/win32/api/cfgmgr32/nf-cfgmgr32-cm_get_device_interface_listw
- https://learn.microsoft.com/en-us/windows/win32/api/cfgmgr32/nf-cfgmgr32-cm_mapcrtowin32err

## Verification

Source-level checks performed locally:

- `VerifyCatalogFile` status is no longer rewritten to `ERROR_SUCCESS`
- both blocked CfgMgr32 driver-package hooks return a non-success status
- hook registration and argument shapes are unchanged
- `git diff --check` passes

Remaining runtime verification recommended on Windows:

- DLL build
- signed/unsigned catalog verification smoke
- driver-package installer smoke proving `SBIE2205` is logged and the hook returns non-success `CONFIGRET`
- compatibility observation for installers that previously advanced after false success