### PR TITLE
Preserve tree state with auto-expand toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - added outside sandboxed-window border modes (`onoutside`, `ttloutside`, and `alloutside`) in SandMan; these draw the configured border outside the application frame, while the new `BorderInsideMaximized=y` setting (enabled by default) moves the border and label inside maximized or snapped windows so they remain visible
+- added persistence for manually expanded and collapsed SandMan process-tree branches across task-list refreshes and UI restarts [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)
+
+### Changed
+- changed SandMan's Auto Expand Tree to temporarily expand box groups, sandboxes, and process branches without overwriting their saved manual expansion states; set the SandMan UI configuration option `Options/LegacyAutoExpandTree=true` to retain the previous expand-all/collapse-all behavior [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)
 
 ### Fixed
 - fixed SandMan File Panel column widths resetting when switching between boxes [#5473](https://github.com/sandboxie-plus/Sandboxie/issues/5473)

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -4198,10 +4198,8 @@ void CSandMan::OnAutoExpand()
 {
 	theConf->SetValue("Options/AutoExpandTree", m_pAutoExpand->isChecked());
 
-	if (m_pAutoExpand->isChecked())
-		m_pBoxView->GetTree()->expandAll();
-	else
-		m_pBoxView->GetTree()->collapseAll();
+	m_pBoxView->SetAutoExpand(m_pAutoExpand->isChecked(),
+		theConf->GetBool("Options/LegacyAutoExpandTree", false));
 }
 
 void CSandMan::OnSettings()

--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -558,8 +558,10 @@ void CSbieView::Refresh()
 				if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
 					CBoxedProcessPtr pProcess = m_pSbieModel->GetProcess(ModelIndex);
 					QString Key = GetProcessExpandKey(pProcess);
-					bool bExpand = bAutoExpand && !bLegacyAutoExpand;
-					if (!bExpand)
+					bool bExpand;
+					if (bAutoExpand && !bLegacyAutoExpand)
+						bExpand = !m_AutoExpandCollapsed.contains(GetExpandStateKey(ModelIndex));
+					else
 						bExpand = m_ProcessExpandState.contains(Key)
 							? m_ProcessExpandState.value(Key) : bAutoExpand;
 					if (bExpand) {
@@ -581,7 +583,10 @@ void CSbieView::Refresh()
 					else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eBox)
 						Name = m_pSbieModel->GetSandBox(ModelIndex)->GetName();
 
-					if ((bAutoExpand && !bLegacyAutoExpand) || !m_Collapsed.contains(Name)) {
+					bool bExpand = bAutoExpand && !bLegacyAutoExpand
+						? !m_AutoExpandCollapsed.contains(GetExpandStateKey(ModelIndex))
+						: !m_Collapsed.contains(Name);
+					if (bExpand) {
 						m_HoldExpand = true;
 						m_pSbieTree->expand(m_pSortProxy->mapFromSource(ModelIndex));
 						m_HoldExpand = false;
@@ -2726,11 +2731,21 @@ void CSbieView::ShowOptions(const QString& Name)
 
 void CSbieView::ChangeExpand(const QModelIndex& index, bool bExpand)
 {
-	if (m_HoldExpand || (theGUI->IsAutoExpand()
-	 && !theConf->GetBool("Options/LegacyAutoExpandTree", false)))
+	if (m_HoldExpand)
 		return;
 
 	QModelIndex ModelIndex = m_pSortProxy->mapToSource(index);
+	if (theGUI->IsAutoExpand()
+	 && !theConf->GetBool("Options/LegacyAutoExpandTree", false)) {
+		QString Key = GetExpandStateKey(ModelIndex);
+		if (!Key.isEmpty()) {
+			if (bExpand)
+				m_AutoExpandCollapsed.remove(Key);
+			else
+				m_AutoExpandCollapsed.insert(Key);
+		}
+		return;
+	}
 
 	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
 		QString Key = GetProcessExpandKey(m_pSbieModel->GetProcess(ModelIndex));
@@ -2762,6 +2777,8 @@ void CSbieView::ChangeExpand(const QModelIndex& index, bool bExpand)
 
 void CSbieView::SetAutoExpand(bool bExpand, bool bLegacy)
 {
+	m_AutoExpandCollapsed.clear();
+
 	if (bLegacy) {
 		if (bExpand)
 			m_pSbieTree->expandAll();
@@ -2774,18 +2791,20 @@ void CSbieView::SetAutoExpand(bool bExpand, bool bLegacy)
 	if (bExpand)
 		m_pSbieTree->expandAll();
 	else
-		RestoreExpandState();
+		ApplyExpandState(false);
 	m_HoldExpand = false;
 }
 
-void CSbieView::RestoreExpandState(const QModelIndex& Parent)
+void CSbieView::ApplyExpandState(bool bAutoExpand, const QModelIndex& Parent)
 {
 	for (int Row = 0; Row < m_pSortProxy->rowCount(Parent); ++Row) {
 		QModelIndex Index = m_pSortProxy->index(Row, 0, Parent);
 		QModelIndex ModelIndex = m_pSortProxy->mapToSource(Index);
 
-		bool bExpand = false;
-		if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
+		bool bExpand;
+		if (bAutoExpand)
+			bExpand = !m_AutoExpandCollapsed.contains(GetExpandStateKey(ModelIndex));
+		else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
 			QString Key = GetProcessExpandKey(m_pSbieModel->GetProcess(ModelIndex));
 			bExpand = m_ProcessExpandState.value(Key, false);
 		}
@@ -2799,8 +2818,21 @@ void CSbieView::RestoreExpandState(const QModelIndex& Parent)
 		}
 
 		m_pSbieTree->setExpanded(Index, bExpand);
-		RestoreExpandState(Index);
+		ApplyExpandState(bAutoExpand, Index);
 	}
+}
+
+QString CSbieView::GetExpandStateKey(const QModelIndex& ModelIndex) const
+{
+	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
+		QString Key = GetProcessExpandKey(m_pSbieModel->GetProcess(ModelIndex));
+		return Key.isEmpty() ? QString() : "p|" + Key;
+	}
+	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eGroup)
+		return "g|" + m_pSbieModel->GetID(ModelIndex).toString();
+	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eBox)
+		return "b|" + m_pSbieModel->GetSandBox(ModelIndex)->GetName();
+	return QString();
 }
 
 QString CSbieView::GetProcessExpandKey(const CBoxedProcessPtr& pProcess) const
@@ -2843,6 +2875,12 @@ void CSbieView::CleanupProcessExpandState()
 				LiveProcesses.insert(Key);
 		}
 	}
+	for (auto I = m_AutoExpandCollapsed.begin(); I != m_AutoExpandCollapsed.end();) {
+		if (I->startsWith("p|") && !LiveProcesses.contains(I->mid(2)))
+			I = m_AutoExpandCollapsed.erase(I);
+		else
+			++I;
+	}
 
 	bool Changed = false;
 	for (auto I = m_ProcessExpandState.begin(); I != m_ProcessExpandState.end();) {
@@ -2861,10 +2899,7 @@ void CSbieView::UpdateColapsed()
 {
 	if (!theConf->GetBool("Options/LegacyAutoExpandTree", false)) {
 		m_HoldExpand = true;
-		if (theGUI->IsAutoExpand())
-			m_pSbieTree->expandAll();
-		else
-			RestoreExpandState();
+		ApplyExpandState(theGUI->IsAutoExpand());
 		m_HoldExpand = false;
 		return;
 	}

--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -33,6 +33,7 @@ CSbieView::CSbieView(QWidget* parent) : CPanelView(parent)
 	this->setLayout(m_pMainLayout);
 
 	m_HoldExpand = false;
+	m_ProcessStateCleanupPending = false;
 	m_MoveBatchPending = false;
 	m_MoveBatchChanged = false;
 
@@ -547,14 +548,28 @@ void CSbieView::Refresh()
 
 	if (!Added.isEmpty())
 		QTimer::singleShot(10, this, [this, Added]() {
+			bool bAutoExpand = theGUI->IsAutoExpand();
+			bool bLegacyAutoExpand = theConf->GetBool("Options/LegacyAutoExpandTree", false);
+
 			foreach(const QVariant ID, Added) {
 
 				QModelIndex ModelIndex = m_pSbieModel->FindIndex(ID);
 
 				if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
-					if (theGUI->IsAutoExpand()) {
+					CBoxedProcessPtr pProcess = m_pSbieModel->GetProcess(ModelIndex);
+					QString Key = GetProcessExpandKey(pProcess);
+					bool bExpand = bAutoExpand && !bLegacyAutoExpand;
+					if (!bExpand)
+						bExpand = m_ProcessExpandState.contains(Key)
+							? m_ProcessExpandState.value(Key) : bAutoExpand;
+					if (bExpand) {
 						m_HoldExpand = true;
 						m_pSbieTree->expand(m_pSortProxy->mapFromSource(ModelIndex));
+						m_HoldExpand = false;
+					}
+					else {
+						m_HoldExpand = true;
+						m_pSbieTree->collapse(m_pSortProxy->mapFromSource(ModelIndex));
 						m_HoldExpand = false;
 					}
 				}
@@ -566,7 +581,7 @@ void CSbieView::Refresh()
 					else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eBox)
 						Name = m_pSbieModel->GetSandBox(ModelIndex)->GetName();
 
-					if (!m_Collapsed.contains(Name)) {
+					if ((bAutoExpand && !bLegacyAutoExpand) || !m_Collapsed.contains(Name)) {
 						m_HoldExpand = true;
 						m_pSbieTree->expand(m_pSortProxy->mapFromSource(ModelIndex));
 						m_HoldExpand = false;
@@ -574,6 +589,8 @@ void CSbieView::Refresh()
 				}
 			}
 		});
+
+	CleanupProcessExpandState();
 
 	// add new boxes to the default group
 
@@ -2709,13 +2726,20 @@ void CSbieView::ShowOptions(const QString& Name)
 
 void CSbieView::ChangeExpand(const QModelIndex& index, bool bExpand)
 {
-	if (m_HoldExpand)
+	if (m_HoldExpand || (theGUI->IsAutoExpand()
+	 && !theConf->GetBool("Options/LegacyAutoExpandTree", false)))
 		return;
 
 	QModelIndex ModelIndex = m_pSortProxy->mapToSource(index);
 
-	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess)
+	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
+		QString Key = GetProcessExpandKey(m_pSbieModel->GetProcess(ModelIndex));
+		if (!Key.isEmpty()) {
+			m_ProcessExpandState.insert(Key, bExpand);
+			SaveProcessExpandState();
+		}
 		return;
+	}
 
 	QString Name;
 	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eGroup)
@@ -2736,8 +2760,115 @@ void CSbieView::ChangeExpand(const QModelIndex& index, bool bExpand)
 	theConf->SetValue("UIConfig/BoxCollapsedView", Collapsed);
 }
 
+void CSbieView::SetAutoExpand(bool bExpand, bool bLegacy)
+{
+	if (bLegacy) {
+		if (bExpand)
+			m_pSbieTree->expandAll();
+		else
+			m_pSbieTree->collapseAll();
+		return;
+	}
+
+	m_HoldExpand = true;
+	if (bExpand)
+		m_pSbieTree->expandAll();
+	else
+		RestoreExpandState();
+	m_HoldExpand = false;
+}
+
+void CSbieView::RestoreExpandState(const QModelIndex& Parent)
+{
+	for (int Row = 0; Row < m_pSortProxy->rowCount(Parent); ++Row) {
+		QModelIndex Index = m_pSortProxy->index(Row, 0, Parent);
+		QModelIndex ModelIndex = m_pSortProxy->mapToSource(Index);
+
+		bool bExpand = false;
+		if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
+			QString Key = GetProcessExpandKey(m_pSbieModel->GetProcess(ModelIndex));
+			bExpand = m_ProcessExpandState.value(Key, false);
+		}
+		else {
+			QString Name;
+			if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eGroup)
+				Name = m_pSbieModel->GetID(ModelIndex).toString();
+			else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eBox)
+				Name = m_pSbieModel->GetSandBox(ModelIndex)->GetName();
+			bExpand = !m_Collapsed.contains(Name);
+		}
+
+		m_pSbieTree->setExpanded(Index, bExpand);
+		RestoreExpandState(Index);
+	}
+}
+
+QString CSbieView::GetProcessExpandKey(const CBoxedProcessPtr& pProcess) const
+{
+	if (pProcess.isNull() || !pProcess->GetTimeStamp().isValid())
+		return QString();
+
+	return QString("%1|%2|%3").arg(pProcess->GetBoxName())
+		.arg(pProcess->GetProcessId()).arg(pProcess->GetTimeStamp().toMSecsSinceEpoch());
+}
+
+void CSbieView::SaveProcessExpandState()
+{
+	if (m_ProcessExpandState.isEmpty()) {
+		theConf->DelValue("UIConfig/ProcessTreeState");
+		return;
+	}
+
+	QStringList State;
+	for (auto I = m_ProcessExpandState.constBegin(); I != m_ProcessExpandState.constEnd(); ++I)
+		State.append(QString(I.value() ? "e|" : "c|") + I.key());
+	State.sort();
+	theConf->SetValue("UIConfig/ProcessTreeState", State);
+}
+
+void CSbieView::CleanupProcessExpandState()
+{
+	QMap<quint32, CBoxedProcessPtr> Processes = theAPI->GetAllProcesses();
+	if (m_ProcessStateCleanupPending) {
+		m_ProcessStateCleanupPending = false;
+		if (Processes.isEmpty())
+			return;
+	}
+
+	QSet<QString> LiveProcesses;
+	foreach(const CBoxedProcessPtr& pProcess, Processes) {
+		if (!pProcess->IsTerminated()) {
+			QString Key = GetProcessExpandKey(pProcess);
+			if (!Key.isEmpty())
+				LiveProcesses.insert(Key);
+		}
+	}
+
+	bool Changed = false;
+	for (auto I = m_ProcessExpandState.begin(); I != m_ProcessExpandState.end();) {
+		if (!LiveProcesses.contains(I.key())) {
+			I = m_ProcessExpandState.erase(I);
+			Changed = true;
+		}
+		else
+			++I;
+	}
+	if (Changed)
+		SaveProcessExpandState();
+}
+
 void CSbieView::UpdateColapsed()
 {
+	if (!theConf->GetBool("Options/LegacyAutoExpandTree", false)) {
+		m_HoldExpand = true;
+		if (theGUI->IsAutoExpand())
+			m_pSbieTree->expandAll();
+		else
+			RestoreExpandState();
+		m_HoldExpand = false;
+		return;
+	}
+
 	foreach(const QString& Group, m_Groups.keys())
 	{
 		if (!m_Collapsed.contains(Group)) {
@@ -2780,6 +2911,22 @@ void CSbieView::ReloadUserConfig()
 			m_Collapsed = ListToSet(SplitStr(Collapsed, ","));
 		//}
 	}
+
+	m_ProcessExpandState.clear();
+	QStringList ProcessState = theConf->GetStringList("UIConfig/ProcessTreeState");
+	if (ProcessState.isEmpty()) {
+		QString State = theConf->GetString("UIConfig/ProcessTreeState");
+		if (!State.isEmpty())
+			ProcessState.append(State);
+	}
+	foreach(const QString& State, ProcessState) {
+		if (State.length() > 2 && State.at(1) == '|'
+		 && (State.at(0) == 'e' || State.at(0) == 'c'))
+			m_ProcessExpandState.insert(State.mid(2), State.at(0) == 'e');
+	}
+	m_ProcessStateCleanupPending = !m_ProcessExpandState.isEmpty();
+	if (m_ProcessExpandState.isEmpty())
+		theConf->DelValue("UIConfig/ProcessTreeState");
 
 	ClearUserUIConfig();
 }

--- a/SandboxiePlus/SandMan/Views/SbieView.h
+++ b/SandboxiePlus/SandMan/Views/SbieView.h
@@ -128,6 +128,7 @@ protected:
 	QMap<QString, QStringList>	m_Groups;
 	QSet<QString>				m_Collapsed;
 	QHash<QString, bool>		m_ProcessExpandState;
+	QSet<QString>				m_AutoExpandCollapsed;
 	bool						m_ProcessStateCleanupPending;
 	bool						m_HoldExpand;
 
@@ -154,7 +155,8 @@ private:
 	bool					IsParentOf(const QString& Name, const QString& Group);
 
 	void					ChangeExpand(const QModelIndex& index, bool bExpand);
-	void					RestoreExpandState(const QModelIndex& Parent = QModelIndex());
+	void					ApplyExpandState(bool bAutoExpand, const QModelIndex& Parent = QModelIndex());
+	QString					GetExpandStateKey(const QModelIndex& ModelIndex) const;
 	QString					GetProcessExpandKey(const CBoxedProcessPtr& pProcess) const;
 	void					SaveProcessExpandState();
 	void					CleanupProcessExpandState();

--- a/SandboxiePlus/SandMan/Views/SbieView.h
+++ b/SandboxiePlus/SandMan/Views/SbieView.h
@@ -45,6 +45,7 @@ public:
 
 	virtual QTreeViewEx*		GetTree() { return m_pSbieTree; }
 	CSbieModel*					GetSbieModel() { return m_pSbieModel; }
+	void						SetAutoExpand(bool bExpand, bool bLegacy);
 
 	virtual QList<CSandBoxPtr>	GetSelectedBoxes();
 	virtual QList<CBoxedProcessPtr>	GetSelectedProcesses();
@@ -126,6 +127,8 @@ protected:
 
 	QMap<QString, QStringList>	m_Groups;
 	QSet<QString>				m_Collapsed;
+	QHash<QString, bool>		m_ProcessExpandState;
+	bool						m_ProcessStateCleanupPending;
 	bool						m_HoldExpand;
 
 private:
@@ -151,6 +154,10 @@ private:
 	bool					IsParentOf(const QString& Name, const QString& Group);
 
 	void					ChangeExpand(const QModelIndex& index, bool bExpand);
+	void					RestoreExpandState(const QModelIndex& Parent = QModelIndex());
+	QString					GetProcessExpandKey(const CBoxedProcessPtr& pProcess) const;
+	void					SaveProcessExpandState();
+	void					CleanupProcessExpandState();
 	QStringList				GetSelectedBoxNames();
 	void					RestoreBoxSelectionLater(const QStringList& Names, int Delay = 50);
 	void					RestoreNameSelectionLater(const QStringList& Names, int Delay = 50);


### PR DESCRIPTION
SandMan now applies Auto Expand Tree without overwriting saved manual expansion state for groups, sandboxes, and process branches. It adds non-legacy auto-expand handling in `CSbieView`, restores saved expansion when auto-expand is turned off, and persists per-process expand/collapse state (`UIConfig/ProcessTreeState`) with cleanup of stale entries. A `Options/LegacyAutoExpandTree` flag keeps the old expand-all/collapse-all behavior.