### PR TITLE
fix off-by-one when killing all processes with MSGID_PROCESS_KILL_ALL

### DIFF
--- a/Sandboxie/core/svc/ProcessServer.cpp
+++ b/Sandboxie/core/svc/ProcessServer.cpp
@@ -367,7 +367,7 @@ NTSTATUS ProcessServer::KillAllHelper(const WCHAR *BoxName, ULONG SessionId, BOO
             Sleep(100);
         }
 
-        for (i = 0; i <= count; ++i)
+        for (i = 0; i < count; ++i)
             KillProcess(pids[i]);
     }
 


### PR DESCRIPTION

fix off-by-one in `KillAllHelper` when processing MSGID_PROCESS_KILL_ALL