### PR TITLE
Add security tips page to setup wizard

### DIFF
--- a/SandboxiePlus/SandMan/Wizards/SetupWizard.cpp
+++ b/SandboxiePlus/SandMan/Wizards/SetupWizard.cpp
@@ -23,6 +23,7 @@ CSetupWizard::CSetupWizard(int iOldLevel, QWidget *parent)
     }
     if (iOldLevel < SETUP_LVL_2)
         setPage(Page_Update, new CSBUpdate);
+    setPage(Page_Security, new CSecurityPage);
     setPage(Page_Finish, new CFinishPage);
 
     setWizardStyle(ModernStyle);
@@ -251,7 +252,7 @@ CCertificatePage::CCertificatePage(int iOldLevel, QWidget *parent)
     if (iOldLevel < SETUP_LVL_1)
         m_NextPage = CSetupWizard::Page_UI;
     else if (iOldLevel < SETUP_LVL_3)
-        m_NextPage = CSetupWizard::Page_Finish;
+        m_NextPage = CSetupWizard::Page_Security;
 
     QGridLayout *layout = new QGridLayout;
 
@@ -749,6 +750,44 @@ void CSBUpdate::UpdateOptions()
 }
 
 int CSBUpdate::nextId() const
+{
+    return CSetupWizard::Page_Security;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CSecurityPage
+// 
+
+CSecurityPage::CSecurityPage(QWidget *parent)
+    : QWizardPage(parent)
+{
+    setTitle(tr("Security Tips"));
+    setSubTitle(tr("Keep the following considerations in mind when configuring your sandboxes."));
+
+    QVBoxLayout *layout = new QVBoxLayout;
+
+    m_pTopLabel = new QLabel(tr("Please avoid configuring weak sandbox options as much as possible, as the isolation between sandboxes is not always reliable. "
+        "This is especially true when the 'Sandboxed Desktop' feature from the Insider version is not in use. "
+        "Even a malicious program running in a strongly configured sandbox may interact with a weakly configured sandbox and escape. "
+        "Always adhere to the barrel principle: the weakest configured sandbox defines the overall security baseline."));
+    m_pTopLabel->setWordWrap(true);
+    layout->addWidget(m_pTopLabel);
+
+    QWidget* pSpacer = new QWidget();
+    pSpacer->setMinimumHeight(24);
+    layout->addWidget(pSpacer);
+
+    m_pWarningLabel = new QLabel(tr("Always treat the weakest configured sandbox as your expected line of defense!"));
+    m_pWarningLabel->setWordWrap(true);
+    m_pWarningLabel->setStyleSheet("QLabel { color : red; font-weight : bold; }");
+    layout->addWidget(m_pWarningLabel);
+
+    layout->addStretch(1);
+
+    setLayout(layout);
+}
+
+int CSecurityPage::nextId() const
 {
     return CSetupWizard::Page_Finish;
 }

--- a/SandboxiePlus/SandMan/Wizards/SetupWizard.h
+++ b/SandboxiePlus/SandMan/Wizards/SetupWizard.h
@@ -19,7 +19,7 @@ class CSetupWizard : public QWizard
     Q_OBJECT
 
 public:
-    enum { Page_Intro, Page_Certificate, Page_UI, Page_Shell, Page_Update, Page_Finish };
+    enum { Page_Intro, Page_Certificate, Page_UI, Page_Shell, Page_Update, Page_Security, Page_Finish };
 
     CSetupWizard(int iOldLevel = 0, QWidget *parent = nullptr);
 
@@ -175,6 +175,24 @@ private:
     QCheckBox* m_pAddons;
     QLabel* m_pUpdateInfo;
     QLabel* m_pBottomLabel;
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CSecurityPage
+// 
+
+class CSecurityPage : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    CSecurityPage(QWidget *parent = nullptr);
+
+    int nextId() const override;
+
+private:
+    QLabel* m_pTopLabel;
+    QLabel* m_pWarningLabel;
 };
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR introduces a new security tips page to the Sandboxie Plus setup wizard to inform users about important security considerations when configuring sandboxes.

**Changes:**

- **Added `CSecurityPage` class**: A new wizard page that displays security warnings and best practices
  - Shows guidance on avoiding weak sandbox configurations
  - Emphasizes the "barrel principle" — the weakest sandbox defines overall security
  - Displays a prominent warning about the risks of misconfigurations

- **Updated wizard flow**: 
  - Inserted the new `Page_Security` step into the wizard sequence
  - Modified `CCertificatePage` to route to the security page (instead of jumping directly to finish)
  - Updated `CSBUpdate` to redirect to the security page before finish

- **UI enhancements**:
  - Two-label layout with explanatory text and a bold red warning message
  - Word-wrapped labels for better readability across different window sizes

**Impact:** Users will now see security guidance during the initial setup, promoting stronger sandbox configurations and reducing misconfiguration risks.