### PR TITLE
Add random GUID sandbox name option

### DIFF
--- a/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SettingsWindow.ui
@@ -65,7 +65,14 @@
              <string>General Options</string>
             </attribute>
             <layout class="QGridLayout" name="gridLayout_8">
-             <item row="14" column="3">
+             <item row="12" column="1" colspan="2">
+              <widget class="QCheckBox" name="chkRandomGuidName">
+               <property name="text">
+                <string>Use random GUID as sandbox name when creating new boxes</string>
+               </property>
+              </widget>
+             </item>
+             <item row="15" column="3">
               <spacer name="horizontalSpacer_14">
                <property name="orientation">
                 <enum>Qt::Orientation::Horizontal</enum>
@@ -78,7 +85,7 @@
                </property>
               </spacer>
              </item>
-             <item row="14" column="1">
+             <item row="15" column="1">
               <spacer name="verticalSpacer_4">
                <property name="orientation">
                 <enum>Qt::Orientation::Vertical</enum>
@@ -91,7 +98,7 @@
                </property>
               </spacer>
              </item>
-             <item row="14" column="2">
+             <item row="15" column="2">
               <spacer name="horizontalSpacer_8">
                <property name="orientation">
                 <enum>Qt::Orientation::Horizontal</enum>
@@ -155,7 +162,7 @@
                </property>
               </widget>
              </item>
-             <item row="13" column="1">
+             <item row="14" column="1">
               <layout class="QVBoxLayout" name="verticalLayout_3">
                <property name="bottomMargin">
                 <number>0</number>
@@ -183,7 +190,7 @@
                </item>
               </layout>
              </item>
-             <item row="12" column="0">
+             <item row="13" column="0">
               <widget class="QLabel" name="lblRecovery">
                <property name="font">
                 <font>
@@ -3620,6 +3627,7 @@ Unlike the preview channel, it does not include untested, potentially breaking, 
   <tabstop>chkWatchConfig</tabstop>
   <tabstop>chkSkipUAC</tabstop>
   <tabstop>chkUseW11Style</tabstop>
+  <tabstop>chkRandomGuidName</tabstop>
   <tabstop>chkAdminOnly</tabstop>
   <tabstop>chkPassRequired</tabstop>
   <tabstop>btnSetPassword</tabstop>

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -523,6 +523,7 @@ CSettingsWindow::CSettingsWindow(QWidget* parent)
 	connect(ui.chkRecoveryTop, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
 
 	connect(ui.chkUseW11Style, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
+	connect(ui.chkRandomGuidName, SIGNAL(stateChanged(int)), this, SLOT(OnOptChanged()));
 	QOperatingSystemVersion current = QOperatingSystemVersion::current();
 	ui.chkUseW11Style->setEnabled(current.majorVersion() == 10 && current.microVersion() >= 22000); // Windows 10 22000+ (Windows 11)
 	//
@@ -1543,6 +1544,7 @@ void CSettingsWindow::LoadSettings()
 	ui.chkSingleShow->setChecked(theConf->GetBool("Options/TraySingleClick", false));
 
 	ui.chkUseW11Style->setChecked(theConf->GetBool("Options/UseW11Style", false));
+	ui.chkRandomGuidName->setChecked(theConf->GetBool("Options/UseRandomBoxName", false));
 
 	OnLoadAddon();
 
@@ -2149,6 +2151,7 @@ void CSettingsWindow::SaveSettings()
 	theConf->SetValue("Options/TraySingleClick", ui.chkSingleShow->isChecked());
 
 	theConf->SetValue("Options/UseW11Style", ui.chkUseW11Style->isChecked());
+	theConf->SetValue("Options/UseRandomBoxName", ui.chkRandomGuidName->isChecked());
 
 	if (theAPI->IsConnected())
 	{

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -363,7 +363,10 @@ CBoxTypePage::CBoxTypePage(bool bAlowTemp, QWidget *parent)
         layout->addWidget(m_pAlias, row++, 1, 1, 2);
         m_pAlias->setFocus();
 
-        QString guidName = QUuid::createUuid().toString(QUuid::WithoutBraces).replace("-", "");
+        QString guidName;
+        do {
+            guidName = QUuid::createUuid().toString(QUuid::WithoutBraces).replace("-", "");
+        } while (!theAPI->GetBoxByName(guidName).isNull());
         m_pBoxName = new QLineEdit();
         m_pBoxName->setText(guidName);
         m_pBoxName->setVisible(false);
@@ -1098,6 +1101,9 @@ int CSummaryPage::nextId() const
 void CSummaryPage::initializePage()
 {
     m_pSummary->setText(theGUI->GetBoxDescription(wizard()->field("boxType").toInt()));
+
+    if (((CNewBoxWizard*)wizard())->m_bUseRandomName)
+        m_pSummary->append(tr("\nThe actual sandbox name is: %1").arg(wizard()->field("boxName").toString()));
 
     QString Location = field("boxLocation").toString();
     if (Location.isEmpty())

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -353,7 +353,7 @@ CBoxTypePage::CBoxTypePage(bool bAlowTemp, QWidget *parent)
     layout->addItem(new QSpacerItem(0, 3), row++, 0);
 
     m_pAlias = nullptr;
-    bool bUseRandomName = ((CNewBoxWizard*)wizard())->m_bUseRandomName;
+    bool bUseRandomName = theConf->GetBool("Options/UseRandomBoxName", false);
     if (bUseRandomName)
     {
         layout->addWidget(new QLabel(tr("Alias:")), row++, 0);

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.cpp
@@ -12,6 +12,7 @@
 #include "../Windows/BoxImageWindow.h"
 #include "../AddonManager.h"
 #include <QElapsedTimer>
+#include <QUuid>
 
 
 CNewBoxWizard::CNewBoxWizard(bool bAlowTemp, QWidget *parent)
@@ -24,6 +25,7 @@ CNewBoxWizard::CNewBoxWizard(bool bAlowTemp, QWidget *parent)
     setPage(Page_Summary, new CSummaryPage);
 
     m_bAdvanced = theConf->GetBool("Options/AdvancedBoxWizard", false);
+    m_bUseRandomName = theConf->GetBool("Options/UseRandomBoxName", false);
 
     setWizardStyle(ModernStyle);
     //setOption(HaveHelpButton, true);
@@ -97,6 +99,13 @@ SB_STATUS CNewBoxWizard::TryToCreateBox()
 	if (!Status.IsError())
 	{
 		CSandBoxPtr pBox = theAPI->GetBoxByName(BoxName);
+
+        if (m_bUseRandomName)
+        {
+            QString alias = field("boxNameAlias").toString().trimmed();
+            if (!alias.isEmpty())
+                pBox->SetText("BoxAlias", alias);
+        }
 
         // SharedTemplate
         QElapsedTimer timer;
@@ -343,14 +352,34 @@ CBoxTypePage::CBoxTypePage(bool bAlowTemp, QWidget *parent)
 
     layout->addItem(new QSpacerItem(0, 3), row++, 0);
 
-    layout->addWidget(new QLabel(tr("Enter box name:")), row++, 0);
+    m_pAlias = nullptr;
+    bool bUseRandomName = ((CNewBoxWizard*)wizard())->m_bUseRandomName;
+    if (bUseRandomName)
+    {
+        layout->addWidget(new QLabel(tr("Alias:")), row++, 0);
 
-    m_pBoxName = new QLineEdit();
-    m_pBoxName->setMaxLength(32); // BOXNAME_COUNT
-    m_pBoxName->setText(theAPI->MkNewName("New Box"));
-    m_pBoxName->setFocus();
-    layout->addWidget(m_pBoxName, row++, 1, 1, 2);
+        m_pAlias = new QLineEdit();
+        m_pAlias->setMaxLength(32);
+        layout->addWidget(m_pAlias, row++, 1, 1, 2);
+        m_pAlias->setFocus();
+
+        QString guidName = QUuid::createUuid().toString(QUuid::WithoutBraces).replace("-", "");
+        m_pBoxName = new QLineEdit();
+        m_pBoxName->setText(guidName);
+        m_pBoxName->setVisible(false);
+    }
+    else
+    {
+        layout->addWidget(new QLabel(tr("Enter box name:")), row++, 0);
+
+        m_pBoxName = new QLineEdit();
+        m_pBoxName->setMaxLength(32); // BOXNAME_COUNT
+        m_pBoxName->setText(theAPI->MkNewName("New Box"));
+        m_pBoxName->setFocus();
+        layout->addWidget(m_pBoxName, row++, 1, 1, 2);
+    }
     registerField("boxName", m_pBoxName);
+    registerField("boxNameAlias", m_pAlias ? m_pAlias : m_pBoxName);
 
 
     /*QLabel* pMore = new QLabel(tr("<a href=\"more\">More Types</a>"));
@@ -530,6 +559,8 @@ void CBoxTypePage::OnAdvanced()
     if (m_bInstant)
     {
         QString BoxName = m_pBoxName->text();
+        QString Alias;
+        if (m_pAlias) Alias = m_pAlias->text();
 #ifdef USE_COMBO
         int BoxType = m_pBoxType->currentIndex();
 #endif
@@ -537,6 +568,7 @@ void CBoxTypePage::OnAdvanced()
         wizard()->restart();
 
         m_pBoxName->setText(BoxName);
+        if (m_pAlias) m_pAlias->setText(Alias);
 #ifdef USE_COMBO
         m_pBoxType->setCurrentIndex(BoxType);
 #endif

--- a/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
+++ b/SandboxiePlus/SandMan/Wizards/NewBoxWizard.h
@@ -35,6 +35,7 @@ protected:
     SB_STATUS TryToCreateBox();
 
     bool m_bAdvanced;
+    bool m_bUseRandomName;
 };
 
 
@@ -75,6 +76,7 @@ private:
     QLabel*         m_pInfoLabel;
 #endif
     QLineEdit*      m_pBoxName;
+    QLineEdit*      m_pAlias;
     QButtonGroup*   m_TypeGroup;
     QCheckBox*      m_pAdvanced;
 


### PR DESCRIPTION
First draft by Deepseek

Add a checkbox `chkRandomGuidName` in `SettingsWindow.ui` to allow users to select using a random GUID as the name when creating a new sandbox. Update the related layout to accommodate the new control.

Connect the checkbox state change signal in `SettingsWindow.cpp`, and implement reading and saving the state in `LoadSettings()` and `SaveSettings()`.

Introduce a boolean variable `m_bUseRandomName` in `NewBoxWizard.cpp`, and modify the sandbox name generation logic based on the value of this variable to support random names or user-defined names.

Add a member variable `m_pAlias` in `NewBoxWizard.h` to store the alias entered by the user.