### PR TITLE
Fix stale project paths in build READMEs

### DIFF
--- a/Sandboxie/ReadMe.md
+++ b/Sandboxie/ReadMe.md
@@ -18,7 +18,7 @@ Sandboxie Classic builds under Visual Studio 2019, as it offers the widest compa
 7) If the WDK Extension doesn't install automatically, install it (can be found in <Windows Kits directory>\10\Vsix\VS2019)
 8) If you have a more recent Windows SDK version installed, retarget the solution to 10.0.19041
 	- This is for example necessary if VS 2022 is also installed with the default desktop C++ components
-9) To compile for x64, it's necessary to first compile `Solution/core/LowLevel` for Win32 (x86)
+9) To compile for x64, it's necessary to first compile `core/low/LowLevel.vcxproj` for Win32 (x86)
 
 ### Source projects (in alphabetical order)
 

--- a/SandboxiePlus/ReadMe.md
+++ b/SandboxiePlus/ReadMe.md
@@ -15,7 +15,7 @@ Sandboxie Plus builds under Visual Studio 2019, as it offers the widest compatib
 6) Ok, now we are ready to build, we start with Sandboxie Classic, we open the Sandbox.sln, select our platform and build type, and run the build.
 	- If we build for x64, we will need to also build the SbieSvc and SbieDll for 32-bit.
 	- If we were building for ARM64, we would also need the ARM64EC version of SbieDll.
-7) And now we continue with building the SandMan UI to create Sandboxie Plus. Here we open the Sandboxie-Plus.sln, select our platform and build type, and run the build.
+7) And now we continue with building the SandMan UI to create Sandboxie Plus. Here we open the SandboxiePlus.sln, select our platform and build type, and run the build.
 8) Once that is done, we only need to combine the two and here it is: Sandboxie Plus is ready for service.
 
 At this point, you may wonder how to run this build. In the end, the driver is not signed and we did not touch the process of signing the user mode components either.


### PR DESCRIPTION
## Summary

- Correct the obsolete `Solution/core/LowLevel` path in the Classic build README.
- Correct the obsolete `Sandboxie-Plus.sln` filename in the Plus build README.

Both replacement paths were checked against the repository:

- `Sandboxie/core/low/LowLevel.vcxproj`
- `SandboxiePlus/SandboxiePlus.sln`

No source code or build behavior is changed.