### PR TITLE
zero-initialize num_handles before packing GetAllHandles reply

### DIFF
--- a/Sandboxie/core/svc/fileserver.cpp
+++ b/Sandboxie/core/svc/fileserver.cpp
@@ -515,9 +515,11 @@ MSG_HEADER *FileServer::GetAllHandles(HANDLE idProcess)
 
         if (! rpl)
             status = STATUS_INSUFFICIENT_RESOURCES;
-        else {
+		else {
 
-            for (i = 0; i < info->Count; ++i) {
+			rpl->num_handles = 0;
+
+			for (i = 0; i < info->Count; ++i) {
 
                 if (info->HandleInfo[i].ProcessId == (ULONG_PTR)idProcess) {
 


### PR DESCRIPTION
zero-initialize `num_handles` before packing GetAllHandles reply when handling `MSGID_FILE_GET_ALL_HANDLES`

