### PR TITLE
Add command-line flag injection

### DIFF
--- a/Sandboxie/core/dll/kernel.c
+++ b/Sandboxie/core/dll/kernel.c
@@ -221,6 +221,62 @@ _FX BOOLEAN Kernel_Init()
 		}
 	}
 
+	//
+	// InjectCmdLine: inject command-line flags into any process
+	// Format: InjectCmdLine=process_name.exe,flags to inject
+	//
+	if (!Kernel_CommandLineW.Buffer) {
+		RTL_USER_PROCESS_PARAMETERS* ProcessParms = Proc_GetRtlUserProcessParameters();
+
+		if (!wcsstr(ProcessParms->CommandLine.Buffer, L" --type=")) {
+
+			WCHAR buf[CONF_LINE_LEN];
+			ULONG index = 0;
+			while (1) {
+				NTSTATUS status = SbieApi_QueryConfAsIs(NULL, L"InjectCmdLine", index, buf, ARRAYSIZE(buf));
+				if (!NT_SUCCESS(status)) break;
+				++index;
+
+				WCHAR* ptr = wcschr(buf, L',');
+				if (!ptr) continue;
+
+				*ptr++ = L'\0';
+
+				if (_wcsicmp(Dll_ImageName, buf) == 0) {
+
+					const WCHAR* lpCommandLine = ProcessParms->CommandLine.Buffer;
+					const WCHAR* lpArguments = SbieDll_FindArgumentEnd(lpCommandLine);
+					if (lpArguments == NULL)
+						lpArguments = wcsrchr(lpCommandLine, L'\0');
+
+					Kernel_CommandLineW.MaximumLength = ProcessParms->CommandLine.MaximumLength + (CONF_LINE_LEN + 8) * sizeof(WCHAR);
+					Kernel_CommandLineW.Buffer = LocalAlloc(LMEM_FIXED, Kernel_CommandLineW.MaximumLength);
+
+					wmemcpy(Kernel_CommandLineW.Buffer, lpCommandLine, lpArguments - lpCommandLine);
+					Kernel_CommandLineW.Buffer[lpArguments - lpCommandLine] = 0;
+
+					if (Kernel_CommandLineW.Buffer[lpArguments - lpCommandLine - 1] != L' ')
+						wcscat(Kernel_CommandLineW.Buffer, L" ");
+					wcscat(Kernel_CommandLineW.Buffer, ptr);
+
+					wcscat(Kernel_CommandLineW.Buffer, lpArguments);
+
+					Kernel_CommandLineW.Length = wcslen(Kernel_CommandLineW.Buffer) * sizeof(WCHAR);
+
+					RtlUnicodeStringToAnsiString(&Kernel_CommandLineA, &Kernel_CommandLineW, TRUE);
+
+					void* GetCommandLineW = GetProcAddress(Dll_KernelBase ? Dll_KernelBase : Dll_Kernel32, "GetCommandLineW");
+					SBIEDLL_HOOK(Kernel_, GetCommandLineW);
+
+					void* GetCommandLineA = GetProcAddress(Dll_KernelBase ? Dll_KernelBase : Dll_Kernel32, "GetCommandLineA");
+					SBIEDLL_HOOK(Kernel_, GetCommandLineA);
+
+					break;
+				}
+			}
+		}
+	}
+
 	if (SbieApi_QueryConfBool(NULL, L"BlockInterferePower", FALSE)) {
 
         SBIEDLL_HOOK(Kernel_, SetThreadExecutionState);


### PR DESCRIPTION
In `kernel.c`, the functionality to inject command-line flags has been implemented.
This functionality checks the command-line arguments of the current process and injects specified flags based on the `InjectCmdLine` settings in the configuration file. At the same time, it hooks the `GetCommandLineW` and `GetCommandLineA` functions to ensure that the new command line can be correctly retrieved.
