### PR TITLE
Highlight pending settings changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - added wildcard support for `RecoverFolder` and `AutoRecoverIgnore` patterns (`*`, `?`, `**`), matching across NT, DOS, and network-alias path forms in both DLL and SandMan [#3761](https://github.com/sandboxie-plus/Sandboxie/issues/3761) [#5318](https://github.com/sandboxie-plus/Sandboxie/issues/5318)
 - added `UseAutoRecoverIgnoreForQuick=[y|n]` to apply `AutoRecoverIgnore` patterns to the Quick Recovery window (default: enabled) [#5278](https://github.com/sandboxie-plus/Sandboxie/issues/5278)
+- added pending-change highlighting to SandMan Options and Settings dialogs; it indicates unapplied changes and not controls whose changes take effect immediately
+  - `Options/HighlightPendingChanges` (default: enabled), configurable in Global Settings > Interface Config > User Interface
 
 ### Changed
 - reworked the crash dump menchanism

--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -1148,6 +1148,16 @@
                  </property>
                 </widget>
                </item>
+               <item row="11" column="1" colspan="3">
+                <widget class="QCheckBox" name="chkHighlightPendingChanges">
+                 <property name="text">
+                  <string>Highlight unapplied changes in Options and Settings</string>
+                 </property>
+                 <property name="tristate">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
                <item row="2" column="1" colspan="2">
                 <widget class="QCheckBox" name="chkAltRows">
                  <property name="text">
@@ -1204,10 +1214,10 @@
                  </property>
                 </widget>
                </item>
-               <item row="11" column="2">
+               <item row="12" column="2">
                 <widget class="QComboBox" name="cmbGrouping"/>
                </item>
-               <item row="11" column="1">
+               <item row="12" column="1">
                 <widget class="QLabel" name="label_34">
                  <property name="text">
                   <string>Group state on start</string>

--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -3574,6 +3574,7 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
   <tabstop>chkColorIcons</tabstop>
   <tabstop>chkOverlayIcons</tabstop>
   <tabstop>chkHideCore</tabstop>
+  <tabstop>chkHighlightPendingChanges</tabstop>
   <tabstop>cmbGrouping</tabstop>
   <tabstop>cmbDPI</tabstop>
   <tabstop>cmbFontScale</tabstop>

--- a/SandboxiePlus/SandMan/SandMan.pri
+++ b/SandboxiePlus/SandMan/SandMan.pri
@@ -33,6 +33,7 @@ HEADERS += ./stdafx.h \
     ./Windows/SnapshotsWindow.h \
     ./Windows/SettingsWindow.h \
     ./Windows/OptionsWindow.h \
+    ./Windows/PendingChanges.h \
     ./Windows/EditorSettingsWindow.h \
     ./Windows/SelectBoxWindow.h \
     ./Windows/SupportDialog.h \

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -552,6 +552,7 @@
     <ClInclude Include="Helpers\ReadDirectoryChanges.h" />
     <ClInclude Include="Helpers\ReadDirectoryChangesPrivate.h" />
     <ClInclude Include="Helpers\StorageInfo.h" />
+    <ClInclude Include="Windows\PendingChanges.h" />
     <ClInclude Include="Helpers\TabOrder.h" />
     <ClInclude Include="Helpers\ThreadSafeQueue.h" />
     <ClInclude Include="Helpers\WinAdmin.h" />

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -306,6 +306,9 @@
     <ClInclude Include="CustomStyles.h">
       <Filter>SandMan</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\PendingChanges.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
     <ClInclude Include="Helpers\TabOrder.h">
       <Filter>Helpers</Filter>
     </ClInclude>

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -1018,6 +1018,7 @@ void COptionsWindow::OnAddOption()
 	QString Name = progDialog.value(); 
 
 	AddOptionEntry(Name, "", "");
+	OnAdvancedChanged();
 }
 
 void COptionsWindow::OnDelOption()

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -974,6 +974,8 @@ void COptionsWindow::SaveOptionList()
 void COptionsWindow::AddOptionEntry(const QString& Name, QString Program, const QString& Value, const QString& Template)
 {
 	QTreeWidgetItem* pItem = new QTreeWidgetItem();
+	if (!Template.isEmpty())
+		pItem->setData(0, COptionsWindow::PendingItemTemplateRole, true);
 
 	pItem->setText(0, Name + (Template.isEmpty() ? "" : " (" + Template + ")"));
 	pItem->setData(0, Qt::UserRole, !Template.isEmpty() ? "" : Name);

--- a/SandboxiePlus/SandMan/Windows/OptionsForce.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsForce.cpp
@@ -124,6 +124,8 @@ void COptionsWindow::LoadBreakoutTmpl(bool bUpdate)
 void COptionsWindow::AddForcedEntry(const QString& Name, int type, bool disabled, const QString& Template)
 {
 	QTreeWidgetItem* pItem = new QTreeWidgetItem();
+	if (!Template.isEmpty())
+		pItem->setData(0, COptionsWindow::PendingItemTemplateRole, true);
 	pItem->setCheckState(0, disabled ? Qt::Unchecked : Qt::Checked);
 	QString Type;
 	switch (type)
@@ -142,6 +144,8 @@ void COptionsWindow::AddForcedEntry(const QString& Name, int type, bool disabled
 void COptionsWindow::AddBreakoutEntry(const QString& Name, int type, bool disabled, const QString& Template)
 {
 	QTreeWidgetItem* pItem = new QTreeWidgetItem();
+	if (!Template.isEmpty())
+		pItem->setData(0, COptionsWindow::PendingItemTemplateRole, true);
 	pItem->setCheckState(0, disabled ? Qt::Unchecked : Qt::Checked);
 	QString Type;
 	switch (type)

--- a/SandboxiePlus/SandMan/Windows/OptionsGrouping.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsGrouping.cpp
@@ -57,6 +57,7 @@ void COptionsWindow::LoadGroupsTmpl(bool bUpdate)
 				
 
 				QTreeWidgetItem* pItem = new QTreeWidgetItem();
+				pItem->setData(0, COptionsWindow::PendingItemTemplateRole, true);
 				if (GroupName.length() > 2)
 					GroupName = GroupName.mid(1, GroupName.length() - 2);
 				pItem->setText(0, GroupName + " (" + Template + ")");
@@ -65,6 +66,7 @@ void COptionsWindow::LoadGroupsTmpl(bool bUpdate)
 					if (Entries[i].isEmpty())
 						continue;
 					QTreeWidgetItem* pSubItem = new QTreeWidgetItem();
+					pSubItem->setData(0, COptionsWindow::PendingItemTemplateRole, true);
 					SetProgramItem(Entries[i], pSubItem, 0);
 					pItem->addChild(pSubItem);
 				}

--- a/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
@@ -323,6 +323,8 @@ void COptionsWindow::LoadBlockINet()
 	ui.chkBlockDns->setChecked(m_BoxTemplates.contains("BlockDNS"));
 	ui.chkBlockSamba->setChecked(m_BoxTemplates.contains("BlockPorts"));
 
+	m_PendingChanges.CaptureItemBaselines(m_pTree, ui.treeINet);
+
 	m_HoldChange = holdChange;
 	m_INetBlockChanged = false;
 }

--- a/SandboxiePlus/SandMan/Windows/OptionsTemplates.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsTemplates.cpp
@@ -109,17 +109,8 @@ void COptionsWindow::ShowTemplates()
 {
 	ui.treeTemplates->clear();
 
-	QString CategoryFilter = ui.cmbCategories->currentData().toString();
-	QString TextFilter = ui.txtTemplates->text();
-
 	for (QMultiMap<QString, QPair<QString, QString>>::iterator I = m_AllTemplates.begin(); I != m_AllTemplates.end(); ++I)
 	{
-		if (!CategoryFilter.isEmpty() && I.key().compare(CategoryFilter, Qt::CaseInsensitive) != 0)
-			continue;
-
-		if (I.value().second.indexOf(TextFilter, 0, Qt::CaseInsensitive) == -1)
-			continue;
-
 		if (I.key().isEmpty())
 			continue; // don't show templates without a category (these are usually deprecated templates)
 
@@ -140,7 +131,20 @@ void COptionsWindow::ShowTemplates()
 		ui.treeTemplates->addTopLevelItem(pItem);
 	}
 
+	FilterTemplates();
 	ShowFolders();
+}
+
+void COptionsWindow::FilterTemplates()
+{
+	QString CategoryFilter = ui.cmbCategories->currentData().toString();
+	QString TextFilter = ui.txtTemplates->text();
+	for (int i = 0; i < ui.treeTemplates->topLevelItemCount(); i++) {
+		QTreeWidgetItem* pItem = ui.treeTemplates->topLevelItem(i);
+		bool Visible = (CategoryFilter.isEmpty() || pItem->data(0, Qt::UserRole).toString().compare(CategoryFilter, Qt::CaseInsensitive) == 0)
+			&& pItem->text(1).indexOf(TextFilter, 0, Qt::CaseInsensitive) != -1;
+		pItem->setHidden(!Visible);
+	}
 }
 
 void COptionsWindow::OnTemplateClicked(QTreeWidgetItem* pItem, int Column)

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -811,6 +811,7 @@ void COptionsWindow::OnOptChanged()
 {
 	if (m_HoldChange)
 		return;
+	m_PendingChanges.Update(sender(), m_pTree);
 	ui.buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
@@ -1079,8 +1080,13 @@ void COptionsWindow::WriteGlobalCheck(QCheckBox* pCheck, const QString& Setting,
 void COptionsWindow::LoadConfig()
 {
 	m_ConfigDirty = false;
+	m_StartRadioBaselineLoaded = false;
 
 	m_HoldChange = true;
+	int iHighlightPendingChanges = theConf->GetInt("Options/HighlightPendingChanges", 2);
+	if (iHighlightPendingChanges == 2)
+		iHighlightPendingChanges = theConf->GetInt("Options/ViewMode", 1) != 2 ? 1 : 0;
+	m_PendingChanges.SetEnabled(iHighlightPendingChanges != 0, m_pTree);
 
 	LoadTemplates();
 
@@ -1111,6 +1117,10 @@ void COptionsWindow::LoadConfig()
 
 	// Update autocompletion after all settings are loaded
 	UpdateAutoCompletion();
+	m_PendingChanges.CaptureItemBaselines(m_pTree);
+	m_PendingChanges.CaptureCheckboxBaselines();
+	m_PendingChanges.CaptureRadioButtonBaselines();
+	m_PendingChanges.CaptureValueBaselines();
 
 	m_HoldChange = false;
 }
@@ -1453,6 +1463,13 @@ void COptionsWindow::UpdateCurrentTab()
 		CopyGroupToList("<StartRunAccessDisabled>", ui.treeStart, true);
 
 		OnRestrictStart();
+		m_PendingChanges.CaptureItemBaselines(m_pTree, ui.treeStart);
+		if (!m_StartRadioBaselineLoaded) {
+			m_PendingChanges.CaptureRadioButtonBaseline(ui.radStartAll);
+			m_PendingChanges.CaptureRadioButtonBaseline(ui.radStartExcept);
+			m_PendingChanges.CaptureRadioButtonBaseline(ui.radStartSelected);
+			m_StartRadioBaselineLoaded = true;
+		}
 	}
 	else if (m_pCurrentTab == ui.tabInternet || m_pCurrentTab == ui.tabINet || m_pCurrentTab == ui.tabNetConfig)
 	{

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -243,7 +243,7 @@ private slots:
 	void OnDelUser();
 	//
 
-	void OnFilterTemplates()		{ ShowTemplates(); }
+	void OnFilterTemplates()		{ FilterTemplates(); }
 	void OnTemplateClicked(QTreeWidgetItem* pItem, int Column);
 	void OnTemplateDoubleClicked(QTreeWidgetItem* pItem, int Column);
 	void OnAddTemplates();
@@ -561,6 +561,7 @@ protected:
 
 	void LoadTemplates();
 	void ShowTemplates();
+	void FilterTemplates();
 	void SaveTemplates();
 	void SetTemplate(const QString& Template, bool bEnabled);
 

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -3,6 +3,7 @@
 #include <QtWidgets/QMainWindow>
 #include "ui_OptionsWindow.h"
 #include "SbiePlusAPI.h"
+#include "PendingChanges.h"
 #include "../../MiscHelpers/Common/SettingsWidgets.h"
 
 //////////////////////////////////////////////////////////////////////////
@@ -32,6 +33,7 @@ public:
 		eTemplate,
 		eParent
 	};
+	enum { PendingItemTemplateRole = Qt::UserRole + 103 };
 
 	void LoadCompletionConsent();
 	void SaveCompletionConsent();
@@ -580,6 +582,8 @@ protected:
 	bool m_SkipSaveOnToggle; // Skip saving to config when applying reset settings
 
 	bool m_ConfigDirty;
+	bool m_StartRadioBaselineLoaded;
+	CPendingChanges m_PendingChanges{this, &m_HoldChange, PendingItemTemplateRole, false};
 	QColor m_BorderColor;
 	int m_BorderAlpha;
 	QString m_BoxIcon;

--- a/SandboxiePlus/SandMan/Windows/PendingChanges.h
+++ b/SandboxiePlus/SandMan/Windows/PendingChanges.h
@@ -2,16 +2,21 @@
 
 #include <QAbstractItemModel>
 #include <QAbstractItemView>
+#include <QAbstractButton>
 #include <QBrush>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDoubleSpinBox>
 #include <QKeySequenceEdit>
 #include <QLineEdit>
 #include <QPlainTextEdit>
+#include <QProxyStyle>
+#include <QStyleFactory>
 #include <QRadioButton>
 #include <QSignalBlocker>
 #include <QSpinBox>
 #include <QStyle>
+#include <QStyleOptionButton>
 #include <QStyleOptionComboBox>
 #include <QStylePainter>
 #include <QTimer>
@@ -46,6 +51,69 @@ protected:
 		Painter.fillRect(EditRect, pCombo->property("pending_value_combo_color").value<QColor>());
 		pCombo->style()->drawControl(QStyle::CE_ComboBoxLabel, &Option, &Painter, pCombo);
 		return true;
+	}
+};
+
+class CPendingButtonPaintFilter : public QObject
+{
+public:
+	CPendingButtonPaintFilter(QWidget* pButton)
+		: QObject(pButton)
+	{
+	}
+
+protected:
+	bool eventFilter(QObject* pObject, QEvent* pEvent) override
+	{
+		QWidget* pButton = qobject_cast<QWidget*>(pObject);
+		if (!pButton || pEvent->type() != QEvent::Paint || !pButton->property("pending_button_color").isValid())
+			return QObject::eventFilter(pObject, pEvent);
+		QAbstractButton* pAbstractButton = qobject_cast<QAbstractButton*>(pButton);
+		if (!pAbstractButton)
+			return QObject::eventFilter(pObject, pEvent);
+
+		QStyleOptionButton Option;
+		Option.initFrom(pButton);
+		Option.text = pAbstractButton->text();
+		QStyle::SubElement Element;
+		bool bCheckBox;
+		if (QCheckBox* pCheck = qobject_cast<QCheckBox*>(pButton)) {
+			bCheckBox = true;
+			Option.state |= pCheck->checkState() == Qt::PartiallyChecked ? QStyle::State_NoChange
+				: pCheck->isChecked() ? QStyle::State_On : QStyle::State_Off;
+			Element = QStyle::SE_CheckBoxContents;
+		}
+		else if (QRadioButton* pRadio = qobject_cast<QRadioButton*>(pButton)) {
+			bCheckBox = false;
+			Option.state |= pRadio->isChecked() ? QStyle::State_On : QStyle::State_Off;
+			Element = QStyle::SE_RadioButtonContents;
+		}
+		else
+			return QObject::eventFilter(pObject, pEvent);
+
+		QStylePainter Painter(pButton);
+		Painter.fillRect(pButton->style()->subElementRect(Element, &Option, pButton), pButton->property("pending_button_color").value<QColor>());
+		pButton->style()->drawControl(bCheckBox ? QStyle::CE_CheckBox : QStyle::CE_RadioButton, &Option, &Painter, pButton);
+		return true;
+	}
+};
+
+class CPendingEditorStyle : public QProxyStyle
+{
+public:
+	CPendingEditorStyle(QStyle* pBase)
+		: QProxyStyle(pBase)
+	{
+	}
+
+	void drawPrimitive(PrimitiveElement Element, const QStyleOption* pOption, QPainter* pPainter, const QWidget* pWidget = nullptr) const override
+	{
+		QProxyStyle::drawPrimitive(Element, pOption, pPainter, pWidget);
+		if (Element == PE_PanelLineEdit && pWidget && pWidget->property("pending_editor_color").isValid()) {
+			QRect Rect = pOption ? pOption->rect : pWidget->rect();
+			Rect.adjust(1, 1, -1, -1);
+			pPainter->fillRect(Rect, pWidget->property("pending_editor_color").value<QColor>());
+		}
 	}
 };
 
@@ -88,6 +156,10 @@ public:
 		foreach(QCheckBox* pCheck, m_pRoot->findChildren<QCheckBox*>()) {
 			SetCheckboxHighlight(pCheck, false);
 			pCheck->setProperty(CheckboxBaselineProperty, (int)pCheck->checkState());
+			if (!pCheck->property(CheckboxPaintFilterProperty).toBool()) {
+				pCheck->setProperty(CheckboxPaintFilterProperty, true);
+				pCheck->installEventFilter(new CPendingButtonPaintFilter(pCheck));
+			}
 		}
 	}
 
@@ -101,6 +173,10 @@ public:
 	{
 		SetRadioButtonHighlight(pRadio, false);
 		pRadio->setProperty(RadioBaselineProperty, pRadio->isChecked());
+		if (!pRadio->property(RadioPaintFilterProperty).toBool()) {
+			pRadio->setProperty(RadioPaintFilterProperty, true);
+			pRadio->installEventFilter(new CPendingButtonPaintFilter(pRadio));
+		}
 		if (!pRadio->property(RadioConnectionProperty).toBool()) {
 			pRadio->setProperty(RadioConnectionProperty, true);
 			connect(pRadio, &QRadioButton::toggled, this, [this](bool) {
@@ -248,9 +324,11 @@ private:
 	static constexpr const char* CheckboxBaselineProperty = "pending_checkbox_baseline";
 	static constexpr const char* CheckboxPaletteProperty = "pending_checkbox_palette";
 	static constexpr const char* CheckboxAutoFillProperty = "pending_checkbox_auto_fill";
+	static constexpr const char* CheckboxPaintFilterProperty = "pending_checkbox_paint_filter";
 	static constexpr const char* RadioBaselineProperty = "pending_radio_baseline";
 	static constexpr const char* RadioPaletteProperty = "pending_radio_palette";
 	static constexpr const char* RadioAutoFillProperty = "pending_radio_auto_fill";
+	static constexpr const char* RadioPaintFilterProperty = "pending_radio_paint_filter";
 	static constexpr const char* RadioConnectionProperty = "pending_radio_connection";
 	static constexpr const char* ValueBaselineProperty = "pending_value_baseline";
 	static constexpr const char* ValuePaletteProperty = "pending_value_palette";
@@ -260,7 +338,10 @@ private:
 	static constexpr const char* ValueViewportPaletteProperty = "pending_value_viewport_palette";
 	static constexpr const char* ValueViewportBaseColorProperty = "pending_value_viewport_base_color";
 	static constexpr const char* ValueLineEditAutoFillProperty = "pending_value_line_edit_auto_fill";
-	static constexpr const char* ValueLineEditStyleProperty = "pending_value_line_edit_style";
+	static constexpr const char* ValueSpinBoxLineEditAutoFillProperty = "pending_value_spin_box_line_edit_auto_fill";
+	static constexpr const char* ValueTextViewportAutoFillProperty = "pending_value_text_viewport_auto_fill";
+	static constexpr const char* ValueTextViewportStyleProperty = "pending_value_text_viewport_style";
+	static constexpr const char* ValueEditorStyleProperty = "pending_value_editor_style";
 	static constexpr const char* ValueConnectionProperty = "pending_value_connection";
 	static constexpr const char* ValueComboBackgroundsProperty = "pending_value_combo_backgrounds";
 	static constexpr const char* ValueComboSnapshotProperty = "pending_value_combo_snapshot";
@@ -270,6 +351,36 @@ private:
 
 	bool IsHoldingChanges() const { return m_pHoldChange && *m_pHoldChange; }
 	static bool IsValueExcluded(const QWidget* pControl) { return pControl->property(ValueExcludedProperty).toBool(); }
+	static QString GetStyleKey(const QStyle* pStyle)
+	{
+		if (!pStyle)
+			return QString();
+		QString ClassName = pStyle->metaObject()->className();
+		if (ClassName.contains("Windows11", Qt::CaseInsensitive))
+			return "windows11";
+		if (ClassName.contains("WindowsVista", Qt::CaseInsensitive))
+			return "windowsvista";
+		if (ClassName.contains("Windows", Qt::CaseInsensitive))
+			return "windows";
+		if (ClassName.contains("Fusion", Qt::CaseInsensitive))
+			return "fusion";
+		if (QProxyStyle* pProxy = qobject_cast<QProxyStyle*>(const_cast<QStyle*>(pStyle)))
+			return GetStyleKey(pProxy->baseStyle());
+		return QString();
+	}
+
+	static void InstallEditorStyle(QLineEdit* pLineEdit)
+	{
+		if (pLineEdit->property(ValueEditorStyleProperty).toBool())
+			return;
+		QStyle* pBase = QStyleFactory::create(GetStyleKey(pLineEdit->style()));
+		if (!pBase)
+			return;
+		CPendingEditorStyle* pStyle = new CPendingEditorStyle(pBase);
+		pStyle->setParent(pLineEdit);
+		pLineEdit->setStyle(pStyle);
+		pLineEdit->setProperty(ValueEditorStyleProperty, true);
+	}
 	static bool IsComboLineEdit(const QLineEdit* pLineEdit)
 	{
 		for (const QWidget* pParent = pLineEdit->parentWidget(); pParent; pParent = pParent->parentWidget()) {
@@ -424,12 +535,18 @@ private:
 			Palette.setColor(QPalette::Inactive, QPalette::Window, Color);
 			pCheck->setPalette(Palette);
 			pCheck->setAutoFillBackground(true);
+			pCheck->setProperty("pending_button_color", Color);
+			pCheck->update();
 		}
 		else if (pCheck->property(CheckboxPaletteProperty).isValid()) {
-			pCheck->setPalette(pCheck->property(CheckboxPaletteProperty).value<QPalette>());
+			pCheck->setPalette(QPalette());
 			pCheck->setAutoFillBackground(pCheck->property(CheckboxAutoFillProperty).toBool());
 			pCheck->setProperty(CheckboxPaletteProperty, QVariant());
 			pCheck->setProperty(CheckboxAutoFillProperty, QVariant());
+			pCheck->setProperty("pending_button_color", QVariant());
+			pCheck->style()->unpolish(pCheck);
+			pCheck->style()->polish(pCheck);
+			pCheck->update();
 		}
 	}
 
@@ -454,12 +571,18 @@ private:
 			Palette.setColor(QPalette::Inactive, QPalette::Window, Color);
 			pRadio->setPalette(Palette);
 			pRadio->setAutoFillBackground(true);
+			pRadio->setProperty("pending_button_color", Color);
+			pRadio->update();
 		}
 		else if (pRadio->property(RadioPaletteProperty).isValid()) {
-			pRadio->setPalette(pRadio->property(RadioPaletteProperty).value<QPalette>());
+			pRadio->setPalette(QPalette());
 			pRadio->setAutoFillBackground(pRadio->property(RadioAutoFillProperty).toBool());
 			pRadio->setProperty(RadioPaletteProperty, QVariant());
 			pRadio->setProperty(RadioAutoFillProperty, QVariant());
+			pRadio->setProperty("pending_button_color", QVariant());
+			pRadio->style()->unpolish(pRadio);
+			pRadio->style()->polish(pRadio);
+			pRadio->update();
 		}
 	}
 
@@ -518,9 +641,20 @@ private:
 					pCombo->setProperty(ValueViewportPaletteProperty, QVariant::fromValue(pCombo->view()->viewport()->palette()));
 					pCombo->setProperty(ValueViewportBaseColorProperty, pCombo->view()->viewport()->palette().color(QPalette::Active, QPalette::Base));
 					if (pCombo->isEditable() && pCombo->lineEdit()) {
+						InstallEditorStyle(pCombo->lineEdit());
 						pCombo->setProperty(ValueLineEditAutoFillProperty, pCombo->lineEdit()->autoFillBackground());
-						pCombo->setProperty(ValueLineEditStyleProperty, pCombo->lineEdit()->styleSheet());
 					}
+				}
+				else if (QAbstractSpinBox* pSpinBox = qobject_cast<QAbstractSpinBox*>(pControl)) {
+					if (QLineEdit* pLineEdit = pSpinBox->findChild<QLineEdit*>()) {
+						InstallEditorStyle(pLineEdit);
+						pSpinBox->setProperty(ValueSpinBoxLineEditAutoFillProperty, pLineEdit->autoFillBackground());
+					}
+				}
+				else if (QPlainTextEdit* pTextEdit = qobject_cast<QPlainTextEdit*>(pControl)) {
+					QWidget* pViewport = pTextEdit->viewport();
+					pTextEdit->setProperty(ValueTextViewportAutoFillProperty, pViewport->autoFillBackground());
+					pTextEdit->setProperty(ValueTextViewportStyleProperty, pViewport->styleSheet());
 				}
 			}
 			QPalette Palette = pControl->palette();
@@ -533,16 +667,21 @@ private:
 			pControl->setPalette(Palette);
 			pControl->setAutoFillBackground(true);
 			if (QComboBox* pCombo = qobject_cast<QComboBox*>(pControl)) {
-				if (!pCombo->isEditable())
+				if (!pCombo->isEditable()) {
 					pCombo->setProperty(ValueComboColorProperty, ButtonColor);
+					pCombo->setStyleSheet(pControl->property(ValueStyleProperty).toString()
+						+ "\nbackground-color: " + BaseColor.name() + ";");
+				}
 				else if (QLineEdit* pLineEdit = pCombo->lineEdit()) {
 					QPalette LineEditPalette = pLineEdit->palette();
 					LineEditPalette.setColor(QPalette::Active, QPalette::Base, BaseColor);
 					LineEditPalette.setColor(QPalette::Inactive, QPalette::Base, BaseColor);
 					pLineEdit->setPalette(LineEditPalette);
+					pLineEdit->setProperty("pending_editor_color", BaseColor);
 					pLineEdit->setAutoFillBackground(true);
-					pLineEdit->setStyleSheet(pCombo->property(ValueLineEditStyleProperty).toString()
-						+ "\nQLineEdit { background-color: " + BaseColor.name() + "; }");
+					pLineEdit->style()->unpolish(pLineEdit);
+					pLineEdit->style()->polish(pLineEdit);
+					pLineEdit->update();
 				}
 				pCombo->view()->setPalette(pCombo->property(ValueViewPaletteProperty).value<QPalette>());
 				QPalette ViewportPalette = pCombo->property(ValueViewportPaletteProperty).value<QPalette>();
@@ -557,11 +696,62 @@ private:
 				pControl->setStyleSheet(pControl->property(ValueStyleProperty).toString()
 					+ "\nQKeySequenceEdit, QKeySequenceEdit QLineEdit { background-color: " + BaseColor.name() + "; }");
 			}
+			else if (QPlainTextEdit* pTextEdit = qobject_cast<QPlainTextEdit*>(pControl)) {
+				QWidget* pViewport = pTextEdit->viewport();
+				QPalette ViewportPalette = pViewport->palette();
+				ViewportPalette.setColor(QPalette::Active, QPalette::Base, BaseColor);
+				ViewportPalette.setColor(QPalette::Inactive, QPalette::Base, BaseColor);
+				pViewport->setPalette(ViewportPalette);
+				pViewport->setAutoFillBackground(true);
+				pViewport->setStyleSheet(pTextEdit->property(ValueTextViewportStyleProperty).toString()
+					+ "\nQWidget { background-color: " + BaseColor.name() + "; }");
+				pViewport->style()->unpolish(pViewport);
+				pViewport->style()->polish(pViewport);
+				pViewport->update();
+			}
+			else if (QAbstractSpinBox* pSpinBox = qobject_cast<QAbstractSpinBox*>(pControl)) {
+				if (QLineEdit* pLineEdit = pSpinBox->findChild<QLineEdit*>()) {
+					QPalette LineEditPalette = pLineEdit->palette();
+					LineEditPalette.setColor(QPalette::Active, QPalette::Base, BaseColor);
+					LineEditPalette.setColor(QPalette::Inactive, QPalette::Base, BaseColor);
+					pLineEdit->setPalette(LineEditPalette);
+					pLineEdit->setProperty("pending_editor_color", BaseColor);
+					pLineEdit->setAutoFillBackground(true);
+					pLineEdit->style()->unpolish(pLineEdit);
+					pLineEdit->style()->polish(pLineEdit);
+					pLineEdit->update();
+				}
+			}
+			else {
+				pControl->setStyleSheet(pControl->property(ValueStyleProperty).toString()
+					+ "\nbackground-color: " + BaseColor.name() + ";");
+			}
 		}
 		else if (pControl->property(ValuePaletteProperty).isValid()) {
 			pControl->setStyleSheet(pControl->property(ValueStyleProperty).toString());
 			pControl->setPalette(pControl->property(ValuePaletteProperty).value<QPalette>());
 			pControl->setAutoFillBackground(pControl->property(ValueAutoFillProperty).toBool());
+			if (QAbstractSpinBox* pSpinBox = qobject_cast<QAbstractSpinBox*>(pControl)) {
+				if (QLineEdit* pLineEdit = pSpinBox->findChild<QLineEdit*>()) {
+					pLineEdit->setProperty("pending_editor_color", QVariant());
+					pLineEdit->setPalette(QPalette());
+					pLineEdit->setAutoFillBackground(pSpinBox->property(ValueSpinBoxLineEditAutoFillProperty).toBool());
+					pLineEdit->style()->unpolish(pLineEdit);
+					pLineEdit->style()->polish(pLineEdit);
+					pLineEdit->update();
+				}
+			}
+			if (QPlainTextEdit* pTextEdit = qobject_cast<QPlainTextEdit*>(pControl)) {
+				QWidget* pViewport = pTextEdit->viewport();
+				const QString StyleSheet = pTextEdit->property(ValueTextViewportStyleProperty).toString();
+				pViewport->setStyleSheet(QString());
+				pViewport->setPalette(QPalette());
+				pViewport->setAutoFillBackground(pTextEdit->property(ValueTextViewportAutoFillProperty).toBool());
+				pViewport->setStyleSheet(StyleSheet);
+				pViewport->style()->unpolish(pViewport);
+				pViewport->style()->polish(pViewport);
+				pViewport->update();
+			}
 			if (QComboBox* pCombo = qobject_cast<QComboBox*>(pControl)) {
 				if (pCombo->isEditable())
 					pCombo->setPalette(QPalette());
@@ -571,11 +761,9 @@ private:
 				pCombo->view()->viewport()->setPalette(pCombo->property(ValueViewportPaletteProperty).value<QPalette>());
 				if (pCombo->isEditable() && pCombo->lineEdit()) {
 					QLineEdit* pLineEdit = pCombo->lineEdit();
-					const QString StyleSheet = pCombo->property(ValueLineEditStyleProperty).toString();
-					pLineEdit->setStyleSheet(QString());
+					pLineEdit->setProperty("pending_editor_color", QVariant());
 					pLineEdit->setPalette(QPalette());
 					pLineEdit->setAutoFillBackground(pCombo->property(ValueLineEditAutoFillProperty).toBool());
-					pLineEdit->setStyleSheet(StyleSheet);
 					pLineEdit->style()->unpolish(pLineEdit);
 					pLineEdit->style()->polish(pLineEdit);
 					pLineEdit->update();
@@ -592,7 +780,9 @@ private:
 			pControl->setProperty(ValueViewportPaletteProperty, QVariant());
 			pControl->setProperty(ValueViewportBaseColorProperty, QVariant());
 			pControl->setProperty(ValueLineEditAutoFillProperty, QVariant());
-			pControl->setProperty(ValueLineEditStyleProperty, QVariant());
+			pControl->setProperty(ValueSpinBoxLineEditAutoFillProperty, QVariant());
+			pControl->setProperty(ValueTextViewportAutoFillProperty, QVariant());
+			pControl->setProperty(ValueTextViewportStyleProperty, QVariant());
 		}
 	}
 

--- a/SandboxiePlus/SandMan/Windows/PendingChanges.h
+++ b/SandboxiePlus/SandMan/Windows/PendingChanges.h
@@ -318,18 +318,28 @@ public:
 		UpdateValueHighlights();
 	}
 
+	void UpdateAll(QTreeWidget* pExcludedTree)
+	{
+		if (!m_bEnabled)
+			return;
+
+		UpdateItemHighlights(pExcludedTree);
+		UpdateCheckboxHighlights();
+		UpdateRadioButtonHighlights();
+		UpdateValueHighlights(true);
+	}
+
 private:
 	enum EItemState { eNone, eAdded, eEdited };
 	enum { ItemBaselineRole = Qt::UserRole + 110, ItemStateRole = Qt::UserRole + 111, ItemBackgroundRole = Qt::UserRole + 112 };
 	static constexpr const char* CheckboxBaselineProperty = "pending_checkbox_baseline";
-	static constexpr const char* CheckboxPaletteProperty = "pending_checkbox_palette";
-	static constexpr const char* CheckboxAutoFillProperty = "pending_checkbox_auto_fill";
 	static constexpr const char* CheckboxPaintFilterProperty = "pending_checkbox_paint_filter";
 	static constexpr const char* RadioBaselineProperty = "pending_radio_baseline";
-	static constexpr const char* RadioPaletteProperty = "pending_radio_palette";
-	static constexpr const char* RadioAutoFillProperty = "pending_radio_auto_fill";
 	static constexpr const char* RadioPaintFilterProperty = "pending_radio_paint_filter";
 	static constexpr const char* RadioConnectionProperty = "pending_radio_connection";
+	static constexpr const char* ButtonPaletteProperty = "pending_button_palette";
+	static constexpr const char* ButtonAutoFillProperty = "pending_button_auto_fill";
+	static constexpr const char* ButtonColorProperty = "pending_button_color";
 	static constexpr const char* ValueBaselineProperty = "pending_value_baseline";
 	static constexpr const char* ValuePaletteProperty = "pending_value_palette";
 	static constexpr const char* ValueAutoFillProperty = "pending_value_auto_fill";
@@ -524,30 +534,7 @@ private:
 
 	void SetCheckboxHighlight(QCheckBox* pCheck, bool bPending)
 	{
-		if (bPending) {
-			if (!pCheck->property(CheckboxPaletteProperty).isValid()) {
-				pCheck->setProperty(CheckboxPaletteProperty, QVariant::fromValue(pCheck->palette()));
-				pCheck->setProperty(CheckboxAutoFillProperty, pCheck->autoFillBackground());
-			}
-			QPalette Palette = pCheck->palette();
-			QColor Color = PendingColor(Palette, QPalette::Window);
-			Palette.setColor(QPalette::Active, QPalette::Window, Color);
-			Palette.setColor(QPalette::Inactive, QPalette::Window, Color);
-			pCheck->setPalette(Palette);
-			pCheck->setAutoFillBackground(true);
-			pCheck->setProperty("pending_button_color", Color);
-			pCheck->update();
-		}
-		else if (pCheck->property(CheckboxPaletteProperty).isValid()) {
-			pCheck->setPalette(QPalette());
-			pCheck->setAutoFillBackground(pCheck->property(CheckboxAutoFillProperty).toBool());
-			pCheck->setProperty(CheckboxPaletteProperty, QVariant());
-			pCheck->setProperty(CheckboxAutoFillProperty, QVariant());
-			pCheck->setProperty("pending_button_color", QVariant());
-			pCheck->style()->unpolish(pCheck);
-			pCheck->style()->polish(pCheck);
-			pCheck->update();
-		}
+		SetButtonHighlight(pCheck, bPending);
 	}
 
 	void UpdateCheckboxHighlight(QObject* pSource)
@@ -558,32 +545,18 @@ private:
 			SetCheckboxHighlight(pCheck, Baseline.toInt() != (int)pCheck->checkState());
 	}
 
+	void UpdateCheckboxHighlights()
+	{
+		foreach(QCheckBox* pCheck, m_pRoot->findChildren<QCheckBox*>()) {
+			QVariant Baseline = pCheck->property(CheckboxBaselineProperty);
+			if (Baseline.isValid())
+				SetCheckboxHighlight(pCheck, Baseline.toInt() != (int)pCheck->checkState());
+		}
+	}
+
 	void SetRadioButtonHighlight(QRadioButton* pRadio, bool bPending)
 	{
-		if (bPending) {
-			if (!pRadio->property(RadioPaletteProperty).isValid()) {
-				pRadio->setProperty(RadioPaletteProperty, QVariant::fromValue(pRadio->palette()));
-				pRadio->setProperty(RadioAutoFillProperty, pRadio->autoFillBackground());
-			}
-			QPalette Palette = pRadio->palette();
-			QColor Color = PendingColor(Palette, QPalette::Window);
-			Palette.setColor(QPalette::Active, QPalette::Window, Color);
-			Palette.setColor(QPalette::Inactive, QPalette::Window, Color);
-			pRadio->setPalette(Palette);
-			pRadio->setAutoFillBackground(true);
-			pRadio->setProperty("pending_button_color", Color);
-			pRadio->update();
-		}
-		else if (pRadio->property(RadioPaletteProperty).isValid()) {
-			pRadio->setPalette(QPalette());
-			pRadio->setAutoFillBackground(pRadio->property(RadioAutoFillProperty).toBool());
-			pRadio->setProperty(RadioPaletteProperty, QVariant());
-			pRadio->setProperty(RadioAutoFillProperty, QVariant());
-			pRadio->setProperty("pending_button_color", QVariant());
-			pRadio->style()->unpolish(pRadio);
-			pRadio->style()->polish(pRadio);
-			pRadio->update();
-		}
+		SetButtonHighlight(pRadio, bPending);
 	}
 
 	void UpdateRadioButtonHighlights()
@@ -669,8 +642,6 @@ private:
 			if (QComboBox* pCombo = qobject_cast<QComboBox*>(pControl)) {
 				if (!pCombo->isEditable()) {
 					pCombo->setProperty(ValueComboColorProperty, ButtonColor);
-					pCombo->setStyleSheet(pControl->property(ValueStyleProperty).toString()
-						+ "\nbackground-color: " + BaseColor.name() + ";");
 				}
 				else if (QLineEdit* pLineEdit = pCombo->lineEdit()) {
 					QPalette LineEditPalette = pLineEdit->palette();
@@ -829,19 +800,52 @@ private:
 		}
 	}
 
-	void UpdateValueHighlights()
+	void UpdateValueHighlights(bool bAll = false)
 	{
 		foreach(QComboBox* pCombo, m_pRoot->findChildren<QComboBox*>())
-			if (!IsValueExcluded(pCombo) && pCombo->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pCombo);
+			if (!IsValueExcluded(pCombo) && (bAll || pCombo->property(ValuePaletteProperty).isValid())) UpdateValueHighlight(pCombo);
 		foreach(QAbstractSpinBox* pSpinBox, m_pRoot->findChildren<QAbstractSpinBox*>())
-			if (!IsValueExcluded(pSpinBox) && pSpinBox->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pSpinBox);
+			if (!IsValueExcluded(pSpinBox) && (bAll || pSpinBox->property(ValuePaletteProperty).isValid())) UpdateValueHighlight(pSpinBox);
 		foreach(QLineEdit* pLineEdit, m_pRoot->findChildren<QLineEdit*>())
-			if (!IsComboLineEdit(pLineEdit) && !IsValueExcluded(pLineEdit) && pLineEdit->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pLineEdit);
+			if (!IsComboLineEdit(pLineEdit) && !IsValueExcluded(pLineEdit) && (bAll || pLineEdit->property(ValuePaletteProperty).isValid())) UpdateValueHighlight(pLineEdit);
 		foreach(QPlainTextEdit* pTextEdit, m_pRoot->findChildren<QPlainTextEdit*>())
-			if (!IsValueExcluded(pTextEdit) && pTextEdit->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pTextEdit);
+			if (!IsValueExcluded(pTextEdit) && (bAll || pTextEdit->property(ValuePaletteProperty).isValid())) UpdateValueHighlight(pTextEdit);
 		if (m_bTrackKeySequences)
 			foreach(QKeySequenceEdit* pKeyEdit, m_pRoot->findChildren<QKeySequenceEdit*>())
-				if (!IsValueExcluded(pKeyEdit) && pKeyEdit->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pKeyEdit);
+				if (!IsValueExcluded(pKeyEdit) && (bAll || pKeyEdit->property(ValuePaletteProperty).isValid())) UpdateValueHighlight(pKeyEdit);
+	}
+
+	void SetButtonHighlight(QAbstractButton* pButton, bool bPending)
+	{
+		if (bPending) {
+			QPalette BasePalette = pButton->palette();
+			if (!pButton->property(ButtonPaletteProperty).isValid()) {
+				pButton->setProperty(ButtonPaletteProperty, QVariant::fromValue(BasePalette));
+				pButton->setProperty(ButtonAutoFillProperty, pButton->autoFillBackground());
+			}
+			else {
+				BasePalette = pButton->property(ButtonPaletteProperty).value<QPalette>();
+			}
+
+			QPalette Palette = BasePalette;
+			QColor Color = PendingColor(BasePalette, QPalette::Window);
+			Palette.setColor(QPalette::Active, QPalette::Window, Color);
+			Palette.setColor(QPalette::Inactive, QPalette::Window, Color);
+			pButton->setPalette(Palette);
+			pButton->setAutoFillBackground(true);
+			pButton->setProperty(ButtonColorProperty, Color);
+			pButton->update();
+		}
+		else if (pButton->property(ButtonPaletteProperty).isValid()) {
+			pButton->setPalette(pButton->property(ButtonPaletteProperty).value<QPalette>());
+			pButton->setAutoFillBackground(pButton->property(ButtonAutoFillProperty).toBool());
+			pButton->setProperty(ButtonPaletteProperty, QVariant());
+			pButton->setProperty(ButtonAutoFillProperty, QVariant());
+			pButton->setProperty(ButtonColorProperty, QVariant());
+			pButton->style()->unpolish(pButton);
+			pButton->style()->polish(pButton);
+			pButton->update();
+		}
 	}
 
 	QWidget* m_pRoot;

--- a/SandboxiePlus/SandMan/Windows/PendingChanges.h
+++ b/SandboxiePlus/SandMan/Windows/PendingChanges.h
@@ -1,0 +1,662 @@
+#pragma once
+
+#include <QAbstractItemModel>
+#include <QAbstractItemView>
+#include <QBrush>
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QKeySequenceEdit>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QRadioButton>
+#include <QSignalBlocker>
+#include <QSpinBox>
+#include <QStyle>
+#include <QStyleOptionComboBox>
+#include <QStylePainter>
+#include <QTimer>
+#include <QTreeWidget>
+#include <QTreeWidgetItemIterator>
+
+class CPendingComboPaintFilter : public QObject
+{
+public:
+	CPendingComboPaintFilter(QComboBox* pCombo)
+		: QObject(pCombo)
+	{
+	}
+
+protected:
+	bool eventFilter(QObject* pObject, QEvent* pEvent) override
+	{
+		QComboBox* pCombo = qobject_cast<QComboBox*>(pObject);
+		if (!pCombo || pEvent->type() != QEvent::Paint || !pCombo->property("pending_value_combo_color").isValid())
+			return QObject::eventFilter(pObject, pEvent);
+
+		QStyleOptionComboBox Option;
+		Option.initFrom(pCombo);
+		Option.editable = false;
+		Option.currentText = pCombo->currentText();
+		Option.currentIcon = pCombo->itemIcon(pCombo->currentIndex());
+		Option.iconSize = pCombo->iconSize();
+
+		QStylePainter Painter(pCombo);
+		pCombo->style()->drawComplexControl(QStyle::CC_ComboBox, &Option, &Painter, pCombo);
+		QRect EditRect = pCombo->style()->subControlRect(QStyle::CC_ComboBox, &Option, QStyle::SC_ComboBoxEditField, pCombo);
+		Painter.fillRect(EditRect, pCombo->property("pending_value_combo_color").value<QColor>());
+		pCombo->style()->drawControl(QStyle::CE_ComboBoxLabel, &Option, &Painter, pCombo);
+		return true;
+	}
+};
+
+class CPendingChanges : public QObject
+{
+public:
+	CPendingChanges(QWidget* pRoot, bool* pHoldChange, int TemplateItemRole, bool bTrackKeySequences)
+		: m_pRoot(pRoot), m_pHoldChange(pHoldChange), m_TemplateItemRole(TemplateItemRole), m_bTrackKeySequences(bTrackKeySequences)
+	{
+	}
+
+	void CaptureItemBaselines(QTreeWidget* pExcludedTree, QTreeWidget* pTree = nullptr)
+	{
+		auto Capture = [this](QTreeWidget* pTree) {
+			QSignalBlocker Blocker(pTree);
+			QTreeWidgetItemIterator It(pTree);
+			while (*It) {
+				QTreeWidgetItem* pItem = *It;
+				if (!IsTemplateItem(pItem)) {
+					SetItemHighlight(pItem, eNone);
+					pItem->setData(0, ItemBaselineRole, GetItemSignature(pItem));
+				}
+				++It;
+			}
+		};
+
+		if (pTree) {
+			Capture(pTree);
+			return;
+		}
+
+		foreach(QTreeWidget* pCandidate, m_pRoot->findChildren<QTreeWidget*>()) {
+			if (pCandidate != pExcludedTree)
+				Capture(pCandidate);
+		}
+	}
+
+	void CaptureCheckboxBaselines()
+	{
+		foreach(QCheckBox* pCheck, m_pRoot->findChildren<QCheckBox*>()) {
+			SetCheckboxHighlight(pCheck, false);
+			pCheck->setProperty(CheckboxBaselineProperty, (int)pCheck->checkState());
+		}
+	}
+
+	void CaptureRadioButtonBaselines()
+	{
+		foreach(QRadioButton* pRadio, m_pRoot->findChildren<QRadioButton*>())
+			CaptureRadioButtonBaseline(pRadio);
+	}
+
+	void CaptureRadioButtonBaseline(QRadioButton* pRadio)
+	{
+		SetRadioButtonHighlight(pRadio, false);
+		pRadio->setProperty(RadioBaselineProperty, pRadio->isChecked());
+		if (!pRadio->property(RadioConnectionProperty).toBool()) {
+			pRadio->setProperty(RadioConnectionProperty, true);
+			connect(pRadio, &QRadioButton::toggled, this, [this](bool) {
+				if (m_bEnabled && !IsHoldingChanges())
+					UpdateRadioButtonHighlights();
+			});
+		}
+	}
+
+	void ExcludeValue(QWidget* pControl)
+	{
+		SetValueHighlight(pControl, false);
+		pControl->setProperty(ValueExcludedProperty, true);
+	}
+
+	void SetEnabled(bool bEnabled, QTreeWidget* pExcludedTree)
+	{
+		if (m_bEnabled == bEnabled)
+			return;
+
+		m_bEnabled = bEnabled;
+		if (!m_bEnabled)
+			ClearHighlights(pExcludedTree);
+	}
+
+	void CaptureValueBaselines()
+	{
+		foreach(QComboBox* pCombo, m_pRoot->findChildren<QComboBox*>()) {
+			if (IsValueExcluded(pCombo))
+				continue;
+			SetValueHighlight(pCombo, false);
+			if (pCombo->isEditable()) {
+				QSignalBlocker Blocker(pCombo);
+				EnsureComboSnapshot(pCombo);
+			}
+			pCombo->setProperty(ValueBaselineProperty, ComboValue(pCombo));
+			if (!pCombo->isEditable() && !pCombo->property(ValueComboPaintFilterProperty).toBool()) {
+				pCombo->setProperty(ValueComboPaintFilterProperty, true);
+				pCombo->installEventFilter(new CPendingComboPaintFilter(pCombo));
+			}
+			if (!pCombo->property(ValueConnectionProperty).toBool()) {
+				pCombo->setProperty(ValueConnectionProperty, true);
+				connect(pCombo, qOverload<int>(&QComboBox::currentIndexChanged), this, [this, pCombo](int) {
+					if (!IsHoldingChanges())
+						UpdateValueHighlight(pCombo);
+				});
+				if (pCombo->isEditable()) {
+					connect(pCombo, &QComboBox::currentTextChanged, this, [this, pCombo](const QString&) {
+						if (!IsHoldingChanges())
+							UpdateValueHighlight(pCombo);
+					});
+					connect(pCombo, qOverload<int>(&QComboBox::activated), this, [this, pCombo](int) {
+						QTimer::singleShot(0, pCombo, [this, pCombo]() {
+							if (!IsHoldingChanges())
+								UpdateValueHighlight(pCombo);
+						});
+					});
+				}
+			}
+		}
+
+		foreach(QAbstractSpinBox* pSpinBox, m_pRoot->findChildren<QAbstractSpinBox*>()) {
+			if (IsValueExcluded(pSpinBox))
+				continue;
+			SetValueHighlight(pSpinBox, false);
+			pSpinBox->setProperty(ValueBaselineProperty, SpinBoxValue(pSpinBox));
+			if (!pSpinBox->property(ValueConnectionProperty).toBool()) {
+				pSpinBox->setProperty(ValueConnectionProperty, true);
+				if (QSpinBox* pSpin = qobject_cast<QSpinBox*>(pSpinBox))
+					connect(pSpin, qOverload<int>(&QSpinBox::valueChanged), this, [this, pSpin](int) {
+						if (!IsHoldingChanges())
+							UpdateValueHighlight(pSpin);
+					});
+				else if (QDoubleSpinBox* pSpin = qobject_cast<QDoubleSpinBox*>(pSpinBox))
+					connect(pSpin, qOverload<double>(&QDoubleSpinBox::valueChanged), this, [this, pSpin](double) {
+						if (!IsHoldingChanges())
+							UpdateValueHighlight(pSpin);
+					});
+			}
+		}
+
+		foreach(QLineEdit* pLineEdit, m_pRoot->findChildren<QLineEdit*>()) {
+			if (IsComboLineEdit(pLineEdit))
+				continue;
+			if (IsValueExcluded(pLineEdit))
+				continue;
+			SetValueHighlight(pLineEdit, false);
+			pLineEdit->setProperty(ValueBaselineProperty, pLineEdit->text());
+			pLineEdit->setModified(false);
+			if (!pLineEdit->property(ValueConnectionProperty).toBool()) {
+				pLineEdit->setProperty(ValueConnectionProperty, true);
+				connect(pLineEdit, &QLineEdit::textChanged, this, [this, pLineEdit](const QString&) {
+					if (!IsHoldingChanges())
+						UpdateValueHighlight(pLineEdit);
+				});
+			}
+		}
+
+		foreach(QPlainTextEdit* pTextEdit, m_pRoot->findChildren<QPlainTextEdit*>()) {
+			if (IsValueExcluded(pTextEdit))
+				continue;
+			SetValueHighlight(pTextEdit, false);
+			pTextEdit->setProperty(ValueBaselineProperty, pTextEdit->toPlainText());
+			if (!pTextEdit->property(ValueConnectionProperty).toBool()) {
+				pTextEdit->setProperty(ValueConnectionProperty, true);
+				connect(pTextEdit, &QPlainTextEdit::textChanged, this, [this, pTextEdit]() {
+					if (!IsHoldingChanges())
+						UpdateValueHighlight(pTextEdit);
+				});
+			}
+		}
+
+		if (m_bTrackKeySequences) {
+			foreach(QKeySequenceEdit* pKeyEdit, m_pRoot->findChildren<QKeySequenceEdit*>()) {
+				if (IsValueExcluded(pKeyEdit))
+					continue;
+				SetValueHighlight(pKeyEdit, false);
+				pKeyEdit->setProperty(ValueBaselineProperty, pKeyEdit->keySequence().toString(QKeySequence::PortableText));
+				if (!pKeyEdit->property(ValueConnectionProperty).toBool()) {
+					pKeyEdit->setProperty(ValueConnectionProperty, true);
+					connect(pKeyEdit, &QKeySequenceEdit::keySequenceChanged, this, [this, pKeyEdit](const QKeySequence&) {
+						if (!IsHoldingChanges())
+							UpdateValueHighlight(pKeyEdit);
+					});
+				}
+			}
+		}
+	}
+
+	void Update(QObject* pSource, QTreeWidget* pExcludedTree)
+	{
+		if (!m_bEnabled)
+			return;
+
+		UpdateItemHighlights(pExcludedTree);
+		UpdateCheckboxHighlight(pSource);
+		UpdateRadioButtonHighlights();
+		UpdateValueHighlight(pSource);
+		UpdateValueHighlights();
+	}
+
+private:
+	enum EItemState { eNone, eAdded, eEdited };
+	enum { ItemBaselineRole = Qt::UserRole + 110, ItemStateRole = Qt::UserRole + 111, ItemBackgroundRole = Qt::UserRole + 112 };
+	static constexpr const char* CheckboxBaselineProperty = "pending_checkbox_baseline";
+	static constexpr const char* CheckboxPaletteProperty = "pending_checkbox_palette";
+	static constexpr const char* CheckboxAutoFillProperty = "pending_checkbox_auto_fill";
+	static constexpr const char* RadioBaselineProperty = "pending_radio_baseline";
+	static constexpr const char* RadioPaletteProperty = "pending_radio_palette";
+	static constexpr const char* RadioAutoFillProperty = "pending_radio_auto_fill";
+	static constexpr const char* RadioConnectionProperty = "pending_radio_connection";
+	static constexpr const char* ValueBaselineProperty = "pending_value_baseline";
+	static constexpr const char* ValuePaletteProperty = "pending_value_palette";
+	static constexpr const char* ValueAutoFillProperty = "pending_value_auto_fill";
+	static constexpr const char* ValueStyleProperty = "pending_value_style";
+	static constexpr const char* ValueViewPaletteProperty = "pending_value_view_palette";
+	static constexpr const char* ValueViewportPaletteProperty = "pending_value_viewport_palette";
+	static constexpr const char* ValueViewportBaseColorProperty = "pending_value_viewport_base_color";
+	static constexpr const char* ValueLineEditAutoFillProperty = "pending_value_line_edit_auto_fill";
+	static constexpr const char* ValueLineEditStyleProperty = "pending_value_line_edit_style";
+	static constexpr const char* ValueConnectionProperty = "pending_value_connection";
+	static constexpr const char* ValueComboBackgroundsProperty = "pending_value_combo_backgrounds";
+	static constexpr const char* ValueComboSnapshotProperty = "pending_value_combo_snapshot";
+	static constexpr const char* ValueComboColorProperty = "pending_value_combo_color";
+	static constexpr const char* ValueComboPaintFilterProperty = "pending_value_combo_paint_filter";
+	static constexpr const char* ValueExcludedProperty = "pending_value_excluded";
+
+	bool IsHoldingChanges() const { return m_pHoldChange && *m_pHoldChange; }
+	static bool IsValueExcluded(const QWidget* pControl) { return pControl->property(ValueExcludedProperty).toBool(); }
+	static bool IsComboLineEdit(const QLineEdit* pLineEdit)
+	{
+		for (const QWidget* pParent = pLineEdit->parentWidget(); pParent; pParent = pParent->parentWidget()) {
+			if (const QComboBox* pCombo = qobject_cast<const QComboBox*>(pParent))
+				return pCombo->lineEdit() == pLineEdit;
+		}
+		return false;
+	}
+
+	void ClearHighlights(QTreeWidget* pExcludedTree)
+	{
+		foreach(QTreeWidget* pTree, m_pRoot->findChildren<QTreeWidget*>()) {
+			if (pTree == pExcludedTree)
+				continue;
+			QTreeWidgetItemIterator It(pTree);
+			while (*It) {
+				SetItemHighlight(*It, eNone);
+				++It;
+			}
+		}
+
+		foreach(QCheckBox* pCheck, m_pRoot->findChildren<QCheckBox*>())
+			SetCheckboxHighlight(pCheck, false);
+		foreach(QRadioButton* pRadio, m_pRoot->findChildren<QRadioButton*>())
+			SetRadioButtonHighlight(pRadio, false);
+		foreach(QComboBox* pCombo, m_pRoot->findChildren<QComboBox*>())
+			if (!IsValueExcluded(pCombo)) SetValueHighlight(pCombo, false);
+		foreach(QAbstractSpinBox* pSpinBox, m_pRoot->findChildren<QAbstractSpinBox*>())
+			if (!IsValueExcluded(pSpinBox)) SetValueHighlight(pSpinBox, false);
+		foreach(QLineEdit* pLineEdit, m_pRoot->findChildren<QLineEdit*>())
+			if (!IsComboLineEdit(pLineEdit) && !IsValueExcluded(pLineEdit)) SetValueHighlight(pLineEdit, false);
+		foreach(QPlainTextEdit* pTextEdit, m_pRoot->findChildren<QPlainTextEdit*>())
+			if (!IsValueExcluded(pTextEdit)) SetValueHighlight(pTextEdit, false);
+		if (m_bTrackKeySequences)
+			foreach(QKeySequenceEdit* pKeyEdit, m_pRoot->findChildren<QKeySequenceEdit*>())
+				if (!IsValueExcluded(pKeyEdit)) SetValueHighlight(pKeyEdit, false);
+	}
+
+	static QColor PendingColor(const QPalette& Palette, QPalette::ColorRole Role, const QColor& Accent = QColor(255, 179, 0))
+	{
+		QColor Background = Palette.color(QPalette::Active, Role);
+		constexpr int Opacity = 72;
+		return QColor((Accent.red() * Opacity + Background.red() * (255 - Opacity)) / 255,
+			(Accent.green() * Opacity + Background.green() * (255 - Opacity)) / 255,
+			(Accent.blue() * Opacity + Background.blue() * (255 - Opacity)) / 255);
+	}
+
+	static QString ComboValue(const QComboBox* pCombo)
+	{
+		return pCombo->isEditable() ? "T" + pCombo->currentText().toUtf8().toBase64() : QString::number(pCombo->currentIndex());
+	}
+
+	static void EnsureComboSnapshot(QComboBox* pCombo)
+	{
+		const QString Snapshot = pCombo->currentText();
+		const QString PreviousSnapshot = pCombo->property(ValueComboSnapshotProperty).toString();
+		if (!PreviousSnapshot.isEmpty()) {
+			int Index = pCombo->findText(PreviousSnapshot, Qt::MatchExactly);
+			if (Index >= 0)
+				pCombo->removeItem(Index);
+			pCombo->setProperty(ValueComboSnapshotProperty, QVariant());
+		}
+		if (!Snapshot.isEmpty() && pCombo->findText(Snapshot, Qt::MatchExactly) < 0) {
+			pCombo->insertItem(0, Snapshot);
+			pCombo->setProperty(ValueComboSnapshotProperty, Snapshot);
+		}
+		pCombo->setCurrentText(Snapshot);
+	}
+
+	static QString SpinBoxValue(const QAbstractSpinBox* pSpinBox)
+	{
+		if (const QSpinBox* pSpin = qobject_cast<const QSpinBox*>(pSpinBox))
+			return QString::number(pSpin->value());
+		if (const QDoubleSpinBox* pSpin = qobject_cast<const QDoubleSpinBox*>(pSpinBox))
+			return QString::number(pSpin->value(), 'g', 17);
+		return pSpinBox->text();
+	}
+
+	QString GetItemSignature(const QTreeWidgetItem* pItem) const
+	{
+		QStringList Values;
+		for (int i = 0; i < pItem->columnCount(); i++) {
+			Values.append(pItem->text(i).toUtf8().toBase64());
+			Values.append(pItem->data(i, Qt::UserRole).toString().toUtf8().toBase64());
+			Values.append(QString::number(pItem->checkState(i)));
+		}
+		return Values.join(QChar(0x1E));
+	}
+
+	bool IsTemplateItem(const QTreeWidgetItem* pItem) const
+	{
+		if (m_TemplateItemRole < 0)
+			return false;
+		if (pItem->data(0, m_TemplateItemRole).toBool())
+			return true;
+		for (int i = 0; i < pItem->columnCount(); i++) {
+			if (pItem->data(i, Qt::UserRole).toInt() == -1)
+				return true;
+		}
+		return false;
+	}
+
+	void SetItemHighlight(QTreeWidgetItem* pItem, int State)
+	{
+		int OldState = pItem->data(0, ItemStateRole).toInt();
+		if (State == OldState)
+			return;
+		for (int i = 0; i < pItem->columnCount(); i++) {
+			if (State != eNone) {
+				if (OldState == eNone)
+					pItem->setData(i, ItemBackgroundRole, pItem->data(i, Qt::BackgroundRole));
+				QColor Color = State == eAdded ? QColor(76, 175, 80) : QColor(255, 179, 0);
+				Color.setAlpha(72);
+				pItem->setData(i, Qt::BackgroundRole, QBrush(Color));
+			}
+			else if (OldState != eNone) {
+				pItem->setData(i, Qt::BackgroundRole, pItem->data(i, ItemBackgroundRole));
+				pItem->setData(i, ItemBackgroundRole, QVariant());
+			}
+		}
+		pItem->setData(0, ItemStateRole, State == eNone ? QVariant() : QVariant(State));
+	}
+
+	void UpdateItemHighlights(QTreeWidget* pExcludedTree)
+	{
+		foreach(QTreeWidget* pTree, m_pRoot->findChildren<QTreeWidget*>()) {
+			if (pTree == pExcludedTree)
+				continue;
+			QSignalBlocker Blocker(pTree);
+			QTreeWidgetItemIterator It(pTree);
+			while (*It) {
+				QTreeWidgetItem* pItem = *It;
+				if (!IsTemplateItem(pItem)) {
+					QVariant Baseline = pItem->data(0, ItemBaselineRole);
+					SetItemHighlight(pItem, !Baseline.isValid() ? eAdded : (Baseline.toString() == GetItemSignature(pItem) ? eNone : eEdited));
+				}
+				++It;
+			}
+		}
+	}
+
+	void SetCheckboxHighlight(QCheckBox* pCheck, bool bPending)
+	{
+		if (bPending) {
+			if (!pCheck->property(CheckboxPaletteProperty).isValid()) {
+				pCheck->setProperty(CheckboxPaletteProperty, QVariant::fromValue(pCheck->palette()));
+				pCheck->setProperty(CheckboxAutoFillProperty, pCheck->autoFillBackground());
+			}
+			QPalette Palette = pCheck->palette();
+			QColor Color = PendingColor(Palette, QPalette::Window);
+			Palette.setColor(QPalette::Active, QPalette::Window, Color);
+			Palette.setColor(QPalette::Inactive, QPalette::Window, Color);
+			pCheck->setPalette(Palette);
+			pCheck->setAutoFillBackground(true);
+		}
+		else if (pCheck->property(CheckboxPaletteProperty).isValid()) {
+			pCheck->setPalette(pCheck->property(CheckboxPaletteProperty).value<QPalette>());
+			pCheck->setAutoFillBackground(pCheck->property(CheckboxAutoFillProperty).toBool());
+			pCheck->setProperty(CheckboxPaletteProperty, QVariant());
+			pCheck->setProperty(CheckboxAutoFillProperty, QVariant());
+		}
+	}
+
+	void UpdateCheckboxHighlight(QObject* pSource)
+	{
+		QCheckBox* pCheck = qobject_cast<QCheckBox*>(pSource);
+		QVariant Baseline = pCheck ? pCheck->property(CheckboxBaselineProperty) : QVariant();
+		if (Baseline.isValid())
+			SetCheckboxHighlight(pCheck, Baseline.toInt() != (int)pCheck->checkState());
+	}
+
+	void SetRadioButtonHighlight(QRadioButton* pRadio, bool bPending)
+	{
+		if (bPending) {
+			if (!pRadio->property(RadioPaletteProperty).isValid()) {
+				pRadio->setProperty(RadioPaletteProperty, QVariant::fromValue(pRadio->palette()));
+				pRadio->setProperty(RadioAutoFillProperty, pRadio->autoFillBackground());
+			}
+			QPalette Palette = pRadio->palette();
+			QColor Color = PendingColor(Palette, QPalette::Window);
+			Palette.setColor(QPalette::Active, QPalette::Window, Color);
+			Palette.setColor(QPalette::Inactive, QPalette::Window, Color);
+			pRadio->setPalette(Palette);
+			pRadio->setAutoFillBackground(true);
+		}
+		else if (pRadio->property(RadioPaletteProperty).isValid()) {
+			pRadio->setPalette(pRadio->property(RadioPaletteProperty).value<QPalette>());
+			pRadio->setAutoFillBackground(pRadio->property(RadioAutoFillProperty).toBool());
+			pRadio->setProperty(RadioPaletteProperty, QVariant());
+			pRadio->setProperty(RadioAutoFillProperty, QVariant());
+		}
+	}
+
+	void UpdateRadioButtonHighlights()
+	{
+		foreach(QRadioButton* pRadio, m_pRoot->findChildren<QRadioButton*>()) {
+			QVariant Baseline = pRadio->property(RadioBaselineProperty);
+			if (Baseline.isValid())
+				SetRadioButtonHighlight(pRadio, pRadio->isChecked() && !Baseline.toBool());
+		}
+	}
+
+	void SetComboPopupHighlight(QComboBox* pCombo, bool bPending)
+	{
+		QAbstractItemModel* pModel = pCombo->model();
+		if (!pModel)
+			return;
+		if (bPending) {
+			QVariantList Backgrounds = pCombo->property(ValueComboBackgroundsProperty).toList();
+			if (Backgrounds.isEmpty()) {
+				for (int i = 0; i < pCombo->count(); i++) {
+					QModelIndex Index = pModel->index(i, pCombo->modelColumn(), pCombo->rootModelIndex());
+					Backgrounds.append(pModel->data(Index, Qt::BackgroundRole));
+				}
+				pCombo->setProperty(ValueComboBackgroundsProperty, Backgrounds);
+			}
+			QString Baseline = pCombo->property(ValueBaselineProperty).toString();
+			int Snapshot = pCombo->isEditable() ? pCombo->findText(QString::fromUtf8(QByteArray::fromBase64(Baseline.mid(1).toUtf8()))) : Baseline.toInt();
+			QColor Color = PendingColor(pCombo->palette(), QPalette::Base, QColor(76, 175, 80));
+			QColor BaseColor = pCombo->property(ValueViewportBaseColorProperty).value<QColor>();
+			for (int i = 0; i < pCombo->count(); i++) {
+				QModelIndex Index = pModel->index(i, pCombo->modelColumn(), pCombo->rootModelIndex());
+				QVariant Background = Backgrounds.value(i);
+				pModel->setData(Index, i == Snapshot ? QVariant::fromValue(QBrush(Color)) : (Background.isValid() ? Background : QVariant::fromValue(QBrush(BaseColor))), Qt::BackgroundRole);
+			}
+		}
+		else {
+			QVariantList Backgrounds = pCombo->property(ValueComboBackgroundsProperty).toList();
+			for (int i = 0; i < qMin(pCombo->count(), Backgrounds.count()); i++) {
+				QModelIndex Index = pModel->index(i, pCombo->modelColumn(), pCombo->rootModelIndex());
+				pModel->setData(Index, Backgrounds.value(i), Qt::BackgroundRole);
+			}
+			pCombo->setProperty(ValueComboBackgroundsProperty, QVariant());
+		}
+	}
+
+	void SetValueHighlight(QWidget* pControl, bool bPending)
+	{
+		if (bPending) {
+			if (!pControl->property(ValuePaletteProperty).isValid()) {
+				pControl->setProperty(ValuePaletteProperty, QVariant::fromValue(pControl->palette()));
+				pControl->setProperty(ValueAutoFillProperty, pControl->autoFillBackground());
+				pControl->setProperty(ValueStyleProperty, pControl->styleSheet());
+				if (QComboBox* pCombo = qobject_cast<QComboBox*>(pControl)) {
+					pCombo->setProperty(ValueViewPaletteProperty, QVariant::fromValue(pCombo->view()->palette()));
+					pCombo->setProperty(ValueViewportPaletteProperty, QVariant::fromValue(pCombo->view()->viewport()->palette()));
+					pCombo->setProperty(ValueViewportBaseColorProperty, pCombo->view()->viewport()->palette().color(QPalette::Active, QPalette::Base));
+					if (pCombo->isEditable() && pCombo->lineEdit()) {
+						pCombo->setProperty(ValueLineEditAutoFillProperty, pCombo->lineEdit()->autoFillBackground());
+						pCombo->setProperty(ValueLineEditStyleProperty, pCombo->lineEdit()->styleSheet());
+					}
+				}
+			}
+			QPalette Palette = pControl->palette();
+			QColor BaseColor = PendingColor(Palette, QPalette::Base);
+			QColor ButtonColor = PendingColor(Palette, QPalette::Button);
+			Palette.setColor(QPalette::Active, QPalette::Base, BaseColor);
+			Palette.setColor(QPalette::Inactive, QPalette::Base, BaseColor);
+			Palette.setColor(QPalette::Active, QPalette::Button, ButtonColor);
+			Palette.setColor(QPalette::Inactive, QPalette::Button, ButtonColor);
+			pControl->setPalette(Palette);
+			pControl->setAutoFillBackground(true);
+			if (QComboBox* pCombo = qobject_cast<QComboBox*>(pControl)) {
+				if (!pCombo->isEditable())
+					pCombo->setProperty(ValueComboColorProperty, ButtonColor);
+				else if (QLineEdit* pLineEdit = pCombo->lineEdit()) {
+					QPalette LineEditPalette = pLineEdit->palette();
+					LineEditPalette.setColor(QPalette::Active, QPalette::Base, BaseColor);
+					LineEditPalette.setColor(QPalette::Inactive, QPalette::Base, BaseColor);
+					pLineEdit->setPalette(LineEditPalette);
+					pLineEdit->setAutoFillBackground(true);
+					pLineEdit->setStyleSheet(pCombo->property(ValueLineEditStyleProperty).toString()
+						+ "\nQLineEdit { background-color: " + BaseColor.name() + "; }");
+				}
+				pCombo->view()->setPalette(pCombo->property(ValueViewPaletteProperty).value<QPalette>());
+				QPalette ViewportPalette = pCombo->property(ValueViewportPaletteProperty).value<QPalette>();
+				QColor ViewportBaseColor = pCombo->property(ValueViewportBaseColorProperty).value<QColor>();
+				ViewportPalette.setColor(QPalette::Active, QPalette::Base, ViewportBaseColor);
+				ViewportPalette.setColor(QPalette::Inactive, QPalette::Base, ViewportBaseColor);
+				pCombo->view()->viewport()->setPalette(ViewportPalette);
+				SetComboPopupHighlight(pCombo, true);
+				pCombo->update();
+			}
+			else if (m_bTrackKeySequences && qobject_cast<QKeySequenceEdit*>(pControl)) {
+				pControl->setStyleSheet(pControl->property(ValueStyleProperty).toString()
+					+ "\nQKeySequenceEdit, QKeySequenceEdit QLineEdit { background-color: " + BaseColor.name() + "; }");
+			}
+		}
+		else if (pControl->property(ValuePaletteProperty).isValid()) {
+			pControl->setStyleSheet(pControl->property(ValueStyleProperty).toString());
+			pControl->setPalette(pControl->property(ValuePaletteProperty).value<QPalette>());
+			pControl->setAutoFillBackground(pControl->property(ValueAutoFillProperty).toBool());
+			if (QComboBox* pCombo = qobject_cast<QComboBox*>(pControl)) {
+				if (pCombo->isEditable())
+					pCombo->setPalette(QPalette());
+				pCombo->setProperty(ValueComboColorProperty, QVariant());
+				SetComboPopupHighlight(pCombo, false);
+				pCombo->view()->setPalette(pCombo->property(ValueViewPaletteProperty).value<QPalette>());
+				pCombo->view()->viewport()->setPalette(pCombo->property(ValueViewportPaletteProperty).value<QPalette>());
+				if (pCombo->isEditable() && pCombo->lineEdit()) {
+					QLineEdit* pLineEdit = pCombo->lineEdit();
+					const QString StyleSheet = pCombo->property(ValueLineEditStyleProperty).toString();
+					pLineEdit->setStyleSheet(QString());
+					pLineEdit->setPalette(QPalette());
+					pLineEdit->setAutoFillBackground(pCombo->property(ValueLineEditAutoFillProperty).toBool());
+					pLineEdit->setStyleSheet(StyleSheet);
+					pLineEdit->style()->unpolish(pLineEdit);
+					pLineEdit->style()->polish(pLineEdit);
+					pLineEdit->update();
+				}
+				pCombo->update();
+			}
+			pControl->style()->unpolish(pControl);
+			pControl->style()->polish(pControl);
+			pControl->update();
+			pControl->setProperty(ValuePaletteProperty, QVariant());
+			pControl->setProperty(ValueAutoFillProperty, QVariant());
+			pControl->setProperty(ValueStyleProperty, QVariant());
+			pControl->setProperty(ValueViewPaletteProperty, QVariant());
+			pControl->setProperty(ValueViewportPaletteProperty, QVariant());
+			pControl->setProperty(ValueViewportBaseColorProperty, QVariant());
+			pControl->setProperty(ValueLineEditAutoFillProperty, QVariant());
+			pControl->setProperty(ValueLineEditStyleProperty, QVariant());
+		}
+	}
+
+	void UpdateValueHighlight(QObject* pSource)
+	{
+		if (!m_bEnabled)
+			return;
+
+		if (QWidget* pControl = qobject_cast<QWidget*>(pSource)) {
+			if (IsValueExcluded(pControl))
+				return;
+		}
+
+		if (QComboBox* pCombo = qobject_cast<QComboBox*>(pSource)) {
+			QVariant Baseline = pCombo->property(ValueBaselineProperty);
+			if (Baseline.isValid()) {
+				if (pCombo->isEditable()) {
+					const QString Snapshot = QString::fromUtf8(QByteArray::fromBase64(Baseline.toString().mid(1).toUtf8()));
+					const bool bSnapshotSelected = pCombo->currentIndex() >= 0
+						&& pCombo->itemText(pCombo->currentIndex()) == Snapshot;
+					SetValueHighlight(pCombo, !bSnapshotSelected && pCombo->currentText() != Snapshot);
+				}
+				else
+					SetValueHighlight(pCombo, Baseline.toString() != ComboValue(pCombo));
+			}
+		}
+		else if (QAbstractSpinBox* pSpinBox = qobject_cast<QAbstractSpinBox*>(pSource)) {
+			QVariant Baseline = pSpinBox->property(ValueBaselineProperty);
+			if (Baseline.isValid()) SetValueHighlight(pSpinBox, Baseline.toString() != SpinBoxValue(pSpinBox));
+		}
+		else if (QLineEdit* pLineEdit = qobject_cast<QLineEdit*>(pSource)) {
+			QVariant Baseline = pLineEdit->property(ValueBaselineProperty);
+			if (Baseline.isValid()) SetValueHighlight(pLineEdit, pLineEdit->isModified() && Baseline.toString() != pLineEdit->text());
+		}
+		else if (QPlainTextEdit* pTextEdit = qobject_cast<QPlainTextEdit*>(pSource)) {
+			QVariant Baseline = pTextEdit->property(ValueBaselineProperty);
+			if (Baseline.isValid()) SetValueHighlight(pTextEdit, Baseline.toString() != pTextEdit->toPlainText());
+		}
+		else if (m_bTrackKeySequences) {
+			if (QKeySequenceEdit* pKeyEdit = qobject_cast<QKeySequenceEdit*>(pSource)) {
+				QVariant Baseline = pKeyEdit->property(ValueBaselineProperty);
+				if (Baseline.isValid()) SetValueHighlight(pKeyEdit, Baseline.toString() != pKeyEdit->keySequence().toString(QKeySequence::PortableText));
+			}
+		}
+	}
+
+	void UpdateValueHighlights()
+	{
+		foreach(QComboBox* pCombo, m_pRoot->findChildren<QComboBox*>())
+			if (!IsValueExcluded(pCombo) && pCombo->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pCombo);
+		foreach(QAbstractSpinBox* pSpinBox, m_pRoot->findChildren<QAbstractSpinBox*>())
+			if (!IsValueExcluded(pSpinBox) && pSpinBox->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pSpinBox);
+		foreach(QLineEdit* pLineEdit, m_pRoot->findChildren<QLineEdit*>())
+			if (!IsComboLineEdit(pLineEdit) && !IsValueExcluded(pLineEdit) && pLineEdit->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pLineEdit);
+		foreach(QPlainTextEdit* pTextEdit, m_pRoot->findChildren<QPlainTextEdit*>())
+			if (!IsValueExcluded(pTextEdit) && pTextEdit->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pTextEdit);
+		if (m_bTrackKeySequences)
+			foreach(QKeySequenceEdit* pKeyEdit, m_pRoot->findChildren<QKeySequenceEdit*>())
+				if (!IsValueExcluded(pKeyEdit) && pKeyEdit->property(ValuePaletteProperty).isValid()) UpdateValueHighlight(pKeyEdit);
+	}
+
+	QWidget* m_pRoot;
+	bool* m_pHoldChange;
+	int m_TemplateItemRole;
+	bool m_bTrackKeySequences;
+	bool m_bEnabled = true;
+};

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -596,6 +596,7 @@ CSettingsWindow::CSettingsWindow(QWidget* parent)
 	connect(ui.chkColorIcons, SIGNAL(stateChanged(int)), this, SLOT(OnChangeGUI()));
 	connect(ui.chkOverlayIcons, SIGNAL(stateChanged(int)), this, SLOT(OnChangeGUI()));
 	connect(ui.chkHideCore, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
+	connect(ui.chkHighlightPendingChanges, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
 	connect(ui.cmbGrouping, SIGNAL(currentIndexChanged(int)), this, SLOT(OnOptChanged()));
 	connect(ui.cmbLaunchMonitor, SIGNAL(currentIndexChanged(int)), this, SLOT(OnOptChanged()));
 	connect(ui.cmbNonMainLaunchMonitor, SIGNAL(currentIndexChanged(int)), this, SLOT(OnOptChanged()));
@@ -1078,6 +1079,7 @@ bool CSettingsWindow::eventFilter(QObject *source, QEvent *event)
 		static bool m_bRightButtonPressed = false;
 
 		if (event->type() == QEvent::FocusIn && ui.txtCertificate->property("hidden").toBool())	{
+			QSignalBlocker Blocker(ui.txtCertificate);
 			ui.txtCertificate->setProperty("hidden", false);
 			ui.txtCertificate->setPlainText(g_Certificate);
 			ui.txtCertificate->setProperty("modified", false);
@@ -1087,6 +1089,7 @@ bool CSettingsWindow::eventFilter(QObject *source, QEvent *event)
 		}
 		else if (event->type() == QEvent::FocusOut && !ui.txtCertificate->property("hidden").toBool()) {
 			if (!ui.txtCertificate->property("modified").toBool() && !m_bRightButtonPressed) {
+				QSignalBlocker Blocker(ui.txtCertificate);
 				ui.txtCertificate->setProperty("hidden", true);
 				int Pos = g_Certificate.indexOf("HWID:");
 				if (Pos == -1)
@@ -1379,6 +1382,11 @@ void CSettingsWindow::LoadSettings()
 	ui.chkColorIcons->setChecked(theConf->GetBool("Options/ColorBoxIcons", false));
 	ui.chkOverlayIcons->setChecked(theConf->GetBool("Options/UseOverlayIcons", true));
 	ui.chkHideCore->setChecked(theConf->GetBool("Options/HideSbieProcesses", false));
+	int iHighlightPendingChanges = theConf->GetInt("Options/HighlightPendingChanges", 2);
+	ui.chkHighlightPendingChanges->setCheckState(CSettingsWindow__Int2Chk(iHighlightPendingChanges));
+	if (iHighlightPendingChanges == 2)
+		iHighlightPendingChanges = theConf->GetInt("Options/ViewMode", 1) != 2 ? 1 : 0;
+	m_PendingChanges.SetEnabled(iHighlightPendingChanges != 0, m_pTree);
 	ui.cmbGrouping->setCurrentIndex(theConf->GetInt("Options/BoxGroupHandling", 0));
 	
 
@@ -1734,6 +1742,10 @@ void CSettingsWindow::LoadSettings()
 
 	//ui.chkUpdateTemplates->setEnabled(g_CertInfo.active && !g_CertInfo.expired);
 	ui.chkUpdateIssues->setEnabled(g_CertInfo.active && !g_CertInfo.expired);
+	m_PendingChanges.CaptureItemBaselines(m_pTree);
+	m_PendingChanges.CaptureCheckboxBaselines();
+	m_PendingChanges.CaptureRadioButtonBaselines();
+	m_PendingChanges.CaptureValueBaselines();
 }
 
 void CSettingsWindow::OnRamDiskChange()
@@ -1957,6 +1969,7 @@ void CSettingsWindow::SaveSettings()
 	theConf->SetValue("Options/ColorBoxIcons", ui.chkColorIcons->isChecked());
 	theConf->SetValue("Options/UseOverlayIcons", ui.chkOverlayIcons->isChecked());
 	theConf->SetValue("Options/HideSbieProcesses", ui.chkHideCore->isChecked());
+	theConf->SetValue("Options/HighlightPendingChanges", CSettingsWindow__Chk2Int(ui.chkHighlightPendingChanges->checkState()));
 	theConf->SetValue("Options/BoxGroupHandling", ui.cmbGrouping->currentIndex());
 
 	CIniHighlighter::ClearLanguageCache();
@@ -2372,6 +2385,7 @@ void CSettingsWindow::OnOptChanged()
 
 	if (m_HoldChange)
 		return;
+	m_PendingChanges.Update(sender(), m_pTree);
 	ui.buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
@@ -2531,6 +2545,7 @@ void CSettingsWindow::OnCompat()
 	}
 
 	m_CompatLoaded = 1;
+	m_PendingChanges.CaptureItemBaselines(m_pTree, ui.treeCompat);
 	if(bNew)
 		OnCompatChanged();
 
@@ -2800,6 +2815,8 @@ void CSettingsWindow::LoadTemplates()
 		pItem->setText(0, Title);
 		ui.treeTemplates->addTopLevelItem(pItem);
 	}
+
+	m_PendingChanges.CaptureItemBaselines(m_pTree, ui.treeTemplates);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -3122,6 +3139,8 @@ void CSettingsWindow::InitSupport()
 	connect(ui.lblInsiderInfo, SIGNAL(linkActivated(const QString&)), theGUI, SLOT(OpenUrl(const QString&)));
 
 	m_CertChanged = false;
+	m_PendingChanges.ExcludeValue(ui.txtCertificate);
+	m_PendingChanges.ExcludeValue(ui.txtSerial);
 	connect(ui.txtCertificate, SIGNAL(textChanged()), this, SLOT(CertChanged()));
 	ui.txtCertificate->installEventFilter(this);
 	connect(ui.txtSerial, SIGNAL(textChanged(const QString&)), this, SLOT(KeyChanged()));
@@ -3215,7 +3234,9 @@ void CSettingsWindow::UpdateCert()
 		int datePos = truncatedCert.indexOf("DATE:");
 		if (namePos != -1 && datePos != -1 && datePos > namePos)
 			truncatedCert = truncatedCert.mid(0, namePos + 5) + " ...\n" + truncatedCert.mid(datePos);
+		QSignalBlocker Blocker(ui.txtCertificate);
 		ui.txtCertificate->setPlainText(truncatedCert);
+		ui.txtCertificate->setProperty("modified", false);
 		//ui.lblSupport->setVisible(false);
 
 		QString ReNewUrl = "https://sandboxie-plus.com/go.php?to=sbie-renew-cert";

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -173,6 +173,13 @@ Qt::CheckState CSettingsWindow__Int2Chk(int state)
 	}
 }
 
+static bool CSettingsWindow__IsPendingHighlightEnabled(Qt::CheckState state)
+{
+	if (state == Qt::PartiallyChecked)
+		return theConf->GetInt("Options/ViewMode", 1) != 2;
+	return state == Qt::Checked;
+}
+
 quint32 g_FeatureFlags = 0;
 
 QByteArray g_Certificate;
@@ -1382,11 +1389,8 @@ void CSettingsWindow::LoadSettings()
 	ui.chkColorIcons->setChecked(theConf->GetBool("Options/ColorBoxIcons", false));
 	ui.chkOverlayIcons->setChecked(theConf->GetBool("Options/UseOverlayIcons", true));
 	ui.chkHideCore->setChecked(theConf->GetBool("Options/HideSbieProcesses", false));
-	int iHighlightPendingChanges = theConf->GetInt("Options/HighlightPendingChanges", 2);
-	ui.chkHighlightPendingChanges->setCheckState(CSettingsWindow__Int2Chk(iHighlightPendingChanges));
-	if (iHighlightPendingChanges == 2)
-		iHighlightPendingChanges = theConf->GetInt("Options/ViewMode", 1) != 2 ? 1 : 0;
-	m_PendingChanges.SetEnabled(iHighlightPendingChanges != 0, m_pTree);
+	ui.chkHighlightPendingChanges->setCheckState(CSettingsWindow__Int2Chk(theConf->GetInt("Options/HighlightPendingChanges", 2)));
+	m_PendingChanges.SetEnabled(CSettingsWindow__IsPendingHighlightEnabled(ui.chkHighlightPendingChanges->checkState()), m_pTree);
 	ui.cmbGrouping->setCurrentIndex(theConf->GetInt("Options/BoxGroupHandling", 0));
 	
 
@@ -2383,9 +2387,16 @@ void CSettingsWindow::OnOptChanged()
 	item = model->item(3);
 	item->setFlags((ui.cmbSysTray->currentIndex() != 0) ? item->flags() & ~Qt::ItemIsEnabled : item->flags() | Qt::ItemIsEnabled);
 
+	if (sender() == ui.chkHighlightPendingChanges) {
+		m_PendingChanges.SetEnabled(CSettingsWindow__IsPendingHighlightEnabled(ui.chkHighlightPendingChanges->checkState()), m_pTree);
+		if (!m_HoldChange)
+			m_PendingChanges.UpdateAll(m_pTree);
+	}
+	else if (!m_HoldChange)
+		m_PendingChanges.Update(sender(), m_pTree);
+
 	if (m_HoldChange)
 		return;
-	m_PendingChanges.Update(sender(), m_pTree);
 	ui.buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 }
 
@@ -2422,6 +2433,7 @@ void CSettingsWindow::OnLoadAddon()
 		connect(pLabel, SIGNAL(linkActivated(const QString&)), theGUI, SLOT(OpenUrl(const QString&)));
 		ui.treeAddons->setItemWidget(pItem, 3, pLabel);
 	}
+	m_PendingChanges.CaptureItemBaselines(m_pTree, ui.treeAddons);
 }
 
 void CSettingsWindow::OnInstallAddon()

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.h
@@ -3,6 +3,7 @@
 #include <QtWidgets/QMainWindow>
 #include <QMap>
 #include "ui_SettingsWindow.h"
+#include "PendingChanges.h"
 #include "../../MiscHelpers/Common/SettingsWidgets.h"
 
 void FixTriStateBoxPallete(QWidget* pWidget);
@@ -201,6 +202,7 @@ protected:
 
 	bool	m_bRebuildUI;
 	bool	m_HoldChange;
+	CPendingChanges m_PendingChanges{this, &m_HoldChange, -1, true};
 	bool	m_SkipSaveOnToggle; // Skip saving to config when applying reset settings
 	int 	m_CompatLoaded;
 	QString m_NewPassword;


### PR DESCRIPTION
Resolves #5136 

Add shared pending-change highlighting for SandMan Options and Settings dialogs so unapplied edits stand out while immediate-effect controls stay unmarked. This wires in baseline tracking for trees, checkboxes, radios, and value fields, adds the new `Options/HighlightPendingChanges` setting and UI toggle, and excludes certificate/license fields and template-derived items from misleading highlights.


https://github.com/user-attachments/assets/5235a88c-4c2c-4242-97c4-53b3912e08cd

