### PR TITLE
Remove unsafe inline WFP trace logging block

### DIFF
--- a/Sandboxie/core/drv/wfp.c
+++ b/Sandboxie/core/drv/wfp.c
@@ -876,7 +876,6 @@ void WFP_classify(
 		UINT16 remote_port = inFixedValues->incomingValue[remotePortIndex].value.uint16;
 
 
-		BOOLEAN log = FALSE;
 		BOOLEAN block = FALSE;
 		BOOLEAN noloop = FALSE;
 		BOOLEAN isloopback = FALSE;
@@ -895,7 +894,6 @@ void WFP_classify(
 		wfp_proc = map_get(&WFP_Processes, processId);
 		if (wfp_proc) {
 
-			log = wfp_proc->LogTraffic;
 			block = wfp_proc->BlockInternet;
 			noloop = wfp_proc->BlockLoopback;
 			isloopback = WFP_isLoopback(&remote_ip);
@@ -911,52 +909,13 @@ void WFP_classify(
     
 		KeReleaseSpinLock(&WFP_MapLock, irql);
 
-		// TODO: Fix-Me, no ETW logging for now, we are here at DISPATCH_LEVEL but Session_MonitorPut is using pagable memory,
-		// we need either to create a logging proxy using non-paged pool, or change the tracking mechanism to use non-paged pool itself.
-        /*if (log){
-
-			BOOLEAN send = (filter->filterId == WFP_send_filter_id_v4) || (filter->filterId == WFP_send_filter_id_v6);
-			BOOLEAN v6 = (filter->filterId == WFP_send_filter_id_v6) || (filter->filterId == WFP_recv_filter_id_v6);
-
-			
-			//RtlStringCbPrintfW at DISPATCH_LEVEL or higher can cause a BSOD, 
-			//the issue is with accessing unicode tables, which may be paged out.
-
-			//The documentation for KdPrint() states it this way:
-
-			//<wdk>
-			//Format
-			//Specifies a pointer to the format string to print. The Format string
-			//supports all the printf-style formatting codes. However, the Unicode format
-			//codes (%C, %S, %lc, %ls, %wc, %ws, and %wZ) can only be used with IRQL =
-			//PASSIVE_LEVEL.
-			//</wdk>
-
-			//RtlStringCbPrintfA is technically also not permitted so a better solution needs to be found
-			
-
-			char trace_strA[256];
-			if (v6) {
-				RtlStringCbPrintfA(trace_strA, sizeof(trace_strA), "%s Network Traffic; Port: %u; Prot: %u; IPv6: %02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x", 
-					send ? "Outgoing " : "Incoming ", remote_port, protocol,
-					remote_ip.Data[0], remote_ip.Data[1], remote_ip.Data[2], remote_ip.Data[3], remote_ip.Data[4], remote_ip.Data[5], remote_ip.Data[6], remote_ip.Data[7],
-					remote_ip.Data[8], remote_ip.Data[9], remote_ip.Data[10], remote_ip.Data[11], remote_ip.Data[12], remote_ip.Data[13], remote_ip.Data[14], remote_ip.Data[15]);
-			}
-			else {
-				RtlStringCbPrintfA(trace_strA, sizeof(trace_strA), "%s Network Traffic; Port: %u; Prot: %u; IPv4: %d.%d.%d.%d", 
-					send ? "Outgoing " : "Incoming ", remote_port, protocol,
-					remote_ip.Data[12], remote_ip.Data[13], remote_ip.Data[14], remote_ip.Data[15]);
-			}
-
-			WCHAR trace_str[256];
-			char* cptr = trace_strA;
-			WCHAR* wptr = trace_str;
-			while (*cptr != '\0')
-				*wptr++ = *cptr++;
-			*wptr = L'\0';
-
-            Session_MonitorPut(MONITOR_NETFW | (block ? MONITOR_DENY : MONITOR_OPEN), trace_str, PsGetCurrentProcessId());
-        }*/
+		//
+		// NetFwTrace must not log inline here. WFP classify can run at
+		// DISPATCH_LEVEL, while Session_MonitorPut takes the session
+		// ERESOURCE path and the monitor ring is backed by PagedPool.
+		// Use nonpaged classify-side capture plus a PASSIVE_LEVEL monitor writer
+		// before enabling traffic logging.
+		//
 
 		if (block) {
 


### PR DESCRIPTION
## Summary

This PR removes an inactive `NetFwTrace` logging block from `Sandboxie/core/drv/wfp.c` inside the WFP classify callback.

The removed block formatted monitor strings and called `Session_MonitorPut` from the classify path. The existing comment already noted that this path can run at `DISPATCH_LEVEL`, while the monitor path uses pageable memory. Keeping the disabled implementation in place made it easy to re-enable an IRQL-unsafe logging path later.

This PR changes that path to preserve the current traffic decision behavior while making the boundary explicit:

- remove the unused `log` local and assignment
- remove the commented inline `RtlStringCbPrintfA` / `Session_MonitorPut` implementation
- leave a compact contract comment requiring nonpaged classify-side capture plus a `PASSIVE_LEVEL` monitor writer before traffic logging is enabled from this callback

It does not implement WFP traffic logging.

## Rationale

A WFP classify callback is a decision path, not a safe place to perform pageable monitor logging.

If the old commented implementation were re-enabled, traffic tracing could become an IRQL/DDI bugcheck path because it combines classify-time execution with string formatting and session monitor writeback. Removing the inactive code keeps the current no-logging behavior, but prevents a stale workaround from looking like the intended implementation.

The correct future shape is a deferred logger: capture only resident, bounded data from the classify path, then format and write monitor records from an executor that is legal for the monitor subsystem.

## Official/API shape

Microsoft documents WFP classify callbacks as running at `IRQL <= DISPATCH_LEVEL`:

- https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/fwpsk/nc-fwpsk-fwps_callout_classify_fn0

Microsoft documents `RtlStringCbPrintfA/W` as requiring resident strings when used above `PASSIVE_LEVEL`:

- https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntstrsafe/nf-ntstrsafe-rtlstringcbprintfa

The monitor path reached by `Session_MonitorPut` takes the session resource path and writes to the monitor log. That is not the same IRQL contract as the WFP classify callback.

## Verification

Source-level checks performed locally:

- `WFP_classify` no longer contains direct `Session_MonitorPut` / `Session_MonitorPutEx` calls
- `WFP_classify` no longer contains direct `RtlStringCbPrintfA` / `RtlStringCbPrintfW` calls
- the unused `log` local and `wfp_proc->LogTraffic` assignment were removed from this path
- traffic block/permit decision code is otherwise unchanged
- `git diff --check` passes

Remaining runtime verification recommended on Windows:

- driver build
- Driver Verifier with IRQL checking / DDI compliance enabled
- IPv4/IPv6 TCP and UDP traffic, loopback and non-loopback traffic, blocked and permitted paths
- `NetFwTrace` enabled and disabled compatibility observation
- future logger implementation should prove no inline monitor write, no verifier violation, no monitor-log corruption, and no changed block/permit decisions
