### PR TITLE
Harden Start Menu icon path IPC handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - fixed SandMan Box Groups collapsing during refreshes, restarts, and sandbox moves despite remembered group state [#5477](https://github.com/sandboxie-plus/Sandboxie/issues/5477)
 - fixed driver incompatibility with latest Windows Insider build
 - fixed SandMan File Panel treating registry hive log files such as `RegHive.LOG1` and `RegHive.LOG2` as descendants of `RegHive` because of their shared filename prefix, causing them to be omitted when deleting the selection together [#4788](https://github.com/sandboxie-plus/Sandboxie/issues/4788)
-
+- fixed Start Menu shortcut icon-path IPC buffer handling [#5517](https://github.com/sandboxie-plus/Sandboxie/pull/5517)
 
 
 ## [1.18.1 / 5.73.1] - 2026-07-26

--- a/Sandboxie/apps/start/menu.cpp
+++ b/Sandboxie/apps/start/menu.cpp
@@ -1008,6 +1008,8 @@ _FX BOOL WriteStartMenuResult(const WCHAR *MapName, const WCHAR *Command)
     HANDLE hMapping;
     WCHAR *buf;
     WCHAR *IconPath;
+    WCHAR IconPathBuffer[
+        SBIE_DLL_HANDLE_PATH_BUFFER_BYTES / sizeof(WCHAR)];
     ULONG len, IconIndex;
     BOOLEAN GetLinkIconPathAndNumber(
         WCHAR *LinkPath, WCHAR **IconPath, ULONG *IconIndex);
@@ -1066,11 +1068,15 @@ _FX BOOL WriteStartMenuResult(const WCHAR *MapName, const WCHAR *Command)
 
                 BOOLEAN IsBoxedPath;
                 if (0 == SbieDll_GetHandlePath(
-                                    hFile, buf + 1024, &IsBoxedPath)) {
-                    if (SbieDll_TranslateNtToDosPath(buf + 1024)) {
-
-                        *(ULONG *)(buf + 1020) = IconIndex;
-                        ok = TRUE;
+                                    hFile, IconPathBuffer, &IsBoxedPath)) {
+                    if (SbieDll_TranslateNtToDosPath(IconPathBuffer)) {
+                        len = wcslen(IconPathBuffer);
+                        if (len < 1024) {
+                            wmemcpy(buf + 1024, IconPathBuffer, len);
+                            buf[1024 + len] = L'\0';
+                            *(ULONG *)(buf + 1020) = IconIndex;
+                            ok = TRUE;
+                        }
                     }
                 }
 

--- a/Sandboxie/core/dll/file.c
+++ b/Sandboxie/core/dll/file.c
@@ -8668,7 +8668,7 @@ _FX HANDLE File_GetTrueHandle(HANDLE FileHandle, BOOLEAN *pIsOpenPath)
 
 
 _FX ULONG SbieDll_GetHandlePath(
-    HANDLE FileHandle, WCHAR *OutWchar8192, BOOLEAN *IsBoxedPath)
+    HANDLE FileHandle, WCHAR *OutPath, BOOLEAN *IsBoxedPath)
 {
     THREAD_DATA *TlsData = Dll_GetTlsData(NULL);
 
@@ -8702,7 +8702,7 @@ _FX ULONG SbieDll_GetHandlePath(
     } else if (status == STATUS_BAD_INITIAL_PC)
         status = STATUS_SUCCESS;
 
-    if (NT_SUCCESS(status) && OutWchar8192) {
+    if (NT_SUCCESS(status) && OutPath) {
 
         ULONG len;
         WCHAR *src = TruePath;
@@ -8713,10 +8713,10 @@ _FX ULONG SbieDll_GetHandlePath(
         }
 
         len = wcslen(src);
-        if (len > 8192 / sizeof(WCHAR) - 4)
-            len = 8192 / sizeof(WCHAR) - 4;
-        wmemcpy(OutWchar8192, src, len);
-        OutWchar8192[len] = L'\0';
+        if (len > SBIE_DLL_HANDLE_PATH_BUFFER_BYTES / sizeof(WCHAR) - 4)
+            len = SBIE_DLL_HANDLE_PATH_BUFFER_BYTES / sizeof(WCHAR) - 4;
+        wmemcpy(OutPath, src, len);
+        OutPath[len] = L'\0';
     }
 
     Dll_PopTlsNameBuffer(TlsData);

--- a/Sandboxie/core/dll/sbiedll.h
+++ b/Sandboxie/core/dll/sbiedll.h
@@ -49,6 +49,7 @@ extern "C" {
 #define ENV_VAR_PFX            L"00000000_" SBIE L"_"
 #define DATA_SLOTS 5
 #define SESSION_PROCESS L"SboxSession"
+#define SBIE_DLL_HANDLE_PATH_BUFFER_BYTES 8192
 
 typedef struct _PROCESS_DATA {
     ULONG tid;
@@ -187,7 +188,7 @@ SBIEDLL_EXPORT  BOOLEAN SbieDll_IsDirectory(const WCHAR *PathW);
 SBIEDLL_EXPORT  void *SbieDll_InitPStore(void);
 
 SBIEDLL_EXPORT  ULONG SbieDll_GetHandlePath(
-    HANDLE FileHandle, WCHAR *OutWchar8192, BOOLEAN *IsBoxedPath);
+    HANDLE FileHandle, WCHAR *OutPath, BOOLEAN *IsBoxedPath);
 
 SBIEDLL_EXPORT  BOOLEAN SbieDll_RunFromHome(
     const WCHAR *pgmName, const WCHAR *pgmArgs,


### PR DESCRIPTION
Fixes unsafe buffer usage when writing Start Menu shortcut icon paths through shared memory.