### PR TITLE
Add documentation comments to SetTabOrder functions

### DIFF
--- a/SandboxiePlus/SandMan/Helpers/TabOrder.h
+++ b/SandboxiePlus/SandMan/Helpers/TabOrder.h
@@ -1,4 +1,13 @@
 #pragma once
 
+/**
+ * @brief Sets the tab order for widgets under the given root widget.
+ * @param root The root QWidget whose children will be ordered.
+ */
 void SetTabOrder(QWidget* root);
+
+/**
+ * @brief Sets the tab order for widgets in the given layout.
+ * @param root The root QLayout containing the widgets to order.
+ */
 void SetTabOrder(QLayout* root);


### PR DESCRIPTION
## Problem Background

The public function declarations in `SandboxiePlus/SandMan/Helpers/TabOrder.h` lack documentation comments. This reduces code readability and makes it harder for contributors to understand the purpose and usage of these functions, potentially impacting maintainability.

## Changes Made

Added Doxygen-style documentation comments to both overloaded `SetTabOrder` functions:
- For `SetTabOrder(QWidget* root)`: Documented that it sets tab order for child widgets under a given root QWidget.
- For `SetTabOrder(QLayout* root)`: Documented that it sets tab order for widgets within a given root QLayout.

These changes align with existing code style and enhance clarity without altering functionality.

## Verification

- The modifications are purely additive (comments only) and do not affect code behavior or API.
- Ensure the project compiles successfully after changes to confirm no syntax errors in comments.
- Review comments for consistency and accuracy against intended function behavior.