### PR TITLE
Fix 0xc0000005 crash on long command lines in Proc_CreateProcessInternalW

### DIFF
--- a/Sandboxie/core/dll/proc.c
+++ b/Sandboxie/core/dll/proc.c
@@ -1679,6 +1679,19 @@ finish:
     }*/
 
     //
+    // emit the trace message before freeing the work areas: lpApplicationName
+    // and lpCommandLine may alias TlsData->proc_image_path / proc_command_line,
+    // which are freed below. Reading them afterwards is a use-after-free that
+    // access-violates for long command lines (large freed blocks get unmapped).
+    //
+
+    {
+        WCHAR msg[1024];
+        Sbie_snwprintf(msg, 1024, L"CreateProcess: %s (%s); err=%d", lpApplicationName ? lpApplicationName : L"[noName]", lpCommandLine ? lpCommandLine : L"[noCmd]", ok ? 0 : err);
+        SbieApi_MonitorPutMsg(MONITOR_OTHER | MONITOR_TRACE, msg);
+    }
+
+    //
     // free work areas and return
     //
 
@@ -1699,12 +1712,6 @@ finish:
     if (TlsData->proc_command_line) {
         Dll_Free(TlsData->proc_command_line);
         TlsData->proc_command_line = NULL;
-    }
-
-    {
-        WCHAR msg[1024];
-        Sbie_snwprintf(msg, 1024, L"CreateProcess: %s (%s); err=%d", lpApplicationName ? lpApplicationName : L"[noName]", lpCommandLine ? lpCommandLine : L"[noCmd]", ok ? 0 : err);
-        SbieApi_MonitorPutMsg(MONITOR_OTHER | MONITOR_TRACE, msg);
     }
 
     SetLastError(err);


### PR DESCRIPTION
The trace logging at the end of Proc_CreateProcessInternalW read lpApplicationName / lpCommandLine after Dll_Free had released TlsData->proc_image_path / proc_command_line, which those pointers may alias. For long command lines the freed block is a large allocation that gets unmapped, so the %s read in Sbie_snwprintf access-violates in ntdll!woutput_l.

Move the trace before the Dll_Free block so the pointers are still valid.

fix https://github.com/sandboxie-plus/Sandboxie/issues/5447

before:
<img width="779" height="388" alt="before" src="https://github.com/user-attachments/assets/20d8b7b3-74ef-4b7f-802b-4bb3a455a109" />

after:
<img width="1209" height="448" alt="fixed" src="https://github.com/user-attachments/assets/493748c6-e1d6-4cda-9788-88746a809cb3" />
