### PR TITLE
Fix SOCKS5 auth decoding and send reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - fixed incremental update mechanism fails to copy new files
 - fixed 'RunServiceAsSystem=...' conflicts with 'UseSecurityMode=y'
 - fixed 'cryptsvc' failing with 'RunServicesAsSystem=y'
-
-
+- fixed SOCKS5 proxy password authentication failures caused by unsafe encrypted credential decoding, invalid credential length handling, locale-dependent encoding, and partial socket sends
 
 
 

--- a/Sandboxie/core/dll/net.c
+++ b/Sandboxie/core/dll/net.c
@@ -1,6 +1,6 @@
 /*
  * Copyright 2004-2020 Sandboxie Holdings, LLC
- * Copyright 2020-2025 David Xanatos, xanasoft.com
+ * Copyright 2020-2026 David Xanatos, xanasoft.com
  *
  * This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -323,8 +323,8 @@ struct NETPROXY_RULE {
     SOCKADDR_IN6_LH WSA_ProxyAddr6;
 
     BOOLEAN auth;
-    WCHAR   login[255];
-    WCHAR   pass[255];
+    WCHAR   login[256];
+    WCHAR   pass[256];
 
     rbtree_t ip_map;
 };
@@ -1897,6 +1897,78 @@ void NetFw_RuleAddIpRange(rbtree_t* tree, IP_ADDRESS* IpBegin, IP_ADDRESS* IpEnd
 
 const WCHAR* wcsnchr(const WCHAR* str, size_t max, WCHAR ch);
 
+static BOOLEAN WSA_DecryptProxyPassword(WCHAR password[256], const WCHAR* encoded, ULONG encoded_len)
+{
+    WCHAR* encoded_copy = NULL;
+    SBIE_INI_RC4_CRYPT_REQ* req = NULL;
+    SBIE_INI_RC4_CRYPT_RPL* rpl = NULL;
+    BOOLEAN ok = FALSE;
+
+    if (encoded_len == 0 || (encoded_len % 4) != 0)
+        goto cleanup;
+
+    for (ULONG i = 0; i < encoded_len; ++i) {
+        WCHAR ch = encoded[i];
+        if (ch == L'=') {
+            if (i < encoded_len - 2 || (i == encoded_len - 2 && encoded[i + 1] != L'='))
+                goto cleanup;
+        }
+        else if (!((ch >= L'0' && ch <= L'9') ||
+                   (ch >= L'A' && ch <= L'Z') ||
+                   (ch >= L'a' && ch <= L'z') || ch == L'+' || ch == L'/')) {
+            goto cleanup;
+        }
+    }
+
+    encoded_copy = Dll_Alloc(((SIZE_T)encoded_len + 1) * sizeof(WCHAR));
+    if (!encoded_copy)
+        goto cleanup;
+    wmemcpy(encoded_copy, encoded, encoded_len);
+    encoded_copy[encoded_len] = L'\0';
+
+    SIZE_T decoded_len = b64_decoded_size(encoded_copy);
+    if (decoded_len == 0 || decoded_len > 255 * sizeof(WCHAR) ||
+            (decoded_len % sizeof(WCHAR)) != 0)
+        goto cleanup;
+
+    ULONG req_len = sizeof(SBIE_INI_RC4_CRYPT_REQ) + (ULONG)decoded_len;
+    req = Dll_Alloc(req_len);
+    if (!req)
+        goto cleanup;
+    memset(req, 0, req_len);
+
+    req->h.length = req_len;
+    req->h.msgid = MSGID_SBIE_INI_RC4_CRYPT;
+    req->value_len = (ULONG)decoded_len;
+    if (!b64_decode(encoded_copy, req->value, decoded_len))
+        goto cleanup;
+
+    rpl = (SBIE_INI_RC4_CRYPT_RPL*)SbieDll_CallServer(&req->h);
+    if (!rpl || !NT_SUCCESS(rpl->h.status) ||
+            rpl->h.length < sizeof(SBIE_INI_RC4_CRYPT_RPL) ||
+            rpl->value_len > rpl->h.length - sizeof(SBIE_INI_RC4_CRYPT_RPL) ||
+            rpl->value_len != decoded_len ||
+            (rpl->value_len % sizeof(WCHAR)) != 0)
+        goto cleanup;
+
+    ULONG password_len = rpl->value_len / sizeof(WCHAR);
+    if (password_len > 255)
+        goto cleanup;
+
+    wmemcpy(password, rpl->value, password_len);
+    password[password_len] = L'\0';
+    ok = TRUE;
+
+cleanup:
+    if (rpl)
+        Dll_Free(rpl);
+    if (req)
+        Dll_Free(req);
+    if (encoded_copy)
+        Dll_Free(encoded_copy);
+    return ok;
+}
+
 BOOLEAN WSA_ParseNetProxy(NETPROXY_RULE* proxy, const WCHAR* found_value)
 {
     // NetworkUseProxy=explorer.exe,Address=198.98.55.77;Port=40000;Auth=No;Login=l2sxbnjqR5JJAAoCnA;Password=12OxyLTW9nma5HbNjC
@@ -2001,6 +2073,7 @@ BOOLEAN WSA_ParseNetProxy(NETPROXY_RULE* proxy, const WCHAR* found_value)
         if (login_len > 255)
             return FALSE;
         wmemcpy(proxy->login, login_value, login_len);
+        proxy->login[login_len] = L'\0';
     }
 
     WCHAR* pass_value;
@@ -2014,32 +2087,8 @@ BOOLEAN WSA_ParseNetProxy(NETPROXY_RULE* proxy, const WCHAR* found_value)
     }
     else {
         ok = SbieDll_FindTagValuePtr(found_value, L"EncryptedPW", &pass_value, &pass_len, L'=', L';');
-        if (ok) {
-
-            SBIE_INI_RC4_CRYPT_REQ req;
-            SBIE_INI_RC4_CRYPT_RPL *rpl;
-
-            pass_value[pass_len] = L'\0';
-
-            req.h.length = sizeof(SBIE_INI_RC4_CRYPT_REQ) + 255;
-            req.h.msgid = MSGID_SBIE_INI_RC4_CRYPT;
-            req.value_len = b64_decoded_size(pass_value);
-            b64_decode(pass_value, req.value, req.value_len);
-
-            pass_value[pass_len] = L'\0';
-
-            rpl = (SBIE_INI_RC4_CRYPT_RPL *)SbieDll_CallServer(&req.h);
-            if (rpl){
-
-                pass_len = rpl->value_len / sizeof(wchar_t);
-                if (pass_len > 255)
-                    return FALSE;
-                wmemcpy(proxy->pass, rpl->value, pass_len);
-                proxy->pass[pass_len] = L'\0';
-
-                Dll_Free(rpl);
-            }
-        }
+        if (ok && !WSA_DecryptProxyPassword(proxy->pass, pass_value, pass_len))
+            return FALSE;
     }
 
     return TRUE;

--- a/Sandboxie/core/dll/proxy.c
+++ b/Sandboxie/core/dll/proxy.c
@@ -29,6 +29,10 @@
 #include "common/map.h"
 #include "wsa_defs.h"
 
+#ifndef WC_ERR_INVALID_CHARS
+#define WC_ERR_INVALID_CHARS        0x00000080
+#endif
+
 
 #define SOCKS_VERSION               0x05
 #define SOCKS_SUBVERSION            0x01
@@ -56,6 +60,7 @@
 #define SOCKS_RESPONSE_MAX_SIZE     512
 #define SOCKS_REQUEST_MAX_SIZE      264
 #define SOCKS_AUTH_MAX_SIZE         255
+#define SOCKS_AUTH_BUFFER_SIZE      (SOCKS_AUTH_MAX_SIZE + 1)
 
 #define HOST_NAME_MAX               256
 #define INET_ADDRSTRLEN             16
@@ -81,15 +86,52 @@ extern HASH_MAP     DNS_LookupMap;
 // socks5_handshake
 //---------------------------------------------------------------------------
 
+static BOOLEAN socks5_send_all(SOCKET s, const char* buf, size_t size)
+{
+    while (size > 0) {
+        int sent = __sys_send(s, buf, (int)size, 0);
+        if (sent <= 0)
+            return FALSE;
+        buf += sent;
+        size -= sent;
+    }
+    return TRUE;
+}
 
-_FX BOOLEAN socks5_handshake(SOCKET s, BOOLEAN auth, WCHAR login[SOCKS_AUTH_MAX_SIZE], WCHAR pass[SOCKS_AUTH_MAX_SIZE])
+static BOOLEAN socks5_encode_credential(const WCHAR* value, char encoded[SOCKS_AUTH_MAX_SIZE], size_t* encoded_len)
+{
+    size_t value_len = wcslen(value);
+    if (value_len == 0) {
+        *encoded_len = 0;
+        return TRUE;
+    }
+
+    UINT code_page = GetACP();
+    DWORD flags = code_page == CP_UTF8 ? WC_ERR_INVALID_CHARS : WC_NO_BEST_FIT_CHARS;
+    BOOL used_default = FALSE;
+    LPBOOL used_default_ptr = code_page == CP_UTF8 ? NULL : &used_default;
+    int length = WideCharToMultiByte(code_page, flags, value, (int)value_len,
+        NULL, 0, NULL, used_default_ptr);
+    if (length <= 0 || length > SOCKS_AUTH_MAX_SIZE || used_default)
+        return FALSE;
+
+    used_default = FALSE;
+    if (WideCharToMultiByte(code_page, flags, value, (int)value_len,
+            encoded, length, NULL, used_default_ptr) != length || used_default)
+        return FALSE;
+
+    *encoded_len = (size_t)length;
+    return TRUE;
+}
+
+_FX BOOLEAN socks5_handshake(SOCKET s, BOOLEAN auth, WCHAR login[SOCKS_AUTH_BUFFER_SIZE], WCHAR pass[SOCKS_AUTH_BUFFER_SIZE])
 {
     char req[4] = { SOCKS_VERSION, 1 + auth, SOCKS_NO_AUTHENTICATION, 0 };
 
     if (auth) 
         req[3] = SOCKS_USERNAME_PASSWORD;
 
-    if (__sys_send(s, req, (3 + auth), 0) != (3 + auth))
+    if (!socks5_send_all(s, req, 3 + auth))
         goto on_error;
 
     char res[2];
@@ -111,8 +153,13 @@ _FX BOOLEAN socks5_handshake(SOCKET s, BOOLEAN auth, WCHAR login[SOCKS_AUTH_MAX_
         }
         char l[SOCKS_AUTH_MAX_SIZE];
         char p[SOCKS_AUTH_MAX_SIZE];
-        size_t login_len = wcstombs(l, login, SOCKS_AUTH_MAX_SIZE);
-        size_t pass_len = wcstombs(p, pass, SOCKS_AUTH_MAX_SIZE);
+        size_t login_len;
+        size_t pass_len;
+        if (!socks5_encode_credential(login, l, &login_len) ||
+                !socks5_encode_credential(pass, p, &pass_len)) {
+            SbieApi_Log(2360, L"SOCKS credentials cannot be encoded within the 255-byte limit");
+            goto on_error;
+        }
 
         size_t auth_buf_len = 1 + 1 + login_len + 1 + pass_len;
         char* auth_buf = Dll_AllocTemp(auth_buf_len);
@@ -130,7 +177,7 @@ _FX BOOLEAN socks5_handshake(SOCKET s, BOOLEAN auth, WCHAR login[SOCKS_AUTH_MAX_
         memcpy(auth_buf + offset, p, pass_len);
         offset += pass_len;
 
-        if (__sys_send(s, auth_buf, auth_buf_len , 0) != auth_buf_len) {
+        if (!socks5_send_all(s, auth_buf, auth_buf_len)) {
             Dll_Free(auth_buf);
             goto on_error;
         }
@@ -167,7 +214,7 @@ on_error:
 
 static char socks5_request_send(SOCKET s, char* buf, size_t size)
 {
-    if (__sys_send(s, buf, size, 0) != size)
+    if (!socks5_send_all(s, buf, size))
         return SOCKS_GENERAL_FAILURE;
 
     char res[SOCKS_RESPONSE_MAX_SIZE] = { 0 };
@@ -331,8 +378,8 @@ typedef struct {
         SOCKADDR_IN6_LH proxy6;
     };
     BOOLEAN auth;
-    WCHAR login[SOCKS_AUTH_MAX_SIZE];
-    WCHAR pass[SOCKS_AUTH_MAX_SIZE];
+    WCHAR login[SOCKS_AUTH_BUFFER_SIZE];
+    WCHAR pass[SOCKS_AUTH_BUFFER_SIZE];
 } RELAY_CONFIG,* PRELAY_CONFIG;
 
 
@@ -453,7 +500,7 @@ DWORD WINAPI proxy_handle_relay(LPVOID param)
 // start_socks5_relay
 //---------------------------------------------------------------------------
 
-USHORT start_socks5_relay(const SOCKADDR* addr, const SOCKADDR* proxy, BOOLEAN auth, WCHAR login[SOCKS_AUTH_MAX_SIZE], WCHAR pass[SOCKS_AUTH_MAX_SIZE])
+USHORT start_socks5_relay(const SOCKADDR* addr, const SOCKADDR* proxy, BOOLEAN auth, WCHAR login[SOCKS_AUTH_BUFFER_SIZE], WCHAR pass[SOCKS_AUTH_BUFFER_SIZE])
 {
     PRELAY_CONFIG relay_config = Dll_Alloc(sizeof(RELAY_CONFIG));
     if (!relay_config)
@@ -475,8 +522,8 @@ USHORT start_socks5_relay(const SOCKADDR* addr, const SOCKADDR* proxy, BOOLEAN a
 
     relay_config->auth = auth;
     if (auth) {
-        wcscpy_s(relay_config->login, SOCKS_AUTH_MAX_SIZE, login);
-        wcscpy_s(relay_config->pass, SOCKS_AUTH_MAX_SIZE, pass);
+        wcscpy_s(relay_config->login, SOCKS_AUTH_BUFFER_SIZE, login);
+        wcscpy_s(relay_config->pass, SOCKS_AUTH_BUFFER_SIZE, pass);
     }
 
     relay_config->listen_sock = __sys_socket(addr->sa_family, SOCK_STREAM, IPPROTO_TCP);


### PR DESCRIPTION
Harden proxy credential handling by validating/decrypting EncryptedPW safely, enforcing decoded length/base64 checks, and ensuring login/password buffers are always null-terminated with consistent 256-wide storage. In the SOCKS5 relay path, replace single send assumptions with send-all writes, switch credential conversion to explicit WideCharToMultiByte handling to avoid locale-dependent failures, and reject credentials that cannot be encoded within the 255-byte protocol limit.
