### PR TITLE
Add CopyNewer file migration rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.18.1 / 5.73.1] - 2026-07-??
 
+### Added
+- added `CopyNewer` file migration rules to refresh an existing sandbox copy from a newer host file, with SandMan rule editing support; it only applies to matching existing regular boxed files on normal opens, intentionally replacing their contents only when the host file has a newer last-write time
+  - it does not apply to initial migration, directories, write-only paths, deleted files, or create/overwrite operations
+
 ### Changed
 - updated Chromium_Elevation template now using specifig 'RunServiceAsSystem=...' instead of 'RunServicesAsSystem=y' and added more service names
+- improved SandMan INI setting validation and auto-completion with disabled-setting aliases, localized descriptions, context-aware warnings, and template-specific metadata and tooltips
 
 ### Fixed
 - fixed incremental update mechanism fails to copy new files

--- a/Sandboxie/core/dll/file.c
+++ b/Sandboxie/core/dll/file.c
@@ -274,6 +274,9 @@ static NTSTATUS File_MigrateFile(
     const WCHAR *TruePath, const WCHAR *CopyPath,
     BOOLEAN IsWritePath, BOOLEAN WithContents);
 
+static BOOLEAN File_RefreshNewerCopy(
+    const WCHAR *TruePath, const WCHAR *CopyPath);
+
 static NTSTATUS File_MigrateJunction(
     const WCHAR *TruePath, const WCHAR *CopyPath,
     BOOLEAN IsWritePath);
@@ -4099,6 +4102,15 @@ ReparseLoop:
 
     if (! NT_SUCCESS(status))
         __leave;
+
+    // CopyNewer refreshes an existing regular sandbox copy before it is
+    // opened.  A failed or deferred refresh intentionally leaves the current
+    // copy available to the application.
+    if (HaveCopyFile && (FileType & TYPE_FILE) &&
+            (CreateDisposition == FILE_OPEN || CreateDisposition == FILE_OPEN_IF) &&
+            PATH_NOT_WRITE(mp_flags) && !(FileType & TYPE_DELETED)) {
+        File_RefreshNewerCopy(TruePath, CopyPath);
+    }
 
     //
     // check creation parameters again, now that we know the file type

--- a/Sandboxie/core/dll/file_copy.c
+++ b/Sandboxie/core/dll/file_copy.c
@@ -35,6 +35,8 @@ static BOOLEAN File_Chrome_RemoveEncryptedHashes(char *buffer, ULONGLONG *size);
 
 static BOOLEAN File_CopyNewerMatches(const WCHAR *TruePath);
 
+static ULONG File_CopyNewerHashPath(const WCHAR *CopyPath);
+
 //---------------------------------------------------------------------------
 // Variables
 //---------------------------------------------------------------------------
@@ -115,6 +117,27 @@ static _FX BOOLEAN File_CopyNewerMatches(const WCHAR *TruePath)
 
 
 //---------------------------------------------------------------------------
+// File_CopyNewerHashPath
+//---------------------------------------------------------------------------
+
+
+static _FX ULONG File_CopyNewerHashPath(const WCHAR *CopyPath)
+{
+    ULONG hash = 2166136261UL;
+
+    while (*CopyPath) {
+        WCHAR c = *CopyPath++;
+        if (c >= L'A' && c <= L'Z')
+            c |= 0x20;
+        hash ^= (ULONG)(USHORT)c;
+        hash *= 16777619UL;
+    }
+
+    return hash;
+}
+
+
+//---------------------------------------------------------------------------
 // File_RefreshNewerCopy
 //---------------------------------------------------------------------------
 
@@ -130,6 +153,7 @@ static _FX BOOLEAN File_RefreshNewerCopy(
     HANDLE mutex, temp_handle;
     NTSTATUS status;
     ULONG i;
+    DWORD wait_result;
 
     if (!File_CopyNewerMatches(TruePath))
         return FALSE;
@@ -141,13 +165,15 @@ static _FX BOOLEAN File_RefreshNewerCopy(
     if (!mutex_name)
         return FALSE;
     Sbie_snwprintf(mutex_name, wcslen(Dll_BoxName) + 32,
-        L"Sandboxie_CopyNewer_%s", Dll_BoxName);
+        L"Sandboxie_CopyNewer_%s_%08X", Dll_BoxName,
+        File_CopyNewerHashPath(CopyPath));
 
     mutex = CreateMutex(NULL, FALSE, mutex_name);
     Dll_Free(mutex_name);
     if (!mutex)
         return FALSE;
-    if (WaitForSingleObject(mutex, 0) != WAIT_OBJECT_0) {
+    wait_result = WaitForSingleObject(mutex, 0);
+    if (wait_result != WAIT_OBJECT_0 && wait_result != WAIT_ABANDONED) {
         CloseHandle(mutex);
         return FALSE;
     }

--- a/Sandboxie/core/dll/file_copy.c
+++ b/Sandboxie/core/dll/file_copy.c
@@ -33,6 +33,8 @@ static BOOLEAN File_InitFileMigration(void);
 
 static BOOLEAN File_Chrome_RemoveEncryptedHashes(char *buffer, ULONGLONG *size);
 
+static BOOLEAN File_CopyNewerMatches(const WCHAR *TruePath);
+
 //---------------------------------------------------------------------------
 // Variables
 //---------------------------------------------------------------------------
@@ -48,6 +50,7 @@ typedef enum { // Note: thisorder defines the config priority
 } ENUM_COPY_MODES;
 
 static LIST File_MigrationOptions[NUM_COPY_MODES];
+static LIST File_CopyNewerOptions;
 
 static BOOLEAN File_MigrationDenyWrite = FALSE;
 
@@ -64,10 +67,12 @@ _FX BOOLEAN File_InitFileMigration(void)
 {
     for(ULONG i=0; i < NUM_COPY_MODES; i++)
         List_Init(&File_MigrationOptions[i]);
+    List_Init(&File_CopyNewerOptions);
 
     Config_InitPatternList(NULL, L"CopyEmpty", &File_MigrationOptions[FILE_COPY_EMPTY], FALSE);
     Config_InitPatternList(NULL, L"CopyAlways", &File_MigrationOptions[FILE_COPY_CONTENT], FALSE);
     Config_InitPatternList(NULL, L"DontCopy", &File_MigrationOptions[FILE_DONT_COPY], FALSE);
+    Config_InitPatternList(NULL, L"CopyNewer", &File_CopyNewerOptions, FALSE);
 
     File_MigrationDenyWrite = Config_GetSettingsForImageName_bool(L"CopyBlockDenyWrite", FALSE);
 
@@ -76,6 +81,144 @@ _FX BOOLEAN File_InitFileMigration(void)
     File_NotifyNoCopy = SbieApi_QueryConfBool(NULL, L"NotifyNoCopy", FALSE);
 
     return TRUE;
+}
+
+
+//---------------------------------------------------------------------------
+// File_CopyNewerMatches
+//---------------------------------------------------------------------------
+
+
+static _FX BOOLEAN File_CopyNewerMatches(const WCHAR *TruePath)
+{
+    ULONG path_len = (wcslen(TruePath) + 1) * sizeof(WCHAR);
+    WCHAR *path_lwr = Dll_AllocTemp(path_len);
+    if (!path_lwr)
+        return FALSE;
+
+    memcpy(path_lwr, TruePath, path_len);
+    _wcslwr(path_lwr);
+    path_len = wcslen(path_lwr);
+
+    PATTERN *pat = List_Head(&File_CopyNewerOptions);
+    while (pat) {
+        if (Pattern_Match(pat, path_lwr, path_len)) {
+            Dll_Free(path_lwr);
+            return TRUE;
+        }
+        pat = List_Next(pat);
+    }
+
+    Dll_Free(path_lwr);
+    return FALSE;
+}
+
+
+//---------------------------------------------------------------------------
+// File_RefreshNewerCopy
+//---------------------------------------------------------------------------
+
+
+static _FX BOOLEAN File_RefreshNewerCopy(
+    const WCHAR *TruePath, const WCHAR *CopyPath)
+{
+    FILE_NETWORK_OPEN_INFORMATION true_info, copy_info;
+    OBJECT_ATTRIBUTES objattrs;
+    UNICODE_STRING objname;
+    IO_STATUS_BLOCK IoStatusBlock;
+    WCHAR *mutex_name, *temp_path;
+    HANDLE mutex, temp_handle;
+    NTSTATUS status;
+    ULONG i;
+
+    if (!File_CopyNewerMatches(TruePath))
+        return FALSE;
+
+    // The mutex is deliberately box-wide.  It keeps simultaneous applications
+    // from replacing two matching files at the same time, while a zero wait
+    // leaves the current boxed version usable when another refresh is active.
+    mutex_name = Dll_AllocTemp((wcslen(Dll_BoxName) + 32) * sizeof(WCHAR));
+    if (!mutex_name)
+        return FALSE;
+    Sbie_snwprintf(mutex_name, wcslen(Dll_BoxName) + 32,
+        L"Sandboxie_CopyNewer_%s", Dll_BoxName);
+
+    mutex = CreateMutex(NULL, FALSE, mutex_name);
+    Dll_Free(mutex_name);
+    if (!mutex)
+        return FALSE;
+    if (WaitForSingleObject(mutex, 0) != WAIT_OBJECT_0) {
+        CloseHandle(mutex);
+        return FALSE;
+    }
+
+    InitializeObjectAttributes(&objattrs, &objname, OBJ_CASE_INSENSITIVE, NULL, NULL);
+    RtlInitUnicodeString(&objname, TruePath);
+    status = __sys_NtQueryFullAttributesFile
+        ? __sys_NtQueryFullAttributesFile(&objattrs, &true_info)
+        : NtQueryFullAttributesFile(&objattrs, &true_info);
+    if (NT_SUCCESS(status)) {
+        RtlInitUnicodeString(&objname, CopyPath);
+        status = __sys_NtQueryFullAttributesFile
+            ? __sys_NtQueryFullAttributesFile(&objattrs, &copy_info)
+            : NtQueryFullAttributesFile(&objattrs, &copy_info);
+    }
+
+    if (!NT_SUCCESS(status) ||
+            true_info.LastWriteTime.QuadPart <= copy_info.LastWriteTime.QuadPart) {
+        ReleaseMutex(mutex);
+        CloseHandle(mutex);
+        return FALSE;
+    }
+
+    temp_path = Dll_AllocTemp((wcslen(CopyPath) + 32) * sizeof(WCHAR));
+    if (!temp_path) {
+        ReleaseMutex(mutex);
+        CloseHandle(mutex);
+        return FALSE;
+    }
+
+    status = STATUS_OBJECT_NAME_COLLISION;
+    for (i = 0; i != 4 && status == STATUS_OBJECT_NAME_COLLISION; ++i) {
+        Sbie_snwprintf(temp_path, wcslen(CopyPath) + 32,
+            L"%s.CopyNewer.%08X", CopyPath, GetTickCount() + i);
+        status = File_MigrateFile(TruePath, temp_path, FALSE, TRUE);
+    }
+
+    if (NT_SUCCESS(status)) {
+        RtlInitUnicodeString(&objname, temp_path);
+        status = __sys_NtCreateFile(&temp_handle, DELETE | SYNCHRONIZE,
+            &objattrs, &IoStatusBlock, NULL, 0, FILE_SHARE_VALID_FLAGS,
+            FILE_OPEN, FILE_SYNCHRONOUS_IO_NONALERT | FILE_NON_DIRECTORY_FILE,
+            NULL, 0);
+        if (NT_SUCCESS(status)) {
+            ULONG name_len = wcslen(CopyPath) * sizeof(WCHAR);
+            ULONG info_len = sizeof(FILE_RENAME_INFORMATION) + name_len;
+            FILE_RENAME_INFORMATION *info = Dll_AllocTemp(info_len);
+            if (!info)
+                status = STATUS_INSUFFICIENT_RESOURCES;
+            else {
+                memzero(info, info_len);
+                info->ReplaceIfExists = TRUE;
+                info->FileNameLength = name_len;
+                memcpy(info->FileName, CopyPath, name_len);
+                status = __sys_NtSetInformationFile(temp_handle, &IoStatusBlock,
+                    info, info_len, FileRenameInformation);
+                Dll_Free(info);
+            }
+            NtClose(temp_handle);
+        }
+    }
+
+    if (!NT_SUCCESS(status)) {
+        RtlInitUnicodeString(&objname, temp_path);
+        __sys_NtDeleteFile(&objattrs);
+    }
+
+    Dll_Free(temp_path);
+    ReleaseMutex(mutex);
+    CloseHandle(mutex);
+    return NT_SUCCESS(status);
 }
 
 

--- a/Sandboxie/install/SbieSettings.ini
+++ b/Sandboxie/install/SbieSettings.ini
@@ -77,7 +77,7 @@ _HideConfExclusions=Tmpl.Class|;Tmpl.Comment|;Tmpl.Entry|;Tmpl.Hide|;Tmpl.Scan*|
 # Semi-colon (;) : Record terminator.
 ###
 
-_DisabledSettingsConf=AutoExecDisabled|AutoExec|g;BoxAliasDisabled|BoxAlias|g;BreakoutDocumentDisabled|BreakoutDocument|g;BreakoutFolderDisabled|BreakoutFolder|g;BreakoutProcessDisabled|BreakoutProcess|g;ClosedClsidDisabled|ClosedClsid|g;ClosedFilePathDisabled|ClosedFilePath|g;ClosedIpcPathDisabled|ClosedIpcPath|g;ClosedKeyPathDisabled|ClosedKeyPath|g;ClosedRTDisabled|ClosedRT|g;CopyAlwaysDisabled|CopyAlways|g;CopyEmptyDisabled|CopyEmpty|g;DontCopyDisabled|DontCopy|g;ForceChildrenDisabled|ForceChildren|g;ForceFolderDisabled|ForceFolder|g;ForceProcessDisabled|ForceProcess|g;LeaderProcessDisabled|LeaderProcess|g;LingerProcessDisabled|LingerProcess|g;NetworkAccessDisabled|NetworkAccess|g;NetworkDnsFilterDisabled|NetworkDnsFilter|g;NetworkUseProxyDisabled|NetworkUseProxy|g;NoRenameWinClassDisabled|NoRenameWinClass|g;NormalFilePathDisabled|NormalFilePath|g;NormalIpcPathDisabled|NormalIpcPath|g;NormalKeyPathDisabled|NormalKeyPath|g;NotifyForceProcessDisabled|NotifyForceProcessEnabled|g;OnBoxDeleteDisabled|OnBoxDelete|g;OnBoxTerminateDisabled|OnBoxTerminate|g;OnFileRecoveryDisabled|OnFileRecovery|g;OpenClsidDisabled|OpenClsid|g;OpenConfPathDisabled|OpenConfPath|g;OpenFilePathDisabled|OpenFilePath|g;OpenIpcPathDisabled|OpenIpcPath|g;OpenKeyPathDisabled|OpenKeyPath|g;OpenPipePathDisabled|OpenPipePath|g;OpenWinClassDisabled|OpenWinClass|g;ReadFilePathDisabled|ReadFilePath|g;ReadIpcPathDisabled|ReadIpcPath|g;ReadKeyPathDisabled|ReadKeyPath|g;StartProgramDisabled|StartProgram|g;StartServiceDisabled|StartService|g;WriteFilePathDisabled|WriteFilePath|g;WriteKeyPathDisabled|WriteKeyPath|g;
+_DisabledSettingsConf=AutoExecDisabled|AutoExec|g;BoxAliasDisabled|BoxAlias|g;BreakoutDocumentDisabled|BreakoutDocument|g;BreakoutFolderDisabled|BreakoutFolder|g;BreakoutProcessDisabled|BreakoutProcess|g;ClosedClsidDisabled|ClosedClsid|g;ClosedFilePathDisabled|ClosedFilePath|g;ClosedIpcPathDisabled|ClosedIpcPath|g;ClosedKeyPathDisabled|ClosedKeyPath|g;ClosedRTDisabled|ClosedRT|g;CopyAlwaysDisabled|CopyAlways|g;CopyEmptyDisabled|CopyEmpty|g;CopyNewerDisabled|CopyNewer|g;DontCopyDisabled|DontCopy|g;ForceChildrenDisabled|ForceChildren|g;ForceFolderDisabled|ForceFolder|g;ForceProcessDisabled|ForceProcess|g;LeaderProcessDisabled|LeaderProcess|g;LingerProcessDisabled|LingerProcess|g;NetworkAccessDisabled|NetworkAccess|g;NetworkDnsFilterDisabled|NetworkDnsFilter|g;NetworkUseProxyDisabled|NetworkUseProxy|g;NoRenameWinClassDisabled|NoRenameWinClass|g;NormalFilePathDisabled|NormalFilePath|g;NormalIpcPathDisabled|NormalIpcPath|g;NormalKeyPathDisabled|NormalKeyPath|g;NotifyForceProcessDisabled|NotifyForceProcessEnabled|g;OnBoxDeleteDisabled|OnBoxDelete|g;OnBoxTerminateDisabled|OnBoxTerminate|g;OnFileRecoveryDisabled|OnFileRecovery|g;OpenClsidDisabled|OpenClsid|g;OpenConfPathDisabled|OpenConfPath|g;OpenFilePathDisabled|OpenFilePath|g;OpenIpcPathDisabled|OpenIpcPath|g;OpenKeyPathDisabled|OpenKeyPath|g;OpenPipePathDisabled|OpenPipePath|g;OpenWinClassDisabled|OpenWinClass|g;ReadFilePathDisabled|ReadFilePath|g;ReadIpcPathDisabled|ReadIpcPath|g;ReadKeyPathDisabled|ReadKeyPath|g;StartProgramDisabled|StartProgram|g;StartServiceDisabled|StartService|g;WriteFilePathDisabled|WriteFilePath|g;WriteKeyPathDisabled|WriteKeyPath|g;
 
 #################################
 # DISABLED SETTINGS - END       #
@@ -1533,6 +1533,19 @@ Context=
 Requirements=
 Syntax=[sn]=[process,]pattern\npattern: *.log\n[b]Note[/b]: When a program is specified, paths must use a wildcard character\nfor the drive or device letter and must not rely on expanded environment variables,\nas both result in a full path.\n\t- [b]Correct:[/b] [code]*\Folder\file.log[/code]\n\t- [b]Incorrect:[/b] [code]C:\Folder\file.log[/code] or [code]%USERPROFILE%\Documents\file.log[/code]
 Description=Forces a file to be fully copied into the sandbox (including its contents) when accessed.
+
+
+[CopyNewer]
+AddedVersion=1.18.1
+RemovedVersion=
+ReAddedVersion=
+RenamedVersion=
+SupersededBy=
+Category=f
+Context=
+Requirements=
+Syntax=[sn]=[process,]pattern\npattern: *.json\n[b]Note[/b]: When a program is specified, paths must use a wildcard character\nfor the drive or device letter and must not rely on expanded environment variables,\nas both result in a full path.
+Description=Before opening an existing sandbox copy, replaces it with the host file when the host file is newer.\nThe replacement is skipped if another process is currently refreshing the sandbox.
 
 
 [CopyBlockDenyWrite]
@@ -3316,7 +3329,6 @@ Context=
 Requirements=
 Syntax=[sn]=[process,]registry_key
 Description=Defines key patterns where Sandboxie applies default sandboxing,\noverriding more specific parent rules (Open/Closed/Read/Write).
-
 
 
 [NoSandboxieConsole]

--- a/SandboxiePlus/SandMan/Windows/OptionsGeneral.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsGeneral.cpp
@@ -606,6 +606,8 @@ void COptionsWindow::LoadCopyRules()
 		ParseAndAddCopyRule(Value, eDontCopy);
 	foreach(const QString & Value, m_pBox->GetTextList("CopyEmpty", m_Template))
 		ParseAndAddCopyRule(Value, eCopyEmpty);
+	foreach(const QString & Value, m_pBox->GetTextList("CopyNewer", m_Template))
+		ParseAndAddCopyRule(Value, eCopyNewer);
 
 	foreach(const QString & Value, m_pBox->GetTextList("CopyAlwaysDisabled", m_Template))
 		ParseAndAddCopyRule(Value, eCopyAlways, true);
@@ -613,6 +615,8 @@ void COptionsWindow::LoadCopyRules()
 		ParseAndAddCopyRule(Value, eDontCopy, true);
 	foreach(const QString & Value, m_pBox->GetTextList("CopyEmptyDisabled", m_Template))
 		ParseAndAddCopyRule(Value, eCopyEmpty, true);
+	foreach(const QString & Value, m_pBox->GetTextList("CopyNewerDisabled", m_Template))
+		ParseAndAddCopyRule(Value, eCopyNewer, true);
 
 	LoadCopyRulesTmpl();
 
@@ -631,6 +635,8 @@ void COptionsWindow::LoadCopyRulesTmpl(bool bUpdate)
 				ParseAndAddCopyRule(Value, eDontCopy, false, Template);
 			foreach(const QString & Value, m_pBox->GetTextListTmpl("CopyEmpty", Template))
 				ParseAndAddCopyRule(Value, eCopyEmpty, false, Template);
+			foreach(const QString & Value, m_pBox->GetTextListTmpl("CopyNewer", Template))
+				ParseAndAddCopyRule(Value, eCopyNewer, false, Template);
 		}
 	}
 	else if (bUpdate)
@@ -655,6 +661,7 @@ QString COptionsWindow::GetCopyActionStr(ECopyAction Action)
 	case eCopyAlways:	return tr("Always copy");
 	case eDontCopy:		return tr("Don't copy");
 	case eCopyEmpty:	return tr("Copy empty");
+	case eCopyNewer:	return tr("Copy newer");
 	}
 	return "";
 }
@@ -705,6 +712,8 @@ void COptionsWindow::SaveCopyRules()
 	QList<QString> DontCopyDisabled;
 	QList<QString> CopyEmpty;
 	QList<QString> CopyEmptyDisabled;
+	QList<QString> CopyNewer;
+	QList<QString> CopyNewerDisabled;
 	for (int i = 0; i < ui.treeCopy->topLevelItemCount(); i++)
 	{
 		QTreeWidgetItem* pItem = ui.treeCopy->topLevelItem(i);
@@ -723,6 +732,7 @@ void COptionsWindow::SaveCopyRules()
 			case eCopyAlways:	CopyAlways.append(Pattern); break;
 			case eDontCopy:		DontCopy.append(Pattern); break;
 			case eCopyEmpty:	CopyEmpty.append(Pattern); break;
+			case eCopyNewer:	CopyNewer.append(Pattern); break;
 			}
 		}
 		else {
@@ -730,6 +740,7 @@ void COptionsWindow::SaveCopyRules()
 			case eCopyAlways:	CopyAlwaysDisabled.append(Pattern); break;
 			case eDontCopy:		DontCopyDisabled.append(Pattern); break;
 			case eCopyEmpty:	CopyEmptyDisabled.append(Pattern); break;
+			case eCopyNewer:	CopyNewerDisabled.append(Pattern); break;
 			}
 		}
 	}
@@ -739,6 +750,8 @@ void COptionsWindow::SaveCopyRules()
 	WriteTextList("DontCopyDisabled", DontCopyDisabled);
 	WriteTextList("CopyEmpty", CopyEmpty);
 	WriteTextList("CopyEmptyDisabled", CopyEmptyDisabled);
+	WriteTextList("CopyNewer", CopyNewer);
+	WriteTextList("CopyNewerDisabled", CopyNewerDisabled);
 
 	m_CopyRulesChanged = false;
 }
@@ -755,6 +768,7 @@ void COptionsWindow::OnCopyItemDoubleClicked(QTreeWidgetItem* pItem, int Column)
 	pMode->addItem(tr("Always copy"), (int)eCopyAlways);
 	pMode->addItem(tr("Don't copy"), (int)eDontCopy);
 	pMode->addItem(tr("Copy empty"), (int)eCopyEmpty);
+	pMode->addItem(tr("Copy newer"), (int)eCopyNewer);
 	pMode->setCurrentIndex(pMode->findData(pItem->data(0, Qt::UserRole)));
 	ui.treeCopy->setItemWidget(pItem, 0, pMode);
 

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -299,6 +299,7 @@ public:
 		eCopyAlways,
 		eDontCopy,
 		eCopyEmpty,
+		eCopyNewer,
 	};
 
 	enum ENetWfAction


### PR DESCRIPTION
Introduces a new `CopyNewer` sandbox configuration rule that refreshes an existing sandbox copy from the host file when the host file is newer, before the file is opened by an application.

- Implements `File_RefreshNewerCopy` and `File_CopyNewerMatches` in `file_copy.c`
- Hooks into the open-file path in `file.c` for regular files opened without write intent
- Uses a box-wide named mutex to prevent concurrent refreshes; a busy mutex leaves the existing copy in place
- Adds `CopyNewer`/`CopyNewerDisabled` loading, saving, and UI display in SandMan options
- Registers `CopyNewerDisabled` alias in `SbieSettings.ini` and adds setting metadata