### PR TITLE
Include Hindi in nightly translation sync

### DIFF
--- a/.github/workflows/lupdate.yml
+++ b/.github/workflows/lupdate.yml
@@ -38,6 +38,7 @@ jobs:
             -ts sandman_en.ts \
             -ts sandman_es.ts \
             -ts sandman_fr.ts \
+            -ts sandman_hi.ts \
             -ts sandman_hu.ts \
             -ts sandman_it.ts \
             -ts sandman_ja.ts \


### PR DESCRIPTION
## Summary
- Add `sandman_hi.ts` to the nightly Qt Linguist synchronization workflow.
- Hindi is already listed in `SandboxiePlus/SandMan/SandMan.pri`, but the workflow omitted it, leaving the file stale.

## Validation
- YAML parsed successfully.
- `git diff --check` passed.
- No source code or translation text was changed.