### PR TITLE
Add file access control to NewBoxWizard

### DIFF
--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -2921,95 +2921,36 @@ Enabling this option uses a LOW integrity token instead, which may improve compa
              <property name="bottomMargin">
               <number>3</number>
              </property>
-             <item row="0" column="0">
-              <layout class="QGridLayout" name="gridLayout_67">
-               <item row="3" column="1">
-                <widget class="QCheckBox" name="chkShowFilesTmpl">
-                 <property name="text">
-                  <string>Show Templates</string>
+<item row="0" column="0">
+               <widget class="QWidget" name="wFileAccess">
+                <layout class="QGridLayout" name="gridLayout_67">
+                 <property name="leftMargin">
+                  <number>0</number>
                  </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QPushButton" name="btnDelFile">
-                 <property name="text">
-                  <string>Remove</string>
+                 <property name="topMargin">
+                  <number>0</number>
                  </property>
-                </widget>
-               </item>
-               <item row="1" column="0" rowspan="4">
-                <widget class="QTreeWidget" name="treeFiles">
-                 <property name="sortingEnabled">
-                  <bool>true</bool>
+                 <property name="rightMargin">
+                  <number>0</number>
                  </property>
-                 <column>
-                  <property name="text">
-                   <string>Type</string>
-                  </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Program</string>
-                  </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Access</string>
-                  </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Path</string>
-                  </property>
-                 </column>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QToolButton" name="btnAddFile">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
+                 <property name="bottomMargin">
+                  <number>0</number>
                  </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>23</height>
-                  </size>
-                 </property>
-                 <property name="text">
-                  <string>Add File/Folder</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <spacer name="verticalSpacer_11">
-                 <property name="orientation">
-                  <enum>Qt::Orientation::Vertical</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>40</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_7">
-                 <property name="text">
-                  <string>Configure which processes can access Files, Folders and Pipes. 
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_7">
+                   <property name="text">
+                    <string>Configure which processes can access Files, Folders and Pipes. 
 'Open' access only applies to program binaries located outside the sandbox, you can use 'Open for All' instead to make it apply to all programs, or change this behavior in the Policies tab.</string>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
            </widget>
            <widget class="QWidget" name="tabKeys">
             <attribute name="title">
@@ -6449,10 +6390,6 @@ Please note that this values are currently user specific and saved globally for 
   <tabstop>chkStartBlockMsg</tabstop>
   <tabstop>chkAlertBeforeStart</tabstop>
   <tabstop>tabsAccess</tabstop>
-  <tabstop>treeFiles</tabstop>
-  <tabstop>btnAddFile</tabstop>
-  <tabstop>chkShowFilesTmpl</tabstop>
-  <tabstop>btnDelFile</tabstop>
   <tabstop>treeKeys</tabstop>
   <tabstop>btnAddKey</tabstop>
   <tabstop>chkShowKeysTmpl</tabstop>

--- a/SandboxiePlus/SandMan/SandMan.pri
+++ b/SandboxiePlus/SandMan/SandMan.pri
@@ -33,6 +33,7 @@ HEADERS += ./stdafx.h \
     ./Windows/SnapshotsWindow.h \
     ./Windows/SettingsWindow.h \
     ./Windows/OptionsWindow.h \
+    ./Windows/SharedAccessWidget.h \
     ./Windows/PendingChanges.h \
     ./Windows/EditorSettingsWindow.h \
     ./Windows/SelectBoxWindow.h \
@@ -40,6 +41,7 @@ HEADERS += ./stdafx.h \
     ./Windows/TestProxyDialog.h \
     ./OnlineUpdater.h \
     ./Wizards/NewBoxWizard.h \
+    ./Wizards/AccessControlWidget.h \
     ./Wizards/TemplateWizard.h \
     ./Wizards/SetupWizard.h \
     ./Wizards/BoxAssistant.h \
@@ -89,6 +91,7 @@ SOURCES += ./main.cpp \
     ./Helpers/TabOrder.cpp \
     ./Helpers/MiniDumpFilter.cpp \
     ./Windows/OptionsWindow.cpp \
+    ./Windows/SharedAccessWidget.cpp \
     ./Windows/EditorSettingsWindow.cpp \
     ./Windows/PopUpWindow.cpp \
     ./Windows/RecoveryWindow.cpp \
@@ -99,6 +102,7 @@ SOURCES += ./main.cpp \
     ./Windows/TestProxyDialog.cpp \
     ./OnlineUpdater.cpp \
     ./Wizards/NewBoxWizard.cpp \
+    ./Wizards/AccessControlWidget.cpp \
     ./Wizards/TemplateWizard.cpp \
     ./Wizards/SetupWizard.cpp \
     ./Wizards/BoxAssistant.cpp \

--- a/SandboxiePlus/SandMan/SandMan.pri
+++ b/SandboxiePlus/SandMan/SandMan.pri
@@ -41,7 +41,6 @@ HEADERS += ./stdafx.h \
     ./Windows/TestProxyDialog.h \
     ./OnlineUpdater.h \
     ./Wizards/NewBoxWizard.h \
-    ./Wizards/AccessControlWidget.h \
     ./Wizards/TemplateWizard.h \
     ./Wizards/SetupWizard.h \
     ./Wizards/BoxAssistant.h \
@@ -102,7 +101,6 @@ SOURCES += ./main.cpp \
     ./Windows/TestProxyDialog.cpp \
     ./OnlineUpdater.cpp \
     ./Wizards/NewBoxWizard.cpp \
-    ./Wizards/AccessControlWidget.cpp \
     ./Wizards/TemplateWizard.cpp \
     ./Wizards/SetupWizard.cpp \
     ./Wizards/BoxAssistant.cpp \

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -478,6 +478,20 @@
       <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Release|x64'">input</DynamicSource>
       <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Filename).moc</QtMocFileName>
     </ClCompile>
+    <ClCompile Include="Windows\SharedAccessWidget.cpp">
+      <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">input</DynamicSource>
+      <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">%(Filename).moc</QtMocFileName>
+      <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">input</DynamicSource>
+      <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(Filename).moc</QtMocFileName>
+      <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">input</DynamicSource>
+      <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(Filename).moc</QtMocFileName>
+      <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">input</DynamicSource>
+      <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(Filename).moc</QtMocFileName>
+      <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">input</DynamicSource>
+      <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">%(Filename).moc</QtMocFileName>
+      <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Release|x64'">input</DynamicSource>
+      <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(Filename).moc</QtMocFileName>
+    </ClCompile>
     <ClCompile Include="Windows\EditorSettingsWindow.cpp">
       <DynamicSource Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">input</DynamicSource>
       <QtMocFileName Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">%(Filename).moc</QtMocFileName>
@@ -501,6 +515,7 @@
     <ClCompile Include="Windows\SupportDialog.cpp" />
     <ClCompile Include="Wizards\BoxAssistant.cpp" />
     <ClCompile Include="Wizards\NewBoxWizard.cpp" />
+    <ClCompile Include="Wizards\AccessControlWidget.cpp" />
     <ClCompile Include="Wizards\SetupWizard.cpp" />
     <ClCompile Include="Wizards\TemplateWizard.cpp" />
     <ClCompile Include="Windows\TestProxyDialog.cpp" />
@@ -516,6 +531,7 @@
     <QtMoc Include="Views\StackView.h" />
     <QtMoc Include="Wizards\TemplateWizard.h" />
     <QtMoc Include="Wizards\NewBoxWizard.h" />
+    <QtMoc Include="Wizards\AccessControlWidget.h" />
     <QtMoc Include="OnlineUpdater.h" />
     <QtMoc Include="Views\FileView.h" />
     <QtMoc Include="Windows\SupportDialog.h" />
@@ -528,6 +544,7 @@
     <QtMoc Include="Windows\SnapshotsWindow.h" />
     <QtMoc Include="Windows\SettingsWindow.h" />
     <QtMoc Include="Windows\OptionsWindow.h" />
+    <QtMoc Include="Windows\SharedAccessWidget.h" />
     <QtMoc Include="Windows\EditorSettingsWindow.h" />
     <QtMoc Include="Views\SbieView.h" />
     <QtMoc Include="SandMan.h" />

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -515,7 +515,6 @@
     <ClCompile Include="Windows\SupportDialog.cpp" />
     <ClCompile Include="Wizards\BoxAssistant.cpp" />
     <ClCompile Include="Wizards\NewBoxWizard.cpp" />
-    <ClCompile Include="Wizards\AccessControlWidget.cpp" />
     <ClCompile Include="Wizards\SetupWizard.cpp" />
     <ClCompile Include="Wizards\TemplateWizard.cpp" />
     <ClCompile Include="Windows\TestProxyDialog.cpp" />
@@ -531,7 +530,6 @@
     <QtMoc Include="Views\StackView.h" />
     <QtMoc Include="Wizards\TemplateWizard.h" />
     <QtMoc Include="Wizards\NewBoxWizard.h" />
-    <QtMoc Include="Wizards\AccessControlWidget.h" />
     <QtMoc Include="OnlineUpdater.h" />
     <QtMoc Include="Views\FileView.h" />
     <QtMoc Include="Windows\SupportDialog.h" />

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -180,9 +180,6 @@
     <ClCompile Include="Wizards\NewBoxWizard.cpp">
       <Filter>Wizards</Filter>
     </ClCompile>
-    <ClCompile Include="Wizards\AccessControlWidget.cpp">
-      <Filter>Wizards</Filter>
-    </ClCompile>
     <ClCompile Include="Helpers\StorageInfo.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
@@ -385,9 +382,6 @@
       <Filter>SandMan</Filter>
     </QtMoc>
     <QtMoc Include="Wizards\NewBoxWizard.h">
-      <Filter>Wizards</Filter>
-    </QtMoc>
-    <QtMoc Include="Wizards\AccessControlWidget.h">
       <Filter>Wizards</Filter>
     </QtMoc>
     <QtMoc Include="Wizards\TemplateWizard.h">

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClCompile Include="Wizards\NewBoxWizard.cpp">
       <Filter>Wizards</Filter>
     </ClCompile>
+    <ClCompile Include="Wizards\AccessControlWidget.cpp">
+      <Filter>Wizards</Filter>
+    </ClCompile>
     <ClCompile Include="Helpers\StorageInfo.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
@@ -245,6 +248,9 @@
     </ClCompile>
 
     <ClCompile Include="Windows\OptionsWindow.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\SharedAccessWidget.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Helpers\IniHighlighter.cpp">
@@ -329,6 +335,9 @@
     <QtMoc Include="Windows\OptionsWindow.h">
       <Filter>Windows</Filter>
     </QtMoc>
+    <QtMoc Include="Windows\SharedAccessWidget.h">
+      <Filter>Windows</Filter>
+    </QtMoc>
     <QtMoc Include="Windows\SettingsWindow.h">
       <Filter>Windows</Filter>
     </QtMoc>
@@ -376,6 +385,9 @@
       <Filter>SandMan</Filter>
     </QtMoc>
     <QtMoc Include="Wizards\NewBoxWizard.h">
+      <Filter>Wizards</Filter>
+    </QtMoc>
+    <QtMoc Include="Wizards\AccessControlWidget.h">
       <Filter>Wizards</Filter>
     </QtMoc>
     <QtMoc Include="Wizards\TemplateWizard.h">

--- a/SandboxiePlus/SandMan/Windows/OptionsAccess.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAccess.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "OptionsWindow.h"
+#include "SharedAccessWidget.h"
 #include "SandMan.h"
 #include "SettingsWindow.h"
 #include "../MiscHelpers/Common/Settings.h"
@@ -21,14 +22,21 @@ void COptionsWindow::CreateAccess()
 	connect(ui.chkNoOpenForBox, SIGNAL(clicked(bool)), this, SLOT(OnAccessChangedEx()));
 	//
 
-	connect(ui.btnAddFile, SIGNAL(clicked(bool)), this, SLOT(OnAddFile()));
-	QMenu* pFileBtnMenu = new QMenu(ui.btnAddFile);
-	pFileBtnMenu->addAction(tr("Browse for File"), this, SLOT(OnBrowseFile()));
-	pFileBtnMenu->addAction(tr("Browse for Folder"), this, SLOT(OnBrowseFolder()));
-	ui.btnAddFile->setPopupMode(QToolButton::MenuButtonPopup);
-	ui.btnAddFile->setMenu(pFileBtnMenu);
-	connect(ui.chkShowFilesTmpl, SIGNAL(clicked(bool)), this, SLOT(OnShowFilesTmpl()));
-	connect(ui.btnDelFile, SIGNAL(clicked(bool)), this, SLOT(OnDelFile()));
+	m_FileAccess = new CSharedFileWidget(ui.wFileAccess);
+	((QGridLayout*)ui.wFileAccess->layout())->addWidget(m_FileAccess, 1, 0);
+	((QGridLayout*)ui.wFileAccess->layout())->setRowStretch(1, 1);
+	m_FileAccess->GetTree()->setObjectName("treeFiles");
+	m_FileAccess->SetConfig(m_pBox, m_Template);
+	if (m_Template)
+		m_FileAccess->SetTemplatesEnabled(false);
+	m_FileAccess->SetGroupsProvider([this]() -> QStringList { return GetCurrentGroups(); });
+	m_FileAccess->SetPrograms(m_Programs);
+	m_FileAccess->SetPathExpander([this](const QString& Path) { return ExpandPath(eFile, Path); });
+	connect(m_FileAccess, &CSharedAccessWidget::Changed, this, [this]() {
+		m_Programs.unite(m_FileAccess->GetPrograms());
+		OnAccessChanged();
+	});
+
 	connect(ui.btnAddKey, SIGNAL(clicked(bool)), this, SLOT(OnAddKey()));
 	connect(ui.chkShowKeysTmpl, SIGNAL(clicked(bool)), this, SLOT(OnShowKeysTmpl()));
 	connect(ui.btnDelKey, SIGNAL(clicked(bool)), this, SLOT(OnDelKey()));
@@ -44,7 +52,7 @@ void COptionsWindow::CreateAccess()
 	//connect(ui.chkShowAccessTmpl, SIGNAL(clicked(bool)), this, SLOT(OnShowAccessTmpl()));
 	//connect(ui.btnDelAccess, SIGNAL(clicked(bool)), this, SLOT(OnDelAccess()));
 
-	QTreeWidget* pTrees[] = { ui.treeFiles, ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
+	QTreeWidget* pTrees[] = { ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
 	for (QTreeWidget** pTree = pTrees; *pTree; pTree++) {
 		//connect(*pTree, SIGNAL(itemClicked(QTreeWidgetItem*, int)), this, SLOT(OnAccessItemClicked(QTreeWidgetItem*, int)));
 		connect(*pTree, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(OnAccessItemDoubleClicked(QTreeWidgetItem*, int)));
@@ -168,12 +176,17 @@ void COptionsWindow::LoadAccessList()
 	ui.chkCloseForBox->setChecked(m_pBox->GetBool("AlwaysCloseForBoxed", true));
 	ui.chkNoOpenForBox->setChecked(m_pBox->GetBool("DontOpenForBoxed", true));
 
-	QTreeWidget* pTrees[] = { ui.treeFiles, ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
+	QTreeWidget* pTrees[] = { ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
 	for (QTreeWidget** pTree = pTrees; *pTree; pTree++)
 		(*pTree )->clear();
 
+	// File access entries are managed by the shared widget
 	for (int i = 0; i < eMaxAccessEntry; i++)
 	{
+		QPair<EAccessType, EAccessMode> Type = SplitAccessType((EAccessEntry)i);
+		if (Type.first == eFile)
+			continue;
+
 		foreach(const QString& Value, m_pBox->GetTextList(AccessTypeToName((EAccessEntry)i), m_Template))
 			ParseAndAddAccessEntry((EAccessEntry)i, Value);
 
@@ -183,6 +196,9 @@ void COptionsWindow::LoadAccessList()
 
 	LoadAccessListTmpl();
 
+	m_FileAccess->LoadAccessList();
+	m_Programs.unite(m_FileAccess->GetPrograms());
+
 	UpdateAccessPolicy();
 
 	m_AccessChanged = false;
@@ -191,10 +207,11 @@ void COptionsWindow::LoadAccessList()
 void COptionsWindow::LoadAccessListTmpl(bool bUpdate)
 {
 	for (int i = 0; i < eMaxAccessType; i++) {
+		if (i == eFile)
+			continue; // handled by the shared widget
 		QCheckBox* pCheck = NULL;
 		switch (i)
 		{
-		case eFile:	pCheck = ui.chkShowFilesTmpl; break;
 		case eKey:	pCheck = ui.chkShowKeysTmpl; break;
 		case eIPC:	pCheck = ui.chkShowIPCTmpl; break;
 		case eWnd:	pCheck = ui.chkShowWndTmpl; break;
@@ -209,7 +226,7 @@ QTreeWidget* COptionsWindow::GetAccessTree(EAccessType Type)
 	QTreeWidget* pTree = NULL;
 	switch (Type)
 	{
-	case eFile:	pTree = ui.treeFiles; break;
+	case eFile:	pTree = m_FileAccess ? m_FileAccess->GetTree() : NULL; break;
 	case eKey:	pTree = ui.treeKeys; break;
 	case eIPC:	pTree = ui.treeIPC; break;
 	case eWnd:	pTree = ui.treeWnd; break;
@@ -364,32 +381,6 @@ QString COptionsWindow::GetAccessTypeStr(EAccessType Type)
 	return tr("Unknown");
 }
 
-void COptionsWindow::OnBrowseFile()
-{
-	QString Value = QFileDialog::getOpenFileName(this, tr("Select File"), "", tr("All Files (*.*)")).replace("/", "\\");
-	if (Value.isEmpty())
-		return;
-
-	AddAccessEntry(eFile, eOpen, "", Value);
-
-	OnAccessChanged();
-}
-
-void COptionsWindow::OnBrowseFolder()
-{
-	QString Value = QFileDialog::getExistingDirectory(this, tr("Select Directory")).replace("/", "\\");
-	if (Value.isEmpty())
-		return;
-
-	// Add a trailing backslash if it does not exist
-	if (!Value.endsWith("\\"))
-		Value.append("\\");
-
-	AddAccessEntry(eFile, eOpen, "", Value);
-
-	OnAccessChanged();
-}
-
 QString COptionsWindow::ExpandPath(EAccessType Type, const QString& Path)
 {
 	QString sPath = Path;
@@ -507,7 +498,10 @@ QString COptionsWindow::MakeAccessStr(EAccessType Type, EAccessMode Mode)
 
 void COptionsWindow::CloseAccessEdit(bool bSave)
 {
-	QTreeWidget* pTrees[] = { ui.treeFiles, ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
+	if (m_FileAccess)
+		m_FileAccess->CloseAccessEdit(bSave);
+
+	QTreeWidget* pTrees[] = { ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
 	for (QTreeWidget** pTree = pTrees; *pTree; pTree++) {
 		for (int i = 0; i < (*pTree)->topLevelItemCount(); i++)
 		{
@@ -710,8 +704,10 @@ void COptionsWindow::SaveAccessList()
 
 	CloseAccessEdit(true);
 
+	m_FileAccess->CloseAccessEdit(true);
+	m_FileAccess->SaveAccessList();
+
 	QStringList Keys = QStringList() 
-		<< "NormalFilePath" << "OpenFilePath" << "OpenPipePath" << "ClosedFilePath" << "ReadFilePath" << "WriteFilePath"
 		<< "NormalKeyPath" << "OpenKeyPath" << "OpenConfPath" << "ClosedKeyPath" << "ReadKeyPath" << "WriteKeyPath"
 		<< "NormalIpcPath"<< "OpenIpcPath" << "ClosedIpcPath" << "ReadIpcPath" 
 		<< "OpenWinClass" << "NoRenameWinClass"
@@ -720,7 +716,7 @@ void COptionsWindow::SaveAccessList()
 	QMap<QString, QList<QString>> AccessMap;
 
 
-	QTreeWidget* pTrees[] = { ui.treeFiles, ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
+	QTreeWidget* pTrees[] = { ui.treeKeys , ui.treeIPC, ui.treeWnd, ui.treeCOM, NULL};
 	for (QTreeWidget** pTree = pTrees; *pTree; pTree++)
 	{
 		for (int i = 0; i < (*pTree)->topLevelItemCount(); i++)

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -524,7 +524,6 @@ COptionsWindow::COptionsWindow(const QSharedPointer<CSbieIni>& pBox, const QStri
 		ui.chkShowStopTmpl->setEnabled(false);
 		ui.chkShowLeaderTmpl->setEnabled(false);
 		ui.chkShowStartTmpl->setEnabled(false);
-		ui.chkShowFilesTmpl->setEnabled(false);
 		ui.chkShowKeysTmpl->setEnabled(false);
 		ui.chkShowIPCTmpl->setEnabled(false);
 		ui.chkShowWndTmpl->setEnabled(false);
@@ -713,7 +712,6 @@ COptionsWindow::COptionsWindow(const QSharedPointer<CSbieIni>& pBox, const QStri
 	ui.treeNetFw->viewport()->installEventFilter(this);
 	ui.treeDns->viewport()->installEventFilter(this);
 	ui.treeProxy->viewport()->installEventFilter(this);
-	ui.treeFiles->viewport()->installEventFilter(this);
 	ui.treeKeys->viewport()->installEventFilter(this);
 	ui.treeIPC->viewport()->installEventFilter(this);
 	ui.treeWnd->viewport()->installEventFilter(this);
@@ -854,7 +852,7 @@ bool COptionsWindow::eventFilter(QObject *source, QEvent *event)
 		&& (source == ui.treeCopy->viewport()
 			|| source == ui.treeINet->viewport() || source == ui.treeNetFw->viewport() 
 			// || source == ui.treeAccess->viewport()
-			|| source == ui.treeFiles->viewport() || source == ui.treeKeys->viewport() || source == ui.treeIPC->viewport() || source == ui.treeWnd->viewport() || source == ui.treeCOM->viewport() 
+			|| source == ui.treeKeys->viewport() || source == ui.treeIPC->viewport() || source == ui.treeWnd->viewport() || source == ui.treeCOM->viewport() 
 			|| (ui.treeOptions && source == ui.treeOptions->viewport())))
 	{
 		CloseCopyEdit(false);
@@ -900,7 +898,6 @@ bool COptionsWindow::eventFilter(QObject *source, QEvent *event)
 		else if (isTreeViewport(ui.treeNetFw))		OnDelNetFwRule();
 		else if (isTreeViewport(ui.treeDns))			OnDelDnsFilter();
 		else if (isTreeViewport(ui.treeProxy))		OnDelNetProxy();
-		else if (isTreeViewport(ui.treeFiles))		OnDelFile();
 		else if (isTreeViewport(ui.treeKeys))			OnDelKey();
 		else if (isTreeViewport(ui.treeIPC))			OnDelIPC();
 		else if (isTreeViewport(ui.treeWnd))			OnDelWnd();
@@ -939,7 +936,7 @@ bool COptionsWindow::eventFilter(QObject *source, QEvent *event)
 	}
 
 	if (//source == ui.treeAccess->viewport() 
-		(source == ui.treeFiles->viewport() || source == ui.treeKeys->viewport() || source == ui.treeIPC->viewport() || source == ui.treeWnd->viewport() || source == ui.treeCOM->viewport())
+		(source == ui.treeKeys->viewport() || source == ui.treeIPC->viewport() || source == ui.treeWnd->viewport() || source == ui.treeCOM->viewport())
 		&& event->type() == QEvent::MouseButtonPress)
 	{
 		CloseAccessEdit();

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -6,6 +6,9 @@
 #include "PendingChanges.h"
 #include "../../MiscHelpers/Common/SettingsWidgets.h"
 
+class CSbieIni;
+class CSharedFileWidget;
+
 //////////////////////////////////////////////////////////////////////////
 // COptionsWindow
 
@@ -174,11 +177,6 @@ private slots:
 	void OnAccessSelectionChanged() { CloseAccessEdit(); OnOptChanged();}
 	void OnAccessChanged(QTreeWidgetItem* pItem, int Column);
 
-	void OnAddFile()				{ AddAccessEntry(eFile, eOpen, "", ""); OnAccessChanged(); }
-	void OnBrowseFile();
-	void OnBrowseFolder();
-	void OnDelFile()				{ DeleteAccessEntry(ui.treeFiles->currentItem()); OnAccessChanged(); }
-	void OnShowFilesTmpl()			{ LoadAccessListTmpl(eFile, ui.chkShowFilesTmpl->isChecked(), true); }
 	void OnAddKey()					{ AddAccessEntry(eKey, eOpen, "", ""); OnAccessChanged(); }
 	void OnDelKey()					{ DeleteAccessEntry(ui.treeKeys->currentItem()); OnAccessChanged(); }
 	void OnShowKeysTmpl()			{ LoadAccessListTmpl(eKey, ui.chkShowKeysTmpl->isChecked(), true); }
@@ -625,6 +623,8 @@ protected:
 	QSharedPointer<CSbieIni> m_pBox;
 
 	QSet<QString> m_Programs;
+
+	CSharedFileWidget* m_FileAccess;
 
 	enum EProcCpec {
 		eNoSpec,

--- a/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
+++ b/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
@@ -133,7 +133,7 @@ void CSharedAccessWidget::ClearEntries()
 	m_pTree->clear();
 }
 
-void CSharedAccessWidget::AddEntry(eAccessMode::EAccessMode Mode, QString Program, const QString& Path, bool Enabled, const QString& Template)
+void CSharedAccessWidget::AddEntry(eAccessMode::EAccessMode Mode, const QString& Program, const QString& Path, bool Enabled, const QString& Template)
 {
 	QTreeWidgetItem* pItem = new QTreeWidgetItem();
 
@@ -142,16 +142,17 @@ void CSharedAccessWidget::AddEntry(eAccessMode::EAccessMode Mode, QString Progra
 	pItem->setData(0, Qt::UserRole, !Template.isEmpty() ? -1 : GetAccessTypeId());
 
 	// column 1: program
-	bool bAll = Program.isEmpty();
-	bool Not = !bAll && Program.left(1) == "!";
+	QString ProgramDisp = Program;
+	bool bAll = ProgramDisp.isEmpty();
+	bool Not = !bAll && ProgramDisp.left(1) == "!";
 	if (Not)
-		Program.remove(0, 1);
-	if (Program.left(1) == "<")
-		Program = tr("Group: %1").arg(Program.mid(1, Program.length() - 2));
+		ProgramDisp.remove(0, 1);
+	if (ProgramDisp.left(1) == "<")
+		ProgramDisp = tr("Group: %1").arg(ProgramDisp.mid(1, ProgramDisp.length() - 2));
 	else if (!bAll)
-		m_Programs.insert(Program);
-	pItem->setText(1, (Not ? "NOT " : "") + (bAll ? tr("All Programs") : Program));
-	pItem->setData(1, Qt::UserRole, (Not ? "!" : "") + (bAll ? "" : Program));
+		m_Programs.insert(ProgramDisp);
+	pItem->setText(1, (Not ? "NOT " : "") + (bAll ? tr("All Programs") : ProgramDisp));
+	pItem->setData(1, Qt::UserRole, (Not ? "!" : "") + (bAll ? "" : ProgramDisp));
 
 	// column 2: access mode
 	QString ModeStr, ModeTip;
@@ -538,7 +539,7 @@ CSharedFileWidget::CSharedFileWidget(QWidget* parent)
 	FillAddMenu();
 }
 
-QList<SAccessEntryConfig> CSharedFileWidget::GetAccessConfig()
+QList<SAccessEntryConfig> CSharedFileWidget::GetAccessConfig() const
 {
 	QList<SAccessEntryConfig> Config;
 

--- a/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
+++ b/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
@@ -1,0 +1,627 @@
+#include "stdafx.h"
+
+#include "SharedAccessWidget.h"
+
+#include "../../QSbieAPI/SbieIni.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QTreeWidget>
+#include <QHeaderView>
+#include <QCheckBox>
+#include <QToolButton>
+#include <QMenu>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QFileDialog>
+#include <QMessageBox>
+#include <QKeyEvent>
+
+
+QTreeWidget* CSharedAccessWidget::CreateListWidget()
+{
+	QTreeWidget* pTree = new QTreeWidget(this);
+	pTree->setHeaderLabels(QStringList() << tr("Type") << tr("Program") << tr("Access") << tr("Path"));
+	pTree->header()->setStretchLastSection(false);
+	pTree->header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+	pTree->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+	pTree->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+	pTree->header()->setSectionResizeMode(3, QHeaderView::Stretch);
+	pTree->setRootIsDecorated(false);
+	pTree->setAlternatingRowColors(false);
+	pTree->setSortingEnabled(true);
+	return pTree;
+}
+
+QToolButton* CSharedAccessWidget::CreateAddButton()
+{
+	QToolButton* pButton = new QToolButton(this);
+	pButton->setText(tr("Add"));
+	pButton->setPopupMode(QToolButton::MenuButtonPopup);
+	pButton->setMenu(new QMenu(pButton)); // gets filled by FillAddMenu()
+	return pButton;
+}
+
+CSharedAccessWidget::CSharedAccessWidget(QWidget* parent)
+	: QWidget(parent)
+	, m_pTree(NULL)
+	, m_pShowTemplates(NULL)
+	, m_pAddButton(NULL)
+	, m_pRemoveButton(NULL)
+	, m_bTemplate(false)
+{
+	QVBoxLayout* pLayout = new QVBoxLayout();
+	pLayout->setContentsMargins(0, 0, 0, 0);
+
+	m_pTree = CreateListWidget();
+	m_pTree->viewport()->installEventFilter(this);
+	pLayout->addWidget(m_pTree);
+
+	QHBoxLayout* pToolbar = new QHBoxLayout();
+	pToolbar->setContentsMargins(0, 2, 0, 0);
+
+	m_pShowTemplates = new QCheckBox(tr("Show Templates"), this);
+	pToolbar->addWidget(m_pShowTemplates);
+	pToolbar->addStretch(1);
+
+	m_pAddButton = CreateAddButton();
+	pToolbar->addWidget(m_pAddButton);
+
+	m_pRemoveButton = new QToolButton(this);
+	m_pRemoveButton->setText(tr("Remove"));
+	pToolbar->addWidget(m_pRemoveButton);
+
+	pLayout->addLayout(pToolbar);
+
+	setLayout(pLayout);
+
+	FillAddMenu();
+
+	connect(m_pTree, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(OnItemDoubleClicked(QTreeWidgetItem*, int)));
+	connect(m_pTree, SIGNAL(itemSelectionChanged()), this, SLOT(OnSelectionChanged()));
+	connect(m_pTree, SIGNAL(itemChanged(QTreeWidgetItem*, int)), this, SLOT(OnItemChanged(QTreeWidgetItem*, int)));
+	connect(m_pAddButton, SIGNAL(clicked(bool)), this, SLOT(OnAdd()));
+	connect(m_pRemoveButton, SIGNAL(clicked(bool)), this, SLOT(OnDel()));
+	connect(m_pShowTemplates, SIGNAL(toggled(bool)), this, SLOT(OnChangeTemplates()));
+}
+
+CSharedAccessWidget::~CSharedAccessWidget()
+{
+}
+
+void CSharedAccessWidget::FillAddMenu()
+{
+}
+
+void CSharedAccessWidget::SetConfig(const QSharedPointer<CSbieIni>& pIni, bool bTemplate)
+{
+	m_pIni = pIni;
+	m_bTemplate = bTemplate;
+}
+
+void CSharedAccessWidget::SetTemplatesEnabled(bool bEnabled)
+{
+	m_pShowTemplates->setEnabled(bEnabled);
+}
+
+void CSharedAccessWidget::SetShowTemplates(bool bShow)
+{
+	m_pShowTemplates->setChecked(bShow);
+	OnChangeTemplates();
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+QString CSharedAccessWidget::GetSettingName(eAccessMode::EAccessMode Mode) const
+{
+	foreach(const SAccessEntryConfig& Config, GetAccessConfig())
+		if (Config.Mode == Mode)
+			return Config.Setting;
+	return "";
+}
+
+eAccessMode::EAccessMode CSharedAccessWidget::GetModeFromSetting(const QString& Setting) const
+{
+	foreach(const SAccessEntryConfig& Config, GetAccessConfig())
+		if (Config.Setting.compare(Setting, Qt::CaseInsensitive) == 0)
+			return Config.Mode;
+	return eAccessMode::eMaxMode;
+}
+
+void CSharedAccessWidget::ClearEntries()
+{
+	m_pTree->clear();
+}
+
+void CSharedAccessWidget::AddEntry(eAccessMode::EAccessMode Mode, QString Program, const QString& Path, bool Enabled, const QString& Template)
+{
+	QTreeWidgetItem* pItem = new QTreeWidgetItem();
+
+	// column 0: type
+	pItem->setText(0, GetAccessTypeStr() + (Template.isEmpty() ? "" : " (" + Template + ")"));
+	pItem->setData(0, Qt::UserRole, !Template.isEmpty() ? -1 : GetAccessTypeId());
+
+	// column 1: program
+	bool bAll = Program.isEmpty();
+	bool Not = !bAll && Program.left(1) == "!";
+	if (Not)
+		Program.remove(0, 1);
+	if (Program.left(1) == "<")
+		Program = tr("Group: %1").arg(Program.mid(1, Program.length() - 2));
+	else if (!bAll)
+		m_Programs.insert(Program);
+	pItem->setText(1, (Not ? "NOT " : "") + (bAll ? tr("All Programs") : Program));
+	pItem->setData(1, Qt::UserRole, (Not ? "!" : "") + (bAll ? "" : Program));
+
+	// column 2: access mode
+	QString ModeStr, ModeTip;
+	foreach(const SAccessEntryConfig& Config, GetAccessConfig())
+		if (Config.Mode == Mode) {
+			ModeStr = Config.ModeName;
+			ModeTip = Config.ModeTip;
+			break;
+		}
+	pItem->setText(2, ModeStr);
+	pItem->setData(2, Qt::UserRole, (int)Mode);
+	if (!ModeTip.isEmpty())
+		pItem->setToolTip(2, ModeTip);
+
+	// column 3: path
+	pItem->setText(3, ExpandPath(Path));
+	pItem->setData(3, Qt::UserRole, Path);
+
+	if (Template.isEmpty())
+		pItem->setCheckState(0, Enabled ? Qt::Checked : Qt::Unchecked);
+
+	m_pTree->addTopLevelItem(pItem);
+}
+
+void CSharedAccessWidget::ParseAndAddEntry(const QString& Setting, const QString& Value, bool disabled, const QString& Template)
+{
+	eAccessMode::EAccessMode Mode = GetModeFromSetting(Setting);
+	if (Mode == eAccessMode::eMaxMode)
+		return;
+
+	QStringList Values = Value.split(",");
+
+	if (Values.count() >= 2)
+		AddEntry(Mode, Values[0], Values[1], !disabled, Template);
+	else if (Values.count() == 1)
+		AddEntry(Mode, "", Values[0], !disabled, Template);
+}
+
+void CSharedAccessWidget::LoadAccessList()
+{
+	ClearEntries();
+
+	foreach(const SAccessEntryConfig& Config, GetAccessConfig())
+	{
+		foreach(const QString & Value, m_pIni->GetTextList(Config.Setting, m_bTemplate))
+			ParseAndAddEntry(Config.Setting, Value);
+
+		foreach(const QString & Value, m_pIni->GetTextList(Config.Setting + "Disabled", m_bTemplate))
+			ParseAndAddEntry(Config.Setting, Value, true);
+	}
+
+	if (m_pShowTemplates->isChecked())
+		LoadTemplates(true);
+}
+
+void CSharedAccessWidget::LoadTemplates(bool bShow)
+{
+	if (bShow)
+	{
+		foreach(const SAccessEntryConfig& Config, GetAccessConfig())
+		{
+			foreach(const QString & Template, m_pIni->GetTemplates())
+			{
+				foreach(const QString & Value, m_pIni->GetTextListTmpl(Config.Setting, Template))
+					ParseAndAddEntry(Config.Setting, Value, false, Template);
+			}
+		}
+	}
+	else
+	{
+		for (int i = 0; i < m_pTree->topLevelItemCount(); )
+		{
+			QTreeWidgetItem* pItem = m_pTree->topLevelItem(i);
+			if (pItem->data(0, Qt::UserRole).toInt() == -1)
+				delete pItem;
+			else
+				i++;
+		}
+	}
+}
+
+void CSharedAccessWidget::OnChangeTemplates()
+{
+	if (m_pShowTemplates->isChecked())
+		LoadTemplates(true);
+	else
+		LoadTemplates(false);
+	OnConfigChanged();
+}
+
+void CSharedAccessWidget::SaveAccessList()
+{
+	QStringList Keys;
+	foreach(const SAccessEntryConfig& Config, GetAccessConfig()) {
+		if (!Keys.contains(Config.Setting))
+			Keys << Config.Setting;
+	}
+
+	QMap<QString, QList<QString>> AccessMap;
+
+	for (int i = 0; i < m_pTree->topLevelItemCount(); i++)
+	{
+		QTreeWidgetItem* pItem = m_pTree->topLevelItem(i);
+
+		if (pItem->data(0, Qt::UserRole).toInt() == -1)
+			continue; // entry from template
+
+		eAccessMode::EAccessMode Mode = (eAccessMode::EAccessMode)pItem->data(2, Qt::UserRole).toInt();
+		QString Setting = GetSettingName(Mode);
+		if (Setting.isEmpty())
+			continue;
+
+		QString Program = pItem->data(1, Qt::UserRole).toString();
+		QString Value = pItem->data(3, Qt::UserRole).toString();
+		if (!Program.isEmpty())
+			Value.prepend(Program + ",");
+
+		if (pItem->checkState(0) == Qt::Unchecked)
+			Setting += "Disabled";
+		AccessMap[Setting].append(Value);
+	}
+
+	foreach(const QString & Key, Keys) {
+		m_pIni->UpdateTextList(Key, AccessMap[Key], m_bTemplate);
+		m_pIni->UpdateTextList(Key + "Disabled", AccessMap[Key + "Disabled"], m_bTemplate);
+	}
+}
+
+//////////////////////////////////////////////////////////////////// entry lookup (options integration)
+
+QTreeWidgetItem* CSharedAccessWidget::FindEntry(eAccessMode::EAccessMode Mode, const QString& Program, const QString& Path, bool bOnlyEnabled)
+{
+	for (int i = 0; i < m_pTree->topLevelItemCount(); i++)
+	{
+		QTreeWidgetItem* pItem = m_pTree->topLevelItem(i);
+		if (pItem->data(0, Qt::UserRole).toInt() == GetAccessTypeId()
+			&& pItem->data(1, Qt::UserRole).toString().compare(Program, Qt::CaseInsensitive) == 0
+			&& pItem->data(2, Qt::UserRole).toInt() == (int)Mode
+			&& pItem->data(3, Qt::UserRole).toString().compare(Path, Qt::CaseInsensitive) == 0
+			&& (!bOnlyEnabled || pItem->checkState(0) == Qt::Checked))
+			return pItem;
+	}
+	return NULL;
+}
+
+bool CSharedAccessWidget::HasEntry(int Mode, const QString& Program, const QString& Path)
+{
+	return FindEntry((eAccessMode::EAccessMode)Mode, Program, Path, true) != NULL;
+}
+
+void CSharedAccessWidget::SetEntry(int Mode, const QString& Program, const QString& Path)
+{
+	eAccessMode::EAccessMode AccessMode = (eAccessMode::EAccessMode)Mode;
+	if (FindEntry(AccessMode, Program, Path))
+		return; // already set
+	AddEntry(AccessMode, Program, Path);
+	OnConfigChanged();
+}
+
+void CSharedAccessWidget::DelEntry(int Mode, const QString& Program, const QString& Path)
+{
+	if (QTreeWidgetItem* pItem = FindEntry((eAccessMode::EAccessMode)Mode, Program, Path))
+	{
+		delete pItem;
+		OnConfigChanged();
+	}
+}
+
+///////////////////////////////////////////////////////////////////// editing
+
+void CSharedAccessWidget::OnAdd()
+{
+	AddEntry(GetDefaultMode(), "", "");
+	OnConfigChanged();
+}
+
+void CSharedAccessWidget::OnDel()
+{
+	QTreeWidgetItem* pItem = m_pTree->currentItem();
+	if (!pItem)
+		return;
+	if (pItem->data(0, Qt::UserRole).toInt() == -1) {
+		QMessageBox::warning(this, "SandboxiePlus", tr("Template values can not be removed."));
+		return;
+	}
+	delete pItem;
+	OnConfigChanged();
+}
+
+void CSharedAccessWidget::OnItemChanged(QTreeWidgetItem* pItem, int Column)
+{
+	if (Column != 0)
+		return;
+	OnConfigChanged();
+}
+
+void CSharedAccessWidget::OnSelectionChanged()
+{
+	CloseAccessEdit(false);
+	OnConfigChanged();
+}
+
+void CSharedAccessWidget::OnItemDoubleClicked(QTreeWidgetItem* pItem, int Column)
+{
+	int Type = pItem->data(0, Qt::UserRole).toInt();
+	if (Type == -1) {
+		QMessageBox::warning(this, "Sandboxie-Plus", tr("Template values can not be edited."));
+		return;
+	}
+
+	eAccessMode::EAccessMode Mode = (eAccessMode::EAccessMode)pItem->data(2, Qt::UserRole).toInt();
+
+	QString Program = pItem->data(1, Qt::UserRole).toString();
+
+	QWidget* pProgram = new QWidget();
+	pProgram->setAutoFillBackground(true);
+	QHBoxLayout* pLayout = new QHBoxLayout();
+	pLayout->setContentsMargins(0, 0, 0, 0);
+	pLayout->setSpacing(0);
+	pProgram->setLayout(pLayout);
+	QToolButton* pNot = new QToolButton(pProgram);
+	pNot->setText("!");
+	pNot->setCheckable(true);
+	if (Program.left(1) == "!") {
+		pNot->setChecked(true);
+		Program.remove(0, 1);
+	}
+	pLayout->addWidget(pNot);
+
+	QComboBox* pCombo = new QComboBox(pProgram);
+	pCombo->addItem(tr("All Programs"), "");
+
+	if (m_GetGroups) {
+		foreach (const QString & Group, m_GetGroups()) {
+			QString GroupName = Group.mid(1, Group.length() - 2);
+			pCombo->addItem(tr("Group: %1").arg(GroupName), Group);
+		}
+	}
+
+	foreach(const QString & Name, m_Programs)
+		pCombo->addItem(Name, Name);
+
+	pCombo->setEditable(true);
+	int Index = pCombo->findData(Program);
+	pCombo->setCurrentIndex(Index);
+	if (Index == -1)
+		pCombo->setCurrentText(Program);
+	pLayout->addWidget(pCombo);
+
+	m_pTree->setItemWidget(pItem, 1, pProgram);
+
+	QComboBox* pMode = new QComboBox();
+	foreach(const SAccessEntryConfig& Config, GetAccessConfig()) {
+		pMode->addItem(Config.ModeName, (int)Config.Mode);
+		pMode->setItemData(pMode->count() - 1, Config.ModeTip, Qt::ToolTipRole);
+	}
+	pMode->setCurrentIndex(pMode->findData((int)Mode));
+	m_pTree->setItemWidget(pItem, 2, pMode);
+
+	QLineEdit* pPath = new QLineEdit();
+	pPath->setText(pItem->data(3, Qt::UserRole).toString());
+	m_pTree->setItemWidget(pItem, 3, pPath);
+}
+
+void CSharedAccessWidget::CloseAccessEdit(bool bSave)
+{
+	for (int i = 0; i < m_pTree->topLevelItemCount(); i++) {
+		QTreeWidgetItem* pItem = m_pTree->topLevelItem(i);
+		CloseAccessEdit(pItem, bSave);
+	}
+}
+
+void CSharedAccessWidget::CloseAccessEdit(QTreeWidgetItem* pItem, bool bSave)
+{
+	QTreeWidget* pTree = m_pTree;
+
+	QWidget* pProgram = pTree->itemWidget(pItem, 1);
+	if (!pProgram)
+		return;
+
+	if (bSave)
+	{
+		QHBoxLayout* pLayout = (QHBoxLayout*)pProgram->layout();
+		QToolButton* pNot = (QToolButton*)pLayout->itemAt(0)->widget();
+		QComboBox* pCombo = (QComboBox*)pLayout->itemAt(1)->widget();
+
+		QComboBox* pMode = (QComboBox*)pTree->itemWidget(pItem, 2);
+		QLineEdit* pPath = (QLineEdit*)pTree->itemWidget(pItem, 3);
+
+		QString Program = pCombo->currentText();
+		int Index = pCombo->findText(Program);
+		if (Index != -1)
+			Program = pCombo->itemData(Index, Qt::UserRole).toString();
+		if (!Program.isEmpty() && Program.left(1) != "<")
+			m_Programs.insert(Program);
+
+		eAccessMode::EAccessMode Mode = (eAccessMode::EAccessMode)pMode->currentData().toInt();
+		QString Path = pPath->text();
+
+		pItem->setText(1, (pNot->isChecked() ? "NOT " : "") + pCombo->currentText());
+		pItem->setData(1, Qt::UserRole, (pNot->isChecked() ? "!" : "") + Program);
+
+		// update mode
+		QString ModeStr, ModeTip;
+		foreach(const SAccessEntryConfig& Config, GetAccessConfig())
+			if (Config.Mode == Mode) {
+				ModeStr = Config.ModeName;
+				ModeTip = Config.ModeTip;
+				break;
+			}
+		pItem->setText(2, ModeStr);
+		pItem->setData(2, Qt::UserRole, (int)Mode);
+		if (!ModeTip.isEmpty())
+			pItem->setToolTip(2, ModeTip);
+
+		pItem->setText(3, ExpandPath(Path));
+		pItem->setData(3, Qt::UserRole, Path);
+
+		OnConfigChanged();
+	}
+
+	pTree->setItemWidget(pItem, 1, NULL);
+	pTree->setItemWidget(pItem, 2, NULL);
+	pTree->setItemWidget(pItem, 3, NULL);
+}
+
+bool CSharedAccessWidget::eventFilter(QObject* watched, QEvent* event)
+{
+	if (watched == m_pTree->viewport())
+	{
+		if (event->type() == QEvent::KeyPress)
+		{
+			QKeyEvent* pKey = (QKeyEvent*)event;
+			if (pKey->key() == Qt::Key_Delete && pKey->modifiers() == Qt::NoModifier)
+			{
+				CloseAccessEdit(true);
+				OnDel();
+				return true;
+			}
+			if (pKey->key() == Qt::Key_Escape && pKey->modifiers() == Qt::NoModifier)
+			{
+				CloseAccessEdit(false);
+				return true;
+			}
+			if ((pKey->key() == Qt::Key_Enter || pKey->key() == Qt::Key_Return)
+			 && (pKey->modifiers() == Qt::NoModifier || pKey->modifiers() == Qt::KeypadModifier))
+			{
+				CloseAccessEdit(true);
+				return true;
+			}
+		}
+		else if (event->type() == QEvent::MouseButtonPress)
+			CloseAccessEdit(false);
+	}
+	return QWidget::eventFilter(watched, event);
+}
+
+void CSharedAccessWidget::OnConfigChanged()
+{
+	emit Changed();
+}
+
+void CSharedAccessWidget::OnReloadPathDisplay()
+{
+	for (int i = 0; i < m_pTree->topLevelItemCount(); i++)
+	{
+		QTreeWidgetItem* pItem = m_pTree->topLevelItem(i);
+		pItem->setText(3, ExpandPath(pItem->data(3, Qt::UserRole).toString()));
+	}
+}
+
+void CSharedAccessWidget::ReloadPathDisplay()
+{
+	OnReloadPathDisplay();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// CSharedFileWidget
+////////////////////////////////////////////////////////////////////////////////////////
+
+CSharedFileWidget::CSharedFileWidget(QWidget* parent)
+	: CSharedAccessWidget(parent)
+{
+	FillAddMenu();
+}
+
+QList<SAccessEntryConfig> CSharedFileWidget::GetAccessConfig()
+{
+	QList<SAccessEntryConfig> Config;
+
+	SAccessEntryConfig Entry;
+	Entry.Mode = eAccessMode::eNormal;
+	Entry.Setting = "NormalFilePath";
+	Entry.ModeName = tr("Normal");
+	Entry.ModeTip = tr("Regular Sandboxie behavior - allow read and also copy on write.");
+	Config.append(Entry);
+
+	Entry.Mode = eAccessMode::eOpen;
+	Entry.Setting = "OpenFilePath";
+	Entry.ModeName = tr("Open");
+	Entry.ModeTip = tr("Allow write-access outside the sandbox.");
+	Config.append(Entry);
+
+	Entry.Mode = eAccessMode::eOpen4All;
+	Entry.Setting = "OpenPipePath";
+	Entry.ModeName = tr("Open for All");
+	Entry.ModeTip = tr("Allow write-access outside the sandbox, also for applications installed inside the sandbox.");
+	Config.append(Entry);
+
+	Entry.Mode = eAccessMode::eClosed;
+	Entry.Setting = "ClosedFilePath";
+	Entry.ModeName = tr("Closed");
+	Entry.ModeTip = tr("Deny access to host location and prevent creation of sandboxed copies.");
+	Config.append(Entry);
+
+	Entry.Mode = eAccessMode::eReadOnly;
+	Entry.Setting = "ReadFilePath";
+	Entry.ModeName = tr("Read Only");
+	Entry.ModeTip = tr("Allow read-only access only.");
+	Config.append(Entry);
+
+	Entry.Mode = eAccessMode::eBoxOnly;
+	Entry.Setting = "WriteFilePath";
+	Entry.ModeName = tr("Box Only (Write Only)");
+	Entry.ModeTip = tr("Hide host files, folders or registry keys from sandboxed processes.");
+	Config.append(Entry);
+
+	return Config;
+}
+
+QString CSharedFileWidget::ExpandPath(const QString& Path) const
+{
+	QString sPath = CSharedAccessWidget::ExpandPath(Path);
+
+	if (!sPath.isEmpty()) {
+		if (sPath.left(1) == "|")
+			return sPath.mid(1);
+		else if (!sPath.contains("*") && sPath.right(1) != "*")
+			return sPath + "*";
+	}
+	return sPath;
+}
+
+void CSharedFileWidget::FillAddMenu()
+{
+	QMenu* pMenu = m_pAddButton->menu();
+	pMenu->addAction(tr("Browse for File"), this, SLOT(OnBrowseFile()));
+	pMenu->addAction(tr("Browse for Folder"), this, SLOT(OnBrowseFolder()));
+}
+
+void CSharedFileWidget::OnBrowseFile()
+{
+	QString Value = QFileDialog::getOpenFileName(this, tr("Select File"), "", tr("All Files (*.*)")).replace("/", "\\");
+	if (Value.isEmpty())
+		return;
+
+	AddEntry(GetDefaultMode(), "", Value);
+	OnConfigChanged();
+}
+
+void CSharedFileWidget::OnBrowseFolder()
+{
+	QString Value = QFileDialog::getExistingDirectory(this, tr("Select Directory")).replace("/", "\\");
+	if (Value.isEmpty())
+		return;
+
+	// Add a trailing backslash if it does not exist
+	if (!Value.endsWith("\\"))
+		Value.append("\\");
+
+	AddEntry(GetDefaultMode(), "", Value);
+	OnConfigChanged();
+}

--- a/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
+++ b/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
@@ -193,6 +193,9 @@ void CSharedAccessWidget::ParseAndAddEntry(const QString& Setting, const QString
 
 void CSharedAccessWidget::LoadAccessList()
 {
+	if (!m_pIni)
+		return;
+
 	ClearEntries();
 
 	foreach(const SAccessEntryConfig& Config, GetAccessConfig())
@@ -210,6 +213,9 @@ void CSharedAccessWidget::LoadAccessList()
 
 void CSharedAccessWidget::LoadTemplates(bool bShow)
 {
+	if (!m_pIni)
+		return;
+
 	if (bShow)
 	{
 		foreach(const SAccessEntryConfig& Config, GetAccessConfig())
@@ -245,12 +251,25 @@ void CSharedAccessWidget::OnChangeTemplates()
 
 void CSharedAccessWidget::SaveAccessList()
 {
+	if (!m_pIni)
+		return;
+
 	QStringList Keys;
 	foreach(const SAccessEntryConfig& Config, GetAccessConfig()) {
 		if (!Keys.contains(Config.Setting))
 			Keys << Config.Setting;
 	}
 
+	QMap<QString, QList<QString>> AccessMap = GetAccessList();
+
+	foreach(const QString & Key, Keys) {
+		m_pIni->UpdateTextList(Key, AccessMap[Key], m_bTemplate);
+		m_pIni->UpdateTextList(Key + "Disabled", AccessMap[Key + "Disabled"], m_bTemplate);
+	}
+}
+
+QMap<QString, QList<QString>> CSharedAccessWidget::GetAccessList() const
+{
 	QMap<QString, QList<QString>> AccessMap;
 
 	for (int i = 0; i < m_pTree->topLevelItemCount(); i++)
@@ -267,6 +286,8 @@ void CSharedAccessWidget::SaveAccessList()
 
 		QString Program = pItem->data(1, Qt::UserRole).toString();
 		QString Value = pItem->data(3, Qt::UserRole).toString();
+		if (Value.isEmpty())
+			continue; // skip entries without a path
 		if (!Program.isEmpty())
 			Value.prepend(Program + ",");
 
@@ -275,10 +296,7 @@ void CSharedAccessWidget::SaveAccessList()
 		AccessMap[Setting].append(Value);
 	}
 
-	foreach(const QString & Key, Keys) {
-		m_pIni->UpdateTextList(Key, AccessMap[Key], m_bTemplate);
-		m_pIni->UpdateTextList(Key + "Disabled", AccessMap[Key + "Disabled"], m_bTemplate);
-	}
+	return AccessMap;
 }
 
 //////////////////////////////////////////////////////////////////// entry lookup (options integration)
@@ -351,7 +369,7 @@ void CSharedAccessWidget::OnItemChanged(QTreeWidgetItem* pItem, int Column)
 
 void CSharedAccessWidget::OnSelectionChanged()
 {
-	CloseAccessEdit(false);
+	CloseAccessEdit(true);
 	OnConfigChanged();
 }
 
@@ -505,7 +523,7 @@ bool CSharedAccessWidget::eventFilter(QObject* watched, QEvent* event)
 			}
 		}
 		else if (event->type() == QEvent::MouseButtonPress)
-			CloseAccessEdit(false);
+			CloseAccessEdit(true);
 	}
 	return QWidget::eventFilter(watched, event);
 }

--- a/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
+++ b/SandboxiePlus/SandMan/Windows/SharedAccessWidget.cpp
@@ -2,7 +2,7 @@
 
 #include "SharedAccessWidget.h"
 
-#include "../../QSbieAPI/SbieIni.h"
+#include "../QSbieAPI/Sandboxie/SbieIni.h"
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>

--- a/SandboxiePlus/SandMan/Windows/SharedAccessWidget.h
+++ b/SandboxiePlus/SandMan/Windows/SharedAccessWidget.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <QtWidgets/qwidget.h>
+#include <QtCore/qsharedpointer.h>
+#include <QtCore/qstringlist.h>
+#include <QtCore/qset.h>
+#include <QtCore/qmap.h>
+#include <functional>
+
+class QTreeWidget;
+class QTreeWidgetItem;
+class QCheckBox;
+class QToolButton;
+class QMenu;
+class CSbieIni;
+
+
+// modes supported inside the access lists, kept generic so that the widget
+// can be reused on its own; values mirror COptionsWindow::EAccessMode so that
+// the two can interoperate without conversions
+namespace eAccessMode {
+	enum EAccessMode {
+		eNormal,
+		eOpen,
+		eOpen4All,
+		eNoRename,
+		eClosed,
+		eClosedRT,
+		eReadOnly,
+		eBoxOnly,
+		eIgnoreUIPI,
+		eMaxMode
+	};
+};
+
+// access type ids, mirrors COptionsWindow::EAccessType so entries stored from
+// the legacy options window code can be found again
+namespace eAccessType {
+	enum EType {
+		eFile,
+		eKey,
+		eIPC,
+		eWnd,
+		eCOM,
+	};
+};
+
+// one row of GetAccessConfig:
+//  Mode       -> generic mode (see eAccessMode)
+//  Setting    -> ini setting that holds the respective access list (e.g. "OpenFilePath")
+//  ModeName/ ModeTip -> localized display name and tooltip shown in column 2
+struct SAccessEntryConfig {
+	eAccessMode::EAccessMode Mode;
+	QString	Setting;
+	QString	ModeName;
+	QString	ModeTip;
+};
+
+// NOTE: this widget keeps the same item data layout as the old Options window
+// access lists, so that the existing entry-lookup helpers can operate on the
+// widget tree directly:
+//   column 0:  type id (or -1 for template entries)
+//   column 1:  program (raw, may start with '!')
+//   column 2:  access mode
+//   column 3:  raw path (unexpanded)
+class CSharedAccessWidget : public QWidget
+{
+	Q_OBJECT
+
+public:
+	CSharedAccessWidget(QWidget* parent = NULL);
+	virtual ~CSharedAccessWidget();
+
+public:
+	void SetConfig(const QSharedPointer<CSbieIni>& pIni, bool bTemplate);
+	void SetGroupsProvider(const std::function<QStringList()>& GetGroups) { m_GetGroups = GetGroups; }
+	void SetPrograms(const QSet<QString>& Programs) { m_Programs = Programs; }
+
+	// optionally pre-process a path before it is shown (e.g. variable/box expansion);
+	// when not set the path is displayed as-is
+	void SetPathExpander(const std::function<QString(const QString&)>& fn) { m_ExpandPathFn = fn; }
+
+	void SetTemplatesEnabled(bool bEnabled);
+	void SetShowTemplates(bool bShow);
+
+	void LoadAccessList();
+	void SaveAccessList();
+
+	int GetItemCount() const { return m_pTree->topLevelItemCount(); }
+	QTreeWidget* GetTree() const { return m_pTree; }
+	QSet<QString> GetPrograms() const { return m_Programs; }
+
+	// update the shown path of every item to the expanded one (column 3)
+	void ReloadPathDisplay();
+
+	// compatibility helpers, used by special box configuration code
+	bool HasEntry(int Mode, const QString& Program, const QString& Path);
+	void SetEntry(int Mode, const QString& Program, const QString& Path);
+	void DelEntry(int Mode, const QString& Program, const QString& Path);
+
+public slots:
+	void CloseAccessEdit(bool bSave);
+
+signals:
+	void Changed();
+
+protected:
+	virtual QList<SAccessEntryConfig> GetAccessConfig() = 0;	// defines the settings/mode strings for the derived type
+	virtual QString GetAccessTypeStr() const = 0;
+	virtual int GetAccessTypeId() const = 0;
+	virtual eAccessMode::EAccessMode GetDefaultMode() const { return eAccessMode::eOpen; }
+
+	virtual QString ExpandPath(const QString& Path) const { return m_ExpandPathFn ? m_ExpandPathFn(Path) : Path; }
+
+	virtual QTreeWidget* CreateListWidget();
+	virtual QToolButton* CreateAddButton();
+	virtual void FillAddMenu();	// may be re-implemented by derived classes
+
+protected slots:
+	void OnAdd();
+	void OnDel();
+	void OnItemDoubleClicked(QTreeWidgetItem* pItem, int Column);
+	void OnSelectionChanged();
+	void OnItemChanged(QTreeWidgetItem* pItem, int Column);
+	void OnChangeTemplates();
+
+	virtual void OnBrowseFile() {}
+	virtual void OnBrowseFolder() {}
+
+protected:
+	void ParseAndAddEntry(const QString& Setting, const QString& Value, bool disabled = false, const QString& Template = "");
+	void AddEntry(eAccessMode::EAccessMode Mode, const QString& Program, const QString& Path, bool Enabled = true, const QString& Template = QString());
+	void ClearEntries();
+	void LoadTemplates(bool bShow);
+
+	QString GetSettingName(eAccessMode::EAccessMode Mode) const;
+	eAccessMode::EAccessMode GetModeFromSetting(const QString& Setting) const;
+	QTreeWidgetItem* FindEntry(eAccessMode::EAccessMode Mode, const QString& Program, const QString& Path, bool bOnlyEnabled = false);
+	void CloseAccessEdit(QTreeWidgetItem* pItem, bool bSave);
+
+	void OnConfigChanged();
+	void OnReloadPathDisplay();
+
+	QSharedPointer<CSbieIni>	m_pIni;
+	QTreeWidget*				m_pTree;
+	QCheckBox*					m_pShowTemplates;
+	QToolButton*				m_pAddButton;
+	QToolButton*				m_pRemoveButton;
+	QSet<QString>				m_Programs;
+
+	std::function<QStringList()>			m_GetGroups;
+	std::function<QString(const QString&)>	m_ExpandPathFn;
+
+	bool m_bTemplate;
+
+private:
+	bool eventFilter(QObject* watched, QEvent* event);
+};
+
+////////////////////////////////////////////////////////////////////////////////////////
+// CSharedFileWidget: file / folder / pipe access list
+////////////////////////////////////////////////////////////////////////////////////////
+
+class CSharedFileWidget : public CSharedAccessWidget
+{
+	Q_OBJECT
+
+public:
+	CSharedFileWidget(QWidget* parent = NULL);
+
+protected:
+	virtual QList<SAccessEntryConfig> GetAccessConfig();
+	virtual QString GetAccessTypeStr() const { return tr("File/Folder"); }
+	virtual int GetAccessTypeId() const { return eAccessType::eFile; }
+	virtual eAccessMode::EAccessMode GetDefaultMode() const { return eAccessMode::eOpen; }
+
+	// File and Registry entries auto append a '*' wildcard when they don't
+	// contain any; prepending '|' disables this behaviour
+	virtual QString ExpandPath(const QString& Path) const;
+
+	virtual void FillAddMenu();
+	virtual void OnBrowseFile();
+	virtual void OnBrowseFolder();
+};

--- a/SandboxiePlus/SandMan/Windows/SharedAccessWidget.h
+++ b/SandboxiePlus/SandMan/Windows/SharedAccessWidget.h
@@ -105,7 +105,7 @@ signals:
 	void Changed();
 
 protected:
-	virtual QList<SAccessEntryConfig> GetAccessConfig() = 0;	// defines the settings/mode strings for the derived type
+	virtual QList<SAccessEntryConfig> GetAccessConfig() const = 0;	// defines the settings/mode strings for the derived type
 	virtual QString GetAccessTypeStr() const = 0;
 	virtual int GetAccessTypeId() const = 0;
 	virtual eAccessMode::EAccessMode GetDefaultMode() const { return eAccessMode::eOpen; }
@@ -169,7 +169,7 @@ public:
 	CSharedFileWidget(QWidget* parent = NULL);
 
 protected:
-	virtual QList<SAccessEntryConfig> GetAccessConfig();
+	virtual QList<SAccessEntryConfig> GetAccessConfig() const;
 	virtual QString GetAccessTypeStr() const { return tr("File/Folder"); }
 	virtual int GetAccessTypeId() const { return eAccessType::eFile; }
 	virtual eAccessMode::EAccessMode GetDefaultMode() const { return eAccessMode::eOpen; }

--- a/SandboxiePlus/SandMan/Windows/SharedAccessWidget.h
+++ b/SandboxiePlus/SandMan/Windows/SharedAccessWidget.h
@@ -90,6 +90,9 @@ public:
 	QTreeWidget* GetTree() const { return m_pTree; }
 	QSet<QString> GetPrograms() const { return m_Programs; }
 
+	// return all non-template entries as setting -> list of "program,path" values
+	QMap<QString, QList<QString>> GetAccessList() const;
+
 	// update the shown path of every item to the expanded one (column 3)
 	void ReloadPathDisplay();
 

--- a/SandboxiePlus/SandMan/Wizards/AccessControlWidget.cpp
+++ b/SandboxiePlus/SandMan/Wizards/AccessControlWidget.cpp
@@ -1,0 +1,142 @@
+#include "stdafx.h"
+
+#include "AccessControlWidget.h"
+
+#include <QTreeWidget>
+#include <QLineEdit>
+#include <QComboBox>
+#include <QPushButton>
+#include <QFileDialog>
+#include <QVBoxLayout>
+
+
+CAccessControlWidget::CAccessControlWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    QVBoxLayout* pLayout = new QVBoxLayout();
+    pLayout->setContentsMargins(0, 0, 0, 0);
+
+    m_pEntryList = new QTreeWidget(this);
+    m_pEntryList->setHeaderLabels({ tr("Path"), tr("Type") });
+    m_pEntryList->setRootIsDecorated(false);
+    m_pEntryList->setAlternatingRowColors(theConf->GetBool("Options/AltRowColors", false));
+    pLayout->addWidget(m_pEntryList);
+
+    QHBoxLayout* pAddRow = new QHBoxLayout();
+    pAddRow->setContentsMargins(0, 4, 0, 0);
+
+    m_pPathEdit = new QLineEdit(this);
+    m_pPathEdit->setPlaceholderText(tr("Enter file or folder path"));
+    pAddRow->addWidget(m_pPathEdit, 1);
+
+    m_pTypeCombo = new QComboBox(this);
+    pAddRow->addWidget(m_pTypeCombo);
+
+    QPushButton* pBrowseFileBtn = new QPushButton(tr("Browse"), this);
+    connect(pBrowseFileBtn, &QPushButton::clicked, this, &CAccessControlWidget::OnBrowseFile);
+    pAddRow->addWidget(pBrowseFileBtn);
+
+    QPushButton* pBrowseDirBtn = new QPushButton(tr("Folder"), this);
+    connect(pBrowseDirBtn, &QPushButton::clicked, this, &CAccessControlWidget::OnBrowseFolder);
+    pAddRow->addWidget(pBrowseDirBtn);
+
+    QPushButton* pAddBtn = new QPushButton(tr("Add"), this);
+    connect(pAddBtn, &QPushButton::clicked, this, &CAccessControlWidget::OnAddEntry);
+    pAddRow->addWidget(pAddBtn);
+
+    QPushButton* pRemoveBtn = new QPushButton(tr("Remove"), this);
+    connect(pRemoveBtn, &QPushButton::clicked, this, &CAccessControlWidget::OnRemoveEntry);
+    pAddRow->addWidget(pRemoveBtn);
+
+    pLayout->addLayout(pAddRow);
+
+    setLayout(pLayout);
+}
+
+void CAccessControlWidget::SetTypes(const QList<QPair<QString, QString>>& Types)
+{
+    m_Types = Types;
+    m_pTypeCombo->clear();
+    for (const auto& Type : m_Types)
+        m_pTypeCombo->addItem(Type.first, Type.second);
+}
+
+void CAccessControlWidget::SetEntries(const QList<QPair<QString, QString>>& Entries)
+{
+    m_pEntryList->clear();
+    for (const auto& Entry : Entries)
+        AddEntryWidget(Entry.first, Entry.second);
+}
+
+void CAccessControlWidget::AddEntryWidget(const QString& Path, const QString& TypeKey)
+{
+    QTreeWidgetItem* pItem = new QTreeWidgetItem();
+    pItem->setText(0, Path);
+    pItem->setData(0, Qt::UserRole, Path);
+    m_pEntryList->addTopLevelItem(pItem);
+
+    QComboBox* pType = new QComboBox(this);
+    int TypeIndex = 0;
+    for (int i = 0; i < m_Types.count(); i++) {
+        pType->addItem(m_Types[i].first, m_Types[i].second);
+        if (m_Types[i].second.compare(TypeKey, Qt::CaseInsensitive) == 0)
+            TypeIndex = i;
+    }
+    pType->setCurrentIndex(TypeIndex);
+    connect(pType, qOverload<int>(&QComboBox::currentIndexChanged), this, [this]() { emit changed(); });
+    m_pEntryList->setItemWidget(pItem, 1, pType);
+}
+
+QList<QPair<QString, QString>> CAccessControlWidget::GetEntries() const
+{
+    QList<QPair<QString, QString>> Entries;
+    for (int i = 0; i < m_pEntryList->topLevelItemCount(); i++)
+    {
+        QTreeWidgetItem* pItem = m_pEntryList->topLevelItem(i);
+        QString Path = pItem->text(0);
+        QString TypeKey = QString();
+        if (QComboBox* pType = (QComboBox*)m_pEntryList->itemWidget(pItem, 1))
+            TypeKey = pType->currentData().toString();
+        if (!Path.isEmpty() && !TypeKey.isEmpty())
+            Entries.append(qMakePair(Path, TypeKey));
+    }
+    return Entries;
+}
+
+void CAccessControlWidget::OnBrowseFile()
+{
+    QString FilePath = QFileDialog::getOpenFileName(this, tr("Select File")).replace("/", "\\");
+    if (!FilePath.isEmpty())
+        m_pPathEdit->setText(FilePath);
+}
+
+void CAccessControlWidget::OnBrowseFolder()
+{
+    QString DirPath = QFileDialog::getExistingDirectory(this, tr("Select Directory")).replace("/", "\\");
+    if (!DirPath.isEmpty()) {
+        if (!DirPath.endsWith("\\"))
+            DirPath.append("\\");
+        m_pPathEdit->setText(DirPath);
+    }
+}
+
+void CAccessControlWidget::OnAddEntry()
+{
+    QString Path = m_pPathEdit->text().trimmed();
+    if (Path.isEmpty())
+        return;
+    Path.replace("/", "\\");
+    QString TypeKey = m_pTypeCombo->currentData().toString();
+    AddEntryWidget(Path, TypeKey);
+    m_pPathEdit->clear();
+    emit changed();
+}
+
+void CAccessControlWidget::OnRemoveEntry()
+{
+    QTreeWidgetItem* pItem = m_pEntryList->currentItem();
+    if (!pItem)
+        return;
+    delete m_pEntryList->takeTopLevelItem(m_pEntryList->indexOfTopLevelItem(pItem));
+    emit changed();
+}

--- a/SandboxiePlus/SandMan/Wizards/AccessControlWidget.cpp
+++ b/SandboxiePlus/SandMan/Wizards/AccessControlWidget.cpp
@@ -2,6 +2,7 @@
 
 #include "AccessControlWidget.h"
 
+#include "../MiscHelpers/Common/Settings.h"
 #include <QTreeWidget>
 #include <QLineEdit>
 #include <QComboBox>

--- a/SandboxiePlus/SandMan/Wizards/AccessControlWidget.h
+++ b/SandboxiePlus/SandMan/Wizards/AccessControlWidget.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <QWidget>
+
+QT_BEGIN_NAMESPACE
+class QTreeWidget;
+class QLineEdit;
+class QComboBox;
+QT_END_NAMESPACE
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAccessControlWidget
+// 
+// A reusable widget for editing path based access control entries. Each entry is a
+// pair of a path and an access type (Block, Normal, Write, Read, ...). The widget
+// displays the entries in a list widget and provides buttons to browse for a file or
+// folder, add an entry and remove the selected one. The type of an entry can be
+// changed at any time by editing the type column.
+// 
+// This widget is intended to be shared between the box options (where the same kind
+// of entries are edited) and any other part of the UI, like the New Box Wizard.
+//
+
+class CAccessControlWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    CAccessControlWidget(QWidget* parent = nullptr);
+
+    // Set the list of available access types, each as (display name, config key).
+    void SetTypes(const QList<QPair<QString, QString>>& Types);
+
+    // Set / retrieve the configured entries as (path, config key) pairs.
+    void SetEntries(const QList<QPair<QString, QString>>& Entries);
+    QList<QPair<QString, QString>> GetEntries() const;
+
+signals:
+    void changed();
+
+private slots:
+    void OnBrowseFile();
+    void OnBrowseFolder();
+    void OnAddEntry();
+    void OnRemoveEntry();
+
+private:
+    void AddEntryWidget(const QString& Path, const QString& TypeKey);
+
+    QTreeWidget*     m_pEntryList;
+    QLineEdit*       m_pPathEdit;
+    QComboBox*       m_pTypeCombo;
+
+    QList<QPair<QString, QString>> m_Types;
+};

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -6,7 +6,6 @@
 #include "../SandMan.h"
 #include "Helpers/WinAdmin.h"
 #include <QButtonGroup>
-#include <QListWidget>
 #include "../QSbieAPI/SbieUtils.h"
 #include "../Views/SbieView.h"
 #include "../MiscHelpers/Common/CheckableMessageBox.h"
@@ -286,8 +285,8 @@ SB_STATUS CNewBoxWizard::TryToCreateBox()
             {
                 CFilesPage* pFilesPage = (CFilesPage*)page(Page_Files);
                 if (pFilesPage) {
-                    for (const QString& path : pFilesPage->GetNormalFilePaths())
-                        pBox->AppendText("NormalFilePath", path);
+                    for (const auto& entry : pFilesPage->GetFilePathEntries())
+                        pBox->AppendText(entry.second, entry.first);
                 }
             }
 
@@ -674,22 +673,24 @@ CFilesPage::CFilesPage(QWidget *parent)
     layout->addWidget(pAutoRecover, row++, 1, 1, 3);
     registerField("autoRecover", pAutoRecover);
 
-    // Normal File Paths
-    QLabel* pNormalLabel = new QLabel(tr("Exempt File Paths"), this);
+    // Preconfigured File Control Paths
+    QLabel* pNormalLabel = new QLabel(tr("Preconfigured File Control Paths"), this);
     QFont fntNormal = pNormalLabel->font();
     fntNormal.setBold(true);
     pNormalLabel->setFont(fntNormal);
     layout->addWidget(pNormalLabel, row++, 0);
 
-    m_pNormalPaths = new QListWidget();
-    m_pNormalPaths->setMaximumHeight(100);
+    m_pNormalPaths = new QTreeWidget();
+    m_pNormalPaths->setHeaderLabels({ tr("Path"), tr("Type") });
+    m_pNormalPaths->setMaximumHeight(120);
+    m_pNormalPaths->setRootIsDecorated(false);
     layout->addWidget(m_pNormalPaths, row++, 1, 1, 3);
 
     QHBoxLayout* pNormalLayout = new QHBoxLayout();
     pNormalLayout->setContentsMargins(0,0,0,0);
     m_pNormalPathInput = new QLineEdit();
     m_pNormalPathInput->setPlaceholderText(tr("Enter file or folder path..."));
-    pNormalLayout->addWidget(m_pNormalPathInput);
+    pNormalLayout->addWidget(m_pNormalPathInput, 1);
     QPushButton* pBrowseBtn = new QPushButton("...");
     pBrowseBtn->setMaximumWidth(25);
     connect(pBrowseBtn, &QPushButton::clicked, [this]() {
@@ -698,6 +699,12 @@ CFilesPage::CFilesPage(QWidget *parent)
             this->m_pNormalPathInput->setText(FilePath.replace("/", "\\"));
     });
     pNormalLayout->addWidget(pBrowseBtn);
+    m_pTypeCombo = new QComboBox();
+    m_pTypeCombo->addItem("Block", "BlockFilePath");
+    m_pTypeCombo->addItem("Normal", "NormalFilePath");
+    m_pTypeCombo->addItem("Write", "WriteFilePath");
+    m_pTypeCombo->addItem("Read", "ReadFilePath");
+    pNormalLayout->addWidget(m_pTypeCombo);
     QPushButton* pAddBtn = new QPushButton(tr("Add"));
     connect(pAddBtn, &QPushButton::clicked, this, &CFilesPage::OnAddNormalPath);
     pNormalLayout->addWidget(pAddBtn);
@@ -771,22 +778,36 @@ bool CFilesPage::validatePage()
     return true;
 }
 
+QList<QPair<QString, QString>> CFilesPage::GetFilePathEntries() const
+{
+    QList<QPair<QString, QString>> entries;
+    for (int i = 0; i < m_pNormalPaths->topLevelItemCount(); i++) {
+        QTreeWidgetItem* pItem = m_pNormalPaths->topLevelItem(i);
+        entries.append(qMakePair(pItem->text(0), pItem->data(1, Qt::UserRole).toString()));
+    }
+    return entries;
+}
+
 void CFilesPage::OnAddNormalPath()
 {
     QString path = m_pNormalPathInput->text().trimmed();
     if (path.isEmpty()) return;
     path.replace("/", "\\");
-    m_pNormalPaths->addItem(path);
-    m_NormalFilePaths.append(path);
+    QString configKey = m_pTypeCombo->currentData().toString();
+    QString typeName = m_pTypeCombo->currentText();
+    QTreeWidgetItem* pItem = new QTreeWidgetItem();
+    pItem->setText(0, path);
+    pItem->setText(1, typeName);
+    pItem->setData(1, Qt::UserRole, configKey);
+    m_pNormalPaths->addTopLevelItem(pItem);
     m_pNormalPathInput->clear();
 }
 
 void CFilesPage::OnRemoveNormalPath()
 {
-    int row = m_pNormalPaths->currentRow();
-    if (row >= 0) {
-        m_NormalFilePaths.removeAt(row);
-        delete m_pNormalPaths->takeItem(row);
+    QTreeWidgetItem* pItem = m_pNormalPaths->currentItem();
+    if (pItem) {
+        delete m_pNormalPaths->takeTopLevelItem(m_pNormalPaths->indexOfTopLevelItem(pItem));
     }
 }
 
@@ -1148,11 +1169,11 @@ void CSummaryPage::initializePage()
     {
         CFilesPage* pFilesPage = (CFilesPage*)((CNewBoxWizard*)wizard())->page(CNewBoxWizard::Page_Files);
         if (pFilesPage) {
-            QStringList paths = pFilesPage->GetNormalFilePaths();
-            if (!paths.isEmpty()) {
-                m_pSummary->append(tr("\nThe following file paths will be excluded from virtualization:"));
-                for (const QString& path : paths)
-                    m_pSummary->append(tr("  %1").arg(path));
+            auto entries = pFilesPage->GetFilePathEntries();
+            if (!entries.isEmpty()) {
+                m_pSummary->append(tr("\nPreconfigured file control paths:"));
+                for (const auto& entry : entries)
+                    m_pSummary->append(tr("  [%1] %2").arg(entry.second, entry.first));
             }
         }
     }

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -673,8 +673,8 @@ CFilesPage::CFilesPage(QWidget *parent)
     layout->addWidget(pAutoRecover, row++, 1, 1, 3);
     registerField("autoRecover", pAutoRecover);
 
-    // Preconfigured File Control Paths
-    QLabel* pNormalLabel = new QLabel(tr("Preconfigured File Control Paths"), this);
+    // File Access Control
+    QLabel* pNormalLabel = new QLabel(tr("File Access Control"), this);
     QFont fntNormal = pNormalLabel->font();
     fntNormal.setBold(true);
     pNormalLabel->setFont(fntNormal);
@@ -1171,7 +1171,7 @@ void CSummaryPage::initializePage()
         if (pFilesPage) {
             auto entries = pFilesPage->GetFilePathEntries();
             if (!entries.isEmpty()) {
-                m_pSummary->append(tr("\nPreconfigured file control paths:"));
+                m_pSummary->append(tr("\nFile Access Control:"));
                 for (const auto& entry : entries)
                     m_pSummary->append(tr("  [%1] %2").arg(entry.second, entry.first));
             }

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -700,7 +700,7 @@ CFilesPage::CFilesPage(QWidget *parent)
     });
     pNormalLayout->addWidget(pBrowseBtn);
     m_pTypeCombo = new QComboBox();
-    m_pTypeCombo->addItem("Block", "BlockFilePath");
+    m_pTypeCombo->addItem("Closed", "ClosedFilePath");
     m_pTypeCombo->addItem("Normal", "NormalFilePath");
     m_pTypeCombo->addItem("Write", "WriteFilePath");
     m_pTypeCombo->addItem("Read", "ReadFilePath");

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -6,6 +6,7 @@
 #include "../SandMan.h"
 #include "Helpers/WinAdmin.h"
 #include <QButtonGroup>
+#include <QListWidget>
 #include "../QSbieAPI/SbieUtils.h"
 #include "../Views/SbieView.h"
 #include "../MiscHelpers/Common/CheckableMessageBox.h"
@@ -281,6 +282,14 @@ SB_STATUS CNewBoxWizard::TryToCreateBox()
 
             if (!Password.isEmpty())
                 pBox->ImBoxCreate(ImageSize / 1024, Password);
+
+            {
+                CFilesPage* pFilesPage = (CFilesPage*)page(Page_Files);
+                if (pFilesPage) {
+                    for (const QString& path : pFilesPage->GetNormalFilePaths())
+                        pBox->AppendText("NormalFilePath", path);
+                }
+            }
 
             if (field("boxVersion").toInt() == 1) {
                 if (theConf->GetBool("Options/WarnDeleteV2", true)) {
@@ -665,6 +674,38 @@ CFilesPage::CFilesPage(QWidget *parent)
     layout->addWidget(pAutoRecover, row++, 1, 1, 3);
     registerField("autoRecover", pAutoRecover);
 
+    // Normal File Paths
+    QLabel* pNormalLabel = new QLabel(tr("Exempt File Paths"), this);
+    QFont fntNormal = pNormalLabel->font();
+    fntNormal.setBold(true);
+    pNormalLabel->setFont(fntNormal);
+    layout->addWidget(pNormalLabel, row++, 0);
+
+    m_pNormalPaths = new QListWidget();
+    m_pNormalPaths->setMaximumHeight(100);
+    layout->addWidget(m_pNormalPaths, row++, 1, 1, 3);
+
+    QHBoxLayout* pNormalLayout = new QHBoxLayout();
+    pNormalLayout->setContentsMargins(0,0,0,0);
+    m_pNormalPathInput = new QLineEdit();
+    m_pNormalPathInput->setPlaceholderText(tr("Enter file or folder path..."));
+    pNormalLayout->addWidget(m_pNormalPathInput);
+    QPushButton* pBrowseBtn = new QPushButton("...");
+    pBrowseBtn->setMaximumWidth(25);
+    connect(pBrowseBtn, &QPushButton::clicked, [this]() {
+        QString FilePath = QFileDialog::getOpenFileName(this, tr("Select File"));
+        if (!FilePath.isEmpty())
+            this->m_pNormalPathInput->setText(FilePath.replace("/", "\\"));
+    });
+    pNormalLayout->addWidget(pBrowseBtn);
+    QPushButton* pAddBtn = new QPushButton(tr("Add"));
+    connect(pAddBtn, &QPushButton::clicked, this, &CFilesPage::OnAddNormalPath);
+    pNormalLayout->addWidget(pAddBtn);
+    QPushButton* pRemoveBtn = new QPushButton(tr("Remove"));
+    connect(pRemoveBtn, &QPushButton::clicked, this, &CFilesPage::OnRemoveNormalPath);
+    pNormalLayout->addWidget(pRemoveBtn);
+    layout->addLayout(pNormalLayout, row++, 1, 1, 3);
+
 
     setLayout(layout);
 
@@ -728,6 +769,25 @@ bool CFilesPage::validatePage()
         wizard()->setField("boxLocation", Location);
     }
     return true;
+}
+
+void CFilesPage::OnAddNormalPath()
+{
+    QString path = m_pNormalPathInput->text().trimmed();
+    if (path.isEmpty()) return;
+    path.replace("/", "\\");
+    m_pNormalPaths->addItem(path);
+    m_NormalFilePaths.append(path);
+    m_pNormalPathInput->clear();
+}
+
+void CFilesPage::OnRemoveNormalPath()
+{
+    int row = m_pNormalPaths->currentRow();
+    if (row >= 0) {
+        m_NormalFilePaths.removeAt(row);
+        delete m_pNormalPaths->takeItem(row);
+    }
 }
 
 
@@ -1085,6 +1145,17 @@ void CSummaryPage::initializePage()
     if(field("boxToken").toBool())
         m_pSummary->append(tr("\nProcesses in this box will be running with a custom process token indicating the sandbox they belong to."));
 
+    {
+        CFilesPage* pFilesPage = (CFilesPage*)((CNewBoxWizard*)wizard())->page(CNewBoxWizard::Page_Files);
+        if (pFilesPage) {
+            QStringList paths = pFilesPage->GetNormalFilePaths();
+            if (!paths.isEmpty()) {
+                m_pSummary->append(tr("\nThe following file paths will be excluded from virtualization:"));
+                for (const QString& path : paths)
+                    m_pSummary->append(tr("  %1").arg(path));
+            }
+        }
+    }
 
     m_pSetDefault->setVisible(((CNewBoxWizard*)wizard())->m_bAdvanced);
 }

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -1,11 +1,13 @@
 #include "stdafx.h"
 
 #include "NewBoxWizard.h"
+#include "AccessControlWidget.h"
 #include "../MiscHelpers/Common/Common.h"
 #include "../Windows/SettingsWindow.h"
 #include "../SandMan.h"
 #include "Helpers/WinAdmin.h"
 #include <QButtonGroup>
+#include <QVBoxLayout>
 #include "../QSbieAPI/SbieUtils.h"
 #include "../Views/SbieView.h"
 #include "../MiscHelpers/Common/CheckableMessageBox.h"
@@ -19,6 +21,7 @@ CNewBoxWizard::CNewBoxWizard(bool bAlowTemp, QWidget *parent)
 {
     setPage(Page_Type, new CBoxTypePage(bAlowTemp));
     setPage(Page_Files, new CFilesPage);
+    setPage(Page_AccessControl, new CAccessControlPage);
     setPage(Page_Isolation, new CIsolationPage);
     setPage(Page_Advanced, new CAdvancedPage);
     setPage(Page_Summary, new CSummaryPage);
@@ -283,9 +286,9 @@ SB_STATUS CNewBoxWizard::TryToCreateBox()
                 pBox->ImBoxCreate(ImageSize / 1024, Password);
 
             {
-                CFilesPage* pFilesPage = (CFilesPage*)page(Page_Files);
-                if (pFilesPage) {
-                    for (const auto& entry : pFilesPage->GetFilePathEntries())
+                CAccessControlPage* pAccessPage = (CAccessControlPage*)page(Page_AccessControl);
+                if (pAccessPage) {
+                    for (const auto& entry : pAccessPage->GetFileAccessEntries())
                         pBox->AppendText(entry.second, entry.first);
                 }
             }
@@ -673,45 +676,11 @@ CFilesPage::CFilesPage(QWidget *parent)
     layout->addWidget(pAutoRecover, row++, 1, 1, 3);
     registerField("autoRecover", pAutoRecover);
 
-    // Preconfigured File Control Paths
-    QLabel* pNormalLabel = new QLabel(tr("Preconfigured File Control Paths"), this);
-    QFont fntNormal = pNormalLabel->font();
-    fntNormal.setBold(true);
-    pNormalLabel->setFont(fntNormal);
-    layout->addWidget(pNormalLabel, row++, 0);
-
-    m_pNormalPaths = new QTreeWidget();
-    m_pNormalPaths->setHeaderLabels({ tr("Path"), tr("Type") });
-    m_pNormalPaths->setMaximumHeight(120);
-    m_pNormalPaths->setRootIsDecorated(false);
-    layout->addWidget(m_pNormalPaths, row++, 1, 1, 3);
-
-    QHBoxLayout* pNormalLayout = new QHBoxLayout();
-    pNormalLayout->setContentsMargins(0,0,0,0);
-    m_pNormalPathInput = new QLineEdit();
-    m_pNormalPathInput->setPlaceholderText(tr("Enter file or folder path..."));
-    pNormalLayout->addWidget(m_pNormalPathInput, 1);
-    QPushButton* pBrowseBtn = new QPushButton("...");
-    pBrowseBtn->setMaximumWidth(25);
-    connect(pBrowseBtn, &QPushButton::clicked, [this]() {
-        QString FilePath = QFileDialog::getOpenFileName(this, tr("Select File"));
-        if (!FilePath.isEmpty())
-            this->m_pNormalPathInput->setText(FilePath.replace("/", "\\"));
-    });
-    pNormalLayout->addWidget(pBrowseBtn);
-    m_pTypeCombo = new QComboBox();
-    m_pTypeCombo->addItem("Block", "BlockFilePath");
-    m_pTypeCombo->addItem("Normal", "NormalFilePath");
-    m_pTypeCombo->addItem("Write", "WriteFilePath");
-    m_pTypeCombo->addItem("Read", "ReadFilePath");
-    pNormalLayout->addWidget(m_pTypeCombo);
-    QPushButton* pAddBtn = new QPushButton(tr("Add"));
-    connect(pAddBtn, &QPushButton::clicked, this, &CFilesPage::OnAddNormalPath);
-    pNormalLayout->addWidget(pAddBtn);
-    QPushButton* pRemoveBtn = new QPushButton(tr("Remove"));
-    connect(pRemoveBtn, &QPushButton::clicked, this, &CFilesPage::OnRemoveNormalPath);
-    pNormalLayout->addWidget(pRemoveBtn);
-    layout->addLayout(pNormalLayout, row++, 1, 1, 3);
+    m_pSetAccessControl = new QCheckBox(tr("Configure file access control on the next page"));
+    m_pSetAccessControl->setToolTip(tr("When checked, the wizard will show an additional page on which file access control entries "
+        "can be added to restrict or define the access of sandboxed processes to files and folders."));
+    m_pSetAccessControl->setChecked(true);
+    layout->addWidget(m_pSetAccessControl, row++, 1, 1, 3);
 
 
     setLayout(layout);
@@ -726,6 +695,8 @@ CFilesPage::CFilesPage(QWidget *parent)
 
 int CFilesPage::nextId() const
 {
+    if (m_pSetAccessControl->isChecked())
+        return CNewBoxWizard::Page_AccessControl;
     return CNewBoxWizard::Page_Isolation;
 }
 
@@ -778,37 +749,49 @@ bool CFilesPage::validatePage()
     return true;
 }
 
-QList<QPair<QString, QString>> CFilesPage::GetFilePathEntries() const
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAccessControlPage
+// 
+
+CAccessControlPage::CAccessControlPage(QWidget *parent)
+    : QWizardPage(parent)
 {
-    QList<QPair<QString, QString>> entries;
-    for (int i = 0; i < m_pNormalPaths->topLevelItemCount(); i++) {
-        QTreeWidgetItem* pItem = m_pNormalPaths->topLevelItem(i);
-        entries.append(qMakePair(pItem->text(0), pItem->data(1, Qt::UserRole).toString()));
-    }
-    return entries;
+    setTitle(tr("File access control"));
+    setSubTitle(tr("On this page custom file access control entries can be configured. "
+        "These entries define how sandboxed processes can access the specified files and folders, "
+        "e.g. to block access to sensitive data or to allow write access to files located in the host system."));
+
+    QVBoxLayout* pLayout = new QVBoxLayout;
+
+    m_pAccessControl = new CAccessControlWidget();
+    m_pAccessControl->SetTypes(QList<QPair<QString, QString>>()
+        << qMakePair(tr("Block"), QString("BlockFilePath"))
+        << qMakePair(tr("Normal"), QString("NormalFilePath"))
+        << qMakePair(tr("Write"), QString("WriteFilePath"))
+        << qMakePair(tr("Read"), QString("ReadFilePath")));
+    pLayout->addWidget(m_pAccessControl);
+
+    setLayout(pLayout);
 }
 
-void CFilesPage::OnAddNormalPath()
+int CAccessControlPage::nextId() const
 {
-    QString path = m_pNormalPathInput->text().trimmed();
-    if (path.isEmpty()) return;
-    path.replace("/", "\\");
-    QString configKey = m_pTypeCombo->currentData().toString();
-    QString typeName = m_pTypeCombo->currentText();
-    QTreeWidgetItem* pItem = new QTreeWidgetItem();
-    pItem->setText(0, path);
-    pItem->setText(1, typeName);
-    pItem->setData(1, Qt::UserRole, configKey);
-    m_pNormalPaths->addTopLevelItem(pItem);
-    m_pNormalPathInput->clear();
+    return CNewBoxWizard::Page_Isolation;
 }
 
-void CFilesPage::OnRemoveNormalPath()
+void CAccessControlPage::initializePage()
 {
-    QTreeWidgetItem* pItem = m_pNormalPaths->currentItem();
-    if (pItem) {
-        delete m_pNormalPaths->takeTopLevelItem(m_pNormalPaths->indexOfTopLevelItem(pItem));
-    }
+}
+
+bool CAccessControlPage::validatePage()
+{
+    return true;
+}
+
+QList<QPair<QString, QString>> CAccessControlPage::GetFileAccessEntries() const
+{
+    return m_pAccessControl->GetEntries();
 }
 
 
@@ -1167,9 +1150,9 @@ void CSummaryPage::initializePage()
         m_pSummary->append(tr("\nProcesses in this box will be running with a custom process token indicating the sandbox they belong to."));
 
     {
-        CFilesPage* pFilesPage = (CFilesPage*)((CNewBoxWizard*)wizard())->page(CNewBoxWizard::Page_Files);
-        if (pFilesPage) {
-            auto entries = pFilesPage->GetFilePathEntries();
+        CAccessControlPage* pAccessPage = (CAccessControlPage*)((CNewBoxWizard*)wizard())->page(CNewBoxWizard::Page_AccessControl);
+        if (pAccessPage) {
+            auto entries = pAccessPage->GetFileAccessEntries();
             if (!entries.isEmpty()) {
                 m_pSummary->append(tr("\nPreconfigured file control paths:"));
                 for (const auto& entry : entries)

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 
 #include "NewBoxWizard.h"
-#include "AccessControlWidget.h"
+#include "../Windows/SharedAccessWidget.h"
 #include "../MiscHelpers/Common/Common.h"
 #include "../Windows/SettingsWindow.h"
 #include "../SandMan.h"
@@ -764,13 +764,10 @@ CAccessControlPage::CAccessControlPage(QWidget *parent)
 
     QVBoxLayout* pLayout = new QVBoxLayout;
 
-    m_pAccessControl = new CAccessControlWidget();
-    m_pAccessControl->SetTypes(QList<QPair<QString, QString>>()
-        << qMakePair(tr("Block"), QString("BlockFilePath"))
-        << qMakePair(tr("Normal"), QString("NormalFilePath"))
-        << qMakePair(tr("Write"), QString("WriteFilePath"))
-        << qMakePair(tr("Read"), QString("ReadFilePath")));
-    pLayout->addWidget(m_pAccessControl);
+    m_pFileAccess = new CSharedFileWidget(this);
+    m_pFileAccess->SetShowTemplates(false);
+    m_pFileAccess->SetTemplatesEnabled(false);
+    pLayout->addWidget(m_pFileAccess);
 
     setLayout(pLayout);
 }
@@ -791,7 +788,14 @@ bool CAccessControlPage::validatePage()
 
 QList<QPair<QString, QString>> CAccessControlPage::GetFileAccessEntries() const
 {
-    return m_pAccessControl->GetEntries();
+    QList<QPair<QString, QString>> Entries;
+    QMap<QString, QList<QString>> AccessMap = m_pFileAccess->GetAccessList();
+    for (QMap<QString, QList<QString>>::const_iterator I = AccessMap.constBegin(); I != AccessMap.constEnd(); ++I)
+    {
+        foreach(const QString& Value, I.value())
+            Entries.append(qMakePair(Value, I.key()));
+    }
+    return Entries;
 }
 
 

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
@@ -7,7 +7,7 @@ QT_BEGIN_NAMESPACE
 class QCheckBox;
 class QLabel;
 class QLineEdit;
-class QListWidget;
+class QTreeWidget;
 class QRadioButton;
 QT_END_NAMESPACE
 
@@ -98,7 +98,7 @@ public:
     void initializePage() override;
     bool validatePage() override;
 
-    QStringList GetNormalFilePaths() const { return m_NormalFilePaths; }
+    QList<QPair<QString, QString>> GetFilePathEntries() const;
 
 private slots:
     void OnAddNormalPath();
@@ -106,9 +106,9 @@ private slots:
 
 private:
     QComboBox* m_pBoxLocation;
-    QListWidget* m_pNormalPaths;
+    QTreeWidget* m_pNormalPaths;
     QLineEdit* m_pNormalPathInput;
-    QStringList m_NormalFilePaths;
+    QComboBox* m_pTypeCombo;
 };
 
 

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
@@ -7,6 +7,7 @@ QT_BEGIN_NAMESPACE
 class QCheckBox;
 class QLabel;
 class QLineEdit;
+class QListWidget;
 class QRadioButton;
 QT_END_NAMESPACE
 
@@ -97,8 +98,17 @@ public:
     void initializePage() override;
     bool validatePage() override;
 
+    QStringList GetNormalFilePaths() const { return m_NormalFilePaths; }
+
+private slots:
+    void OnAddNormalPath();
+    void OnRemoveNormalPath();
+
 private:
     QComboBox* m_pBoxLocation;
+    QListWidget* m_pNormalPaths;
+    QLineEdit* m_pNormalPathInput;
+    QStringList m_NormalFilePaths;
 };
 
 

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
@@ -7,9 +7,10 @@ QT_BEGIN_NAMESPACE
 class QCheckBox;
 class QLabel;
 class QLineEdit;
-class QTreeWidget;
 class QRadioButton;
 QT_END_NAMESPACE
+
+class CAccessControlWidget;
 
 //#define USE_COMBO
 
@@ -18,7 +19,7 @@ class CNewBoxWizard : public QWizard
     Q_OBJECT
 
 public:
-    enum { Page_Type, Page_Files, Page_Isolation, Page_Advanced, Page_Summary };
+    enum { Page_Type, Page_Files, Page_AccessControl, Page_Isolation, Page_Advanced, Page_Summary };
 
     CNewBoxWizard(bool bAlowTemp, QWidget *parent = nullptr);
 
@@ -98,17 +99,31 @@ public:
     void initializePage() override;
     bool validatePage() override;
 
-    QList<QPair<QString, QString>> GetFilePathEntries() const;
-
-private slots:
-    void OnAddNormalPath();
-    void OnRemoveNormalPath();
-
 private:
     QComboBox* m_pBoxLocation;
-    QTreeWidget* m_pNormalPaths;
-    QLineEdit* m_pNormalPathInput;
-    QComboBox* m_pTypeCombo;
+    QCheckBox* m_pSetAccessControl;
+};
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAccessControlPage
+// 
+
+class CAccessControlPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    CAccessControlPage(QWidget *parent = nullptr);
+
+    int nextId() const override;
+    void initializePage() override;
+    bool validatePage() override;
+
+    QList<QPair<QString, QString>> GetFileAccessEntries() const;
+
+private:
+    CAccessControlWidget* m_pAccessControl;
 };
 
 

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
@@ -10,7 +10,7 @@ class QLineEdit;
 class QRadioButton;
 QT_END_NAMESPACE
 
-class CAccessControlWidget;
+class CSharedFileWidget;
 
 //#define USE_COMBO
 
@@ -123,7 +123,7 @@ public:
     QList<QPair<QString, QString>> GetFileAccessEntries() const;
 
 private:
-    CAccessControlWidget* m_pAccessControl;
+    CSharedFileWidget* m_pFileAccess;
 };
 
 


### PR DESCRIPTION
First draft by DeepSeek

Introduce `QTreeWidget` in `NewBoxWizard.cpp`, and implement file access control functionality in the `CFilesPage` class, including a path input field, type selector (QComboBox with Closed/Normal/Write/Read mappings), browse button, and add/remove buttons.

Update the `TryToCreateBox` method to read file path entries from `GetFilePathEntries()` and persist them to the box configuration.

Display file access rules in the summary page's `initializePage` method.

Add new `OnAddNormalPath` and `OnRemoveNormalPath` methods to handle path addition and removal.

Additionally, add the `GetFilePathEntries` method and related private slot functions and member variables in `NewBoxWizard.h`.