### PR TITLE
Stabilize API tracing, improve stack symbol resolution, and fix TraceView prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - fixed ApiTrace stack exhaustion on Cygwin and other alternate stacks by replacing callback-side formatting with a compact synchronous logging path, preserving legacy ordering and stack capture
 - improved early stack symbol loading by retrying unresolved addresses after process discovery and refreshing the DbgHelp module list when needed
+- fixed SandMan offering to install the DbgHelp add-on when enabling stack traces even though the add-on was already installed
 
 ## [1.18.1 / 5.73.1] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 
 - fixed ApiTrace stack exhaustion on Cygwin and other alternate stacks by replacing callback-side formatting with a compact synchronous logging path, preserving legacy ordering and stack capture
+- improved early stack symbol loading by retrying unresolved addresses after process discovery and refreshing the DbgHelp module list when needed
 
 ## [1.18.1 / 5.73.1] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - changed SandMan's Auto Expand Tree to temporarily expand box groups, sandboxes, and process branches without overwriting their saved manual expansion states; set the SandMan UI configuration option `Options/LegacyAutoExpandTree=true` to retain the previous expand-all/collapse-all behaviour [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)
 - validated compatibility with Windows build 29634 and updated DynData
+- changed SandMan Trace Log auto scrolling overriding manual scrolling; it now pauses away from the bottom and provides an in-list resume button
 
 ### Fixed
 - fixed SandMan File Panel column widths resetting when switching between boxes [#5473](https://github.com/sandboxie-plus/Sandboxie/issues/5473)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - fixed SandMan File Panel treating registry hive log files such as `RegHive.LOG1` and `RegHive.LOG2` as descendants of `RegHive` because of their shared filename prefix, causing them to be omitted when deleting the selection together [#4788](https://github.com/sandboxie-plus/Sandboxie/issues/4788)
 
 
+- fixed ApiTrace stack exhaustion on Cygwin and other alternate stacks by replacing callback-side formatting with a compact synchronous logging path, preserving legacy ordering and stack capture
 
 ## [1.18.1 / 5.73.1] - 2026-07-26
 

--- a/Sandboxie/core/dll/sbieapi.c
+++ b/Sandboxie/core/dll/sbieapi.c
@@ -45,6 +45,7 @@ extern P_NtDeviceIoControlFile __sys_NtDeviceIoControlFile;
 
 static NTSTATUS SbieApi_Ioctl(ULONG64 *parms);
 
+static NTSTATUS SbieApi_IoctlTrace(ULONG64 *parms);
 
 //---------------------------------------------------------------------------
 // Variables
@@ -1754,6 +1755,75 @@ _FX LONG SbieApi_MonitorPut2Ex(
     args->check_object_exists.val64 = bCheckObjectExists;
     args->is_message.val64          = bIsMessage;
     status = SbieApi_Ioctl(parms);
+
+    return status;
+}
+
+
+//---------------------------------------------------------------------------
+// SbieApi_IoctlTrace
+//---------------------------------------------------------------------------
+
+
+__declspec(noinline) static NTSTATUS SbieApi_IoctlTrace(ULONG64 *parms)
+{
+    IO_STATUS_BLOCK io_status;
+
+    if (SbieApi_DeviceHandle == INVALID_HANDLE_VALUE)
+        return STATUS_DEVICE_NOT_READY;
+
+    if (__sys_NtDeviceIoControlFile) {
+        return __sys_NtDeviceIoControlFile(
+            SbieApi_DeviceHandle, NULL, NULL, NULL, &io_status,
+            API_SBIEDRV_CTLCODE, parms, sizeof(ULONG64) * API_NUM_ARGS,
+            NULL, 0);
+    }
+
+    return NtDeviceIoControlFile(
+        SbieApi_DeviceHandle, NULL, NULL, NULL, &io_status,
+        API_SBIEDRV_CTLCODE, parms, sizeof(ULONG64) * API_NUM_ARGS,
+        NULL, 0);
+}
+
+
+//---------------------------------------------------------------------------
+// SbieApi_MonitorPutApiTrace
+//---------------------------------------------------------------------------
+
+
+__declspec(noinline) _FX LONG SbieApi_MonitorPutApiTrace(const CHAR *Name)
+{
+    NTSTATUS status;
+    WCHAR name[128];
+    ULONG length;
+    __declspec(align(8)) ULONG64 parms[API_NUM_ARGS];
+    API_MONITOR_PUT2_ARGS *args = (API_MONITOR_PUT2_ARGS *)parms;
+
+    if (! Name)
+        return STATUS_INVALID_PARAMETER;
+
+    for (length = 0; length < ARRAYSIZE(name) - 1; ++length) {
+        UCHAR ch = (UCHAR)Name[length];
+
+        if (! ch)
+            break;
+
+        name[length] = (WCHAR)ch;
+    }
+
+    if (! length)
+        return STATUS_INVALID_PARAMETER;
+
+    name[length] = L'\0';
+
+    memset(parms, 0, sizeof(parms));
+    args->func_code                 = API_MONITOR_PUT2;
+    args->log_type.val              = MONITOR_APICALL | MONITOR_TRACE;
+    args->log_len.val64             = length * sizeof(WCHAR);
+    args->log_ptr.val64             = (ULONG64)(ULONG_PTR)name;
+    args->check_object_exists.val64 = FALSE;
+    args->is_message.val64          = FALSE;
+    status = SbieApi_IoctlTrace(parms);
 
     return status;
 }

--- a/Sandboxie/core/dll/sbieapi.h
+++ b/Sandboxie/core/dll/sbieapi.h
@@ -231,6 +231,8 @@ LONG SbieApi_MonitorPut2Ex(
     BOOLEAN bCheckObjectExists,
     BOOLEAN bIsMessage);
 
+LONG SbieApi_MonitorPutApiTrace(const CHAR *Name);
+
 SBIEAPI_EXPORT
 LONG SbieApi_MonitorPutEx(
     ULONG Type,

--- a/Sandboxie/core/dll/trace.c
+++ b/Sandboxie/core/dll/trace.c
@@ -510,18 +510,16 @@ void ApiInstrumentation(const char* pName, void** pStack)
 void __fastcall ApiInstrumentation(const char* pName, void** pStack)
 #endif
 {
-    void* ReturnAddress = *(pStack - 1);
-
     TEB* pTEB = NtCurrentTeb();
     ULONG_PTR* sbie_deph = (ULONG_PTR*)&pTEB->ReservedForDebuggerInstrumentation[15];
+
+    (void)pStack;
+
     if (*sbie_deph)
         return;
     *sbie_deph += 1;
 
-    WCHAR trace_str[256];
-    //ULONG len = Sbie_snwprintf(trace_str, 128, L"%S <-- %s%S", pName, CallingModule, pCaller ? pCaller : "");
-    ULONG len = Sbie_snwprintf(trace_str, 128, L"%S", pName);
-    SbieApi_MonitorPut2Ex(MONITOR_APICALL | MONITOR_TRACE, len, trace_str, FALSE, FALSE);
+    SbieApi_MonitorPutApiTrace(pName);
 
     *sbie_deph -= 1;
 }

--- a/SandboxiePlus/QSbieAPI/Helpers/DbgHelper.cpp
+++ b/SandboxiePlus/QSbieAPI/Helpers/DbgHelper.cpp
@@ -20,6 +20,7 @@ typedef BOOL(WINAPI* P_SymGetModuleInfoW64)(HANDLE hProcess, DWORD64 qwAddr, PIM
 typedef DWORD(WINAPI* P_SymSetOptions)(DWORD SymOptions);
 typedef DWORD(WINAPI* P_SymGetOptions)();
 typedef BOOL(WINAPI* P_SymInitialize)(HANDLE hProcess, PCSTR UserSearchPath, BOOL fInvadeProcess);
+typedef BOOL(WINAPI* P_SymRefreshModuleList)(HANDLE hProcess);
 typedef BOOL(WINAPI* P_SymCleanup)(HANDLE ProcessHandle);
 typedef BOOL(WINAPI* P_SymSetSearchPathW)(HANDLE hProcess, PCWSTR SearchPath);
 typedef BOOL(WINAPI* P_SymRegisterCallbackW64)(HANDLE hProcess, PSYMBOL_REGISTERED_CALLBACK64 CallbackFunction, ULONG64 UserContext);
@@ -31,6 +32,7 @@ static P_SymSetOptions              __sys_SymSetOptions             = NULL;
 static P_SymGetOptions              __sys_SymGetOptions             = NULL;
 static P_SymSetSearchPathW          __sys_SymSetSearchPathW         = NULL;
 static P_SymInitialize              __sys_SymInitialize             = NULL;
+static P_SymRefreshModuleList       __sys_SymRefreshModuleList      = NULL;
 static P_SymCleanup                 __sys_SymCleanup                = NULL;
 static P_SymRegisterCallbackW64     __sys_SymRegisterCallbackW64    = NULL;
 
@@ -150,7 +152,27 @@ QString CSymbolProvider::Resolve(quint64 pid, quint64 Address)
     SYMBOL_INFO* symbolInfo = (SYMBOL_INFO*)buffer;
     symbolInfo->SizeOfStruct = sizeof(SYMBOL_INFO);
     symbolInfo->MaxNameLen = MAX_SYM_NAME;
-    if (__sys_SymFromAddr((HANDLE)Worker.handle, Address, &displacement, symbolInfo))
+    IMAGEHLP_MODULEW64 ModuleInfo;
+    ModuleInfo.SizeOfStruct = sizeof(ModuleInfo);
+
+    BOOL resolved = __sys_SymFromAddr(
+        (HANDLE)Worker.handle, Address, &displacement, symbolInfo);
+    BOOL moduleKnown = FALSE;
+    if (!resolved) {
+        moduleKnown = __sys_SymGetModuleInfoW64(
+            (HANDLE)Worker.handle, Address, &ModuleInfo);
+
+        if (!moduleKnown && __sys_SymRefreshModuleList &&
+                __sys_SymRefreshModuleList((HANDLE)Worker.handle)) {
+            resolved = __sys_SymFromAddr(
+                (HANDLE)Worker.handle, Address, &displacement, symbolInfo);
+            if (!resolved)
+                moduleKnown = __sys_SymGetModuleInfoW64(
+                    (HANDLE)Worker.handle, Address, &ModuleInfo);
+        }
+    }
+
+    if (resolved)
     {
         symbolInfo->Name[symbolInfo->NameLen] = 0;
 
@@ -158,7 +180,6 @@ QString CSymbolProvider::Resolve(quint64 pid, quint64 Address)
         if (displacement != 0)
             Symbol.append(QString("+0x%1").arg(displacement, 0, 16));
 
-        IMAGEHLP_MODULEW64 ModuleInfo;
         ModuleInfo.SizeOfStruct = sizeof(ModuleInfo);
         if (__sys_SymGetModuleInfoW64((HANDLE)Worker.handle, symbolInfo->ModBase ? symbolInfo->ModBase : symbolInfo->Address, &ModuleInfo))
             Symbol.prepend(QString::fromWCharArray(ModuleInfo.ModuleName) + "!");
@@ -167,9 +188,7 @@ QString CSymbolProvider::Resolve(quint64 pid, quint64 Address)
     {
         // Then this happens, probably symsrv.dll is missing
 
-        IMAGEHLP_MODULEW64 ModuleInfo;
-        ModuleInfo.SizeOfStruct = sizeof(ModuleInfo);
-        if (__sys_SymGetModuleInfoW64((HANDLE)Worker.handle, Address, &ModuleInfo))
+        if (moduleKnown)
             Symbol.prepend(QString::fromWCharArray(ModuleInfo.ModuleName) + "+" + QString("0x%1").arg(Address - ModuleInfo.BaseOfImage, 0, 16));
     }
 
@@ -379,6 +398,7 @@ CSymbolProvider* CSymbolProvider::Instance()
         __sys_SymGetOptions = (P_SymGetOptions)GetProcAddress(DbgHelpMod, "SymGetOptions");
         __sys_SymSetSearchPathW = (P_SymSetSearchPathW)GetProcAddress(DbgHelpMod, "SymSetSearchPathW");
         __sys_SymInitialize = (P_SymInitialize)GetProcAddress(DbgHelpMod, "SymInitialize");
+        __sys_SymRefreshModuleList = (P_SymRefreshModuleList)GetProcAddress(DbgHelpMod, "SymRefreshModuleList");
         __sys_SymCleanup = (P_SymCleanup)GetProcAddress(DbgHelpMod, "SymCleanup");
         __sys_SymRegisterCallbackW64 = (P_SymRegisterCallbackW64)GetProcAddress(DbgHelpMod, "SymRegisterCallbackW64");
 

--- a/SandboxiePlus/QSbieAPI/Sandboxie/BoxedProcess.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/BoxedProcess.cpp
@@ -446,3 +446,14 @@ void CBoxedProcess::ResolveSymbols(const QVector<quint64>& Addresses)
 		}
 	}
 }
+
+void CBoxedProcess::OnSymbol(quint64 Address, const QString& Name)
+{
+	if (Name.isEmpty()) {
+		m_Symbols.remove(Address);
+		return;
+	}
+
+	m_Symbols[Address].Name = Name;
+	emit SymbolChanged(Address);
+}

--- a/SandboxiePlus/QSbieAPI/Sandboxie/BoxedProcess.h
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/BoxedProcess.h
@@ -65,8 +65,11 @@ public:
 	virtual void			ResolveSymbols(const QVector<quint64>& Addresses);
 	virtual QString			GetSymbol(quint64 Address) { return m_Symbols.value(Address).Name; }
 
+signals:
+	void					SymbolChanged(quint64 Address);
+
 public slots:
-	virtual void			OnSymbol(quint64 Address, const QString& Name) { m_Symbols[Address].Name = Name; }
+	virtual void			OnSymbol(quint64 Address, const QString& Name);
 
 protected:
 	friend class CSbieAPI;

--- a/SandboxiePlus/SandMan/Views/StackView.cpp
+++ b/SandboxiePlus/SandMan/Views/StackView.cpp
@@ -52,6 +52,21 @@ void CStackView::Invalidate()
 
 void CStackView::ShowStack(const QVector<quint64>& Stack, const CBoxedProcessPtr& pProcess)
 {
+	if (m_pCurrentProcess != pProcess)
+	{
+		if (!m_pCurrentProcess.isNull())
+			disconnect(m_pCurrentProcess.data(), SIGNAL(SymbolChanged(quint64)),
+				this, SLOT(OnSymbolChanged(quint64)));
+
+		m_pCurrentProcess = pProcess;
+		if (!m_pCurrentProcess.isNull())
+			connect(m_pCurrentProcess.data(), SIGNAL(SymbolChanged(quint64)),
+				this, SLOT(OnSymbolChanged(quint64)), Qt::UniqueConnection);
+	}
+
+	m_CurrentStack = Stack;
+	pProcess->ResolveSymbols(Stack);
+
 	int i = 0;
 	for (; i < Stack.count(); i++)
 	{
@@ -85,6 +100,19 @@ void CStackView::ShowStack(const QVector<quint64>& Stack, const CBoxedProcessPtr
 	CPanelWidgetEx::ApplyFilter(m_pStackList, m_pFinder->isVisible() ? &m_pFinder->GetSearchExp() : NULL);
 
 	m_bIsInvalid = false;
+}
+
+void CStackView::OnSymbolChanged(quint64 Address)
+{
+	if (m_pCurrentProcess.isNull())
+		return;
+
+	QString Symbol = m_pCurrentProcess->GetSymbol(Address);
+	for (int i = 0; i < m_CurrentStack.count(); i++) {
+		if (m_CurrentStack[i] == Address &&
+				i < m_pStackList->topLevelItemCount())
+			m_pStackList->topLevelItem(i)->setText(eSymbol, Symbol);
+	}
 }
 
 void CStackView::SetFilter(const QRegularExpression& Exp, int iOptions, int Col)

--- a/SandboxiePlus/SandMan/Views/StackView.h
+++ b/SandboxiePlus/SandMan/Views/StackView.h
@@ -21,6 +21,7 @@ public slots:
 	void					Clear()			{ m_pStackList->clear(); }
 	void					Invalidate();
 	void					ShowStack(const QVector<quint64>& Stack, const CBoxedProcessPtr& pProcess);
+	void					OnSymbolChanged(quint64 Address);
 
 	//void					OnMenu(const QPoint &point);
 
@@ -43,6 +44,8 @@ private:
 
 	bool					m_bIsInvalid;
 	QTreeWidgetEx*			m_pStackList;
+	QVector<quint64>		m_CurrentStack;
+	CBoxedProcessPtr		m_pCurrentProcess;
 
 	CFinder*				m_pFinder;
 

--- a/SandboxiePlus/SandMan/Views/TraceView.cpp
+++ b/SandboxiePlus/SandMan/Views/TraceView.cpp
@@ -9,6 +9,9 @@
 #include "..\..\MiscHelpers\Common\CheckableComboBox.h"
 #include "SbieView.h"
 #include <QtConcurrent>
+#include <QEvent>
+#include <QScrollBar>
+#include <QToolButton>
 
 //class CTraceFilterProxyModel : public CSortFilterProxyModel
 //{
@@ -333,6 +336,35 @@ CTraceView::CTraceView(bool bStandAlone, QWidget* parent) : QWidget(parent)
 	m_pTrace->m_pAutoScroll->setChecked(theConf->GetBool("Options/TraceAutoScroll"));
 	m_pTrace->GetMenu()->insertAction(m_pTrace->GetMenu()->actions()[0], m_pTrace->m_pAutoScroll);
 
+	QWidget* pTraceViewport = m_pTrace->m_pTreeList->viewport();
+	m_pResumeAutoScroll = new QToolButton(pTraceViewport);
+	m_pResumeAutoScroll->setIcon(CSandMan::GetIcon("Down"));
+	m_pResumeAutoScroll->setText(tr("Resume Auto Scroll"));
+	m_pResumeAutoScroll->setToolTip(tr("Auto scrolling is paused. Click to resume."));
+	m_pResumeAutoScroll->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+	m_pResumeAutoScroll->setFocusPolicy(Qt::NoFocus);
+	m_pResumeAutoScroll->adjustSize();
+	m_pResumeAutoScroll->hide();
+	pTraceViewport->installEventFilter(this);
+
+	QScrollBar* pTraceScrollBar = m_pTrace->m_pTreeList->verticalScrollBar();
+	connect(m_pTrace->m_pAutoScroll, &QAction::toggled, this, [this](bool bEnabled) {
+		if (bEnabled)
+			m_pTrace->m_pTreeList->scrollToBottom();
+		UpdateAutoScrollIndicator();
+	});
+	connect(m_pResumeAutoScroll, &QToolButton::clicked, this, [this]() {
+		m_pTrace->m_pTreeList->scrollToBottom();
+		UpdateAutoScrollIndicator();
+	});
+	connect(pTraceScrollBar, &QScrollBar::valueChanged, this, [this](int) {
+		UpdateAutoScrollIndicator();
+	});
+	connect(pTraceScrollBar, &QScrollBar::rangeChanged, this, [this](int, int) {
+		UpdateAutoScrollIndicator();
+	});
+	UpdateAutoScrollIndicator();
+
 	if (bStandAlone) {
 		QAction* pAction = new QAction(tr("Cleanup Trace Log"));
 		connect(pAction, SIGNAL(triggered()), this, SLOT(Clear()));
@@ -370,6 +402,43 @@ void CTraceView::timerEvent(QTimerEvent* pEvent)
 	Refresh();
 }
 
+bool CTraceView::eventFilter(QObject* source, QEvent* event)
+{
+	if (source == m_pTrace->m_pTreeList->viewport()
+		&& (event->type() == QEvent::Resize || event->type() == QEvent::Show))
+		PositionAutoScrollIndicator();
+
+	return QWidget::eventFilter(source, event);
+}
+
+bool CTraceView::IsTraceAtBottom() const
+{
+	QScrollBar* pScrollBar = m_pTrace->m_pTreeList->verticalScrollBar();
+	return pScrollBar->value() == pScrollBar->maximum();
+}
+
+void CTraceView::PositionAutoScrollIndicator()
+{
+	QWidget* pViewport = m_pTrace->m_pTreeList->viewport();
+	const int iMargin = 8;
+	const int x = qMax(0, pViewport->width() - m_pResumeAutoScroll->width() - iMargin);
+	const int y = qMax(0, pViewport->height() - m_pResumeAutoScroll->height() - iMargin);
+	m_pResumeAutoScroll->move(x, y);
+	m_pResumeAutoScroll->raise();
+}
+
+void CTraceView::UpdateAutoScrollIndicator()
+{
+	bool bPaused = !m_pMonitorMode->isChecked()
+		&& m_pTrace->m_pAutoScroll->isChecked()
+		&& !IsTraceAtBottom();
+	if (bPaused) {
+		PositionAutoScrollIndicator();
+		m_pResumeAutoScroll->show();
+	} else
+		m_pResumeAutoScroll->hide();
+}
+
 void CTraceView::SetEnabled(bool bSet)
 {
 	setEnabled(bSet);
@@ -390,6 +459,10 @@ void CTraceView::OnShowStack()
 
 void CTraceView::Refresh()
 {
+	QScrollBar* pTraceScrollBar = m_pTrace->m_pTreeList->verticalScrollBar();
+	const bool bFollowTraceTail = m_pTrace->m_pAutoScroll->isChecked()
+		&& IsTraceAtBottom() && !pTraceScrollBar->isSliderDown();
+
 	QList<CSandBoxPtr>Boxes;
 	if(m_pAllBoxes && !m_pAllBoxes->isChecked())
 		Boxes = theGUI->GetBoxView()->GetSelectedBoxes();
@@ -552,15 +625,22 @@ void CTraceView::Refresh()
 		if (m_pTrace->m_pTraceModel->IsTree())
 		{
 			QTimer::singleShot(10, this, [this, NewBranches]() {
+				QScrollBar* pScrollBar = m_pTrace->m_pTreeList->verticalScrollBar();
+				const bool bFollowTraceTail = m_pTrace->m_pAutoScroll->isChecked()
+					&& IsTraceAtBottom() && !pScrollBar->isSliderDown();
 				quint64 start = GetCurCycle();
 				foreach(const QModelIndex& Index, NewBranches)
 					m_pTrace->GetTree()->expand(Index);
+				if (bFollowTraceTail)
+					m_pTrace->m_pTreeList->scrollToBottom();
+				UpdateAutoScrollIndicator();
 				qDebug() << "Expand took" << (GetCurCycle() - start) / 1000000.0 << "s";
 			});
 		}
 
-		if(m_pTrace->m_pAutoScroll->isChecked())
+		if (bFollowTraceTail)
 			m_pTrace->m_pTreeList->scrollToBottom();
+		UpdateAutoScrollIndicator();
 	}
 }
 
@@ -614,6 +694,7 @@ void CTraceView::OnSetMode()
 
 	m_FullRefresh = true;
 	Refresh();
+	UpdateAutoScrollIndicator();
 
 	theConf->SetValue("Options/UseMonitorMode", m_pMonitorMode->isChecked());
 }

--- a/SandboxiePlus/SandMan/Views/TraceView.cpp
+++ b/SandboxiePlus/SandMan/Views/TraceView.cpp
@@ -379,8 +379,11 @@ void CTraceView::SetEnabled(bool bSet)
 
 void CTraceView::OnShowStack()
 {
-	if (m_pShowStack->isChecked() && !theGUI->GetAddonManager()->GetAddon("DbgHelp", CAddonManager::eInstalled).isNull())
-        theGUI->GetAddonManager()->TryInstallAddon("DbgHelp", this, tr("To use the stack traces feature the DbgHelp.dll and SymSrv.dll are required, do you want to download and install them?"));
+	if (m_pShowStack->isChecked()) {
+		theGUI->GetAddonManager()->GetAddons();
+		if (theGUI->GetAddonManager()->GetAddon("DbgHelp", CAddonManager::eInstalled).isNull())
+			theGUI->GetAddonManager()->TryInstallAddon("DbgHelp", this, tr("To use the stack traces feature the DbgHelp.dll and SymSrv.dll are required, do you want to download and install them?"));
+	}
 	theAPI->GetGlobalSettings()->SetBool("MonitorStackTrace", m_pShowStack->isChecked());
 	m_pTrace->m_pStackView->setVisible(m_pShowStack->isChecked());
 }

--- a/SandboxiePlus/SandMan/Views/TraceView.h
+++ b/SandboxiePlus/SandMan/Views/TraceView.h
@@ -8,6 +8,8 @@
 #include "../../MiscHelpers/Common/SortFilterProxyModel.h"
 #include "StackView.h"
 
+class QToolButton;
+
 
 class CTraceTree : public CPanelView
 {
@@ -94,7 +96,11 @@ private slots:
 	void				SaveToFile();
 
 protected:
+	bool				eventFilter(QObject* source, QEvent* event) override;
 	void				timerEvent(QTimerEvent* pEvent);
+	bool				IsTraceAtBottom() const;
+	void				PositionAutoScrollIndicator();
+	void				UpdateAutoScrollIndicator();
 	int					m_uTimerID;
 
 	static void			SaveToFileAsync(const CSbieProgressPtr& pProgress, QVector<CTraceEntryPtr> ResourceLog, QIODevice* pFile);
@@ -135,6 +141,7 @@ protected:
 	QComboBox*			m_pTraceStatus;
 	QAction*			m_pAllBoxes;
 	QAction*			m_pShowStack;
+	QToolButton*		m_pResumeAutoScroll;
 	QAction*			m_pSaveToFile;
 
 	QWidget*			m_pView;


### PR DESCRIPTION
- Stabilizes API tracing on alternate stacks by replacing callback-side formatting with a compact synchronous logging path.
- Improves stack symbol resolution and live symbol refresh.
- Fixes the incorrect DbgHelp installation prompt.
- Makes Trace Log auto-scroll pause when the user manually scrolls through existing entries.