### PR TITLE
Preserve SandMan tree expansion choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added persistence for manually expanded and collapsed SandMan process-tree branches across task-list refreshes and UI restarts [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)
 
 ### Changed
-- changed SandMan's Auto Expand Tree to temporarily expand box groups, sandboxes, and process branches without overwriting their saved manual expansion states; set the SandMan UI configuration option `Options/LegacyAutoExpandTree=true` to retain the previous expand-all/collapse-all behaviour [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)
+- changed SandMan's Auto Expand Tree to preserve explicit group, sandbox, and process expansion choices while using the toggle as the default for items without saved state; Find bar Expand All and Collapse All remain one-time actions, and `Options/LegacyAutoExpandTree=true` retains the previous behavior [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)
 - validated compatibility with Windows build 29634 and updated DynData
 
 ### Fixed

--- a/SandboxiePlus/MiscHelpers/Common/Finder.cpp
+++ b/SandboxiePlus/MiscHelpers/Common/Finder.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Finder.h"
+#include <QSignalBlocker>
 
 bool CFinder::m_DarkMode = false;
 
@@ -393,14 +394,18 @@ void CFinder::OnSelectNext()
 
 void CFinder::OnExpandAll()
 {
-	if (m_pTree)
+	if (m_pTree) {
+		QSignalBlocker Blocker(m_pTree);
 		m_pTree->expandAll();
+	}
 }
 
 void CFinder::OnCollapseAll()
 {
-	if (m_pTree)
+	if (m_pTree) {
+		QSignalBlocker Blocker(m_pTree);
 		m_pTree->collapseAll();
+	}
 }
 
 void CFinder::SetProgress(int value, int maximum)

--- a/SandboxiePlus/QSbieAPI/SbieAPI.cpp
+++ b/SandboxiePlus/QSbieAPI/SbieAPI.cpp
@@ -67,6 +67,7 @@ struct SSbieAPI
 		traceBufferLen = 0;
 
 		SbieMsgDll = NULL;
+		ProcessListInitialized = false;
 
 		SvcLock = 0;
 	}
@@ -102,6 +103,7 @@ struct SSbieAPI
 	ULONG traceBufferLen;
 
 	HMODULE SbieMsgDll;
+	bool ProcessListInitialized;
 
 	mutable volatile LONG   SvcLock;
 	mutable MSG_HEADER*		SvcReq;
@@ -139,7 +141,6 @@ CSbieAPI::CSbieAPI(QObject* parent) : QThread(parent)
 	m_IniReLoad = false;
 	m_bReloadPending = false;
 	m_bBoxesDirty = false;
-	m_bProcessListInitialized = false;
 
 	connect(&m_IniWatcher, SIGNAL(fileChanged(const QString&)), this, SLOT(OnIniChanged(const QString&)));
 	connect(this, SIGNAL(ProcessBoxed(quint32, const QString&, const QString&, quint32, const QString&)), this, SLOT(OnProcessBoxed(quint32, const QString&, const QString&, quint32, const QString&)));
@@ -414,7 +415,7 @@ SB_STATUS CSbieAPI::Disconnect()
 
 	m_SandBoxes.clear();
 	m_BoxedProxesses.clear();
-	m_bProcessListInitialized = false;
+	m->ProcessListInitialized = false;
 	m_bBoxesDirty = true;
 
 	emit StatusChanged();
@@ -1584,8 +1585,13 @@ SB_STATUS CSbieAPI::UpdateProcesses(int iKeep, bool bAllSessions)
 	}
 
 	delete[] boxed_pids;
-	m_bProcessListInitialized = true;
+	m->ProcessListInitialized = true;
 	return SB_OK;
+}
+
+bool CSbieAPI::IsProcessListInitialized() const
+{
+	return m->ProcessListInitialized;
 }
 
 bool CSbieAPI::HasProcesses(const QString& BoxName)

--- a/SandboxiePlus/QSbieAPI/SbieAPI.cpp
+++ b/SandboxiePlus/QSbieAPI/SbieAPI.cpp
@@ -139,6 +139,7 @@ CSbieAPI::CSbieAPI(QObject* parent) : QThread(parent)
 	m_IniReLoad = false;
 	m_bReloadPending = false;
 	m_bBoxesDirty = false;
+	m_bProcessListInitialized = false;
 
 	connect(&m_IniWatcher, SIGNAL(fileChanged(const QString&)), this, SLOT(OnIniChanged(const QString&)));
 	connect(this, SIGNAL(ProcessBoxed(quint32, const QString&, const QString&, quint32, const QString&)), this, SLOT(OnProcessBoxed(quint32, const QString&, const QString&, quint32, const QString&)));
@@ -413,6 +414,7 @@ SB_STATUS CSbieAPI::Disconnect()
 
 	m_SandBoxes.clear();
 	m_BoxedProxesses.clear();
+	m_bProcessListInitialized = false;
 	m_bBoxesDirty = true;
 
 	emit StatusChanged();
@@ -1582,6 +1584,7 @@ SB_STATUS CSbieAPI::UpdateProcesses(int iKeep, bool bAllSessions)
 	}
 
 	delete[] boxed_pids;
+	m_bProcessListInitialized = true;
 	return SB_OK;
 }
 

--- a/SandboxiePlus/QSbieAPI/SbieAPI.h
+++ b/SandboxiePlus/QSbieAPI/SbieAPI.h
@@ -65,6 +65,7 @@ public:
 	virtual SB_STATUS		CreateBox(const QString& BoxName, bool bReLoad = true);
 
 	virtual SB_STATUS		UpdateProcesses(int iKeep, bool bAllSessions);
+	bool					IsProcessListInitialized() const { return m_bProcessListInitialized; }
 
 	virtual QMap<QString, CSandBoxPtr> GetAllBoxes() { return m_SandBoxes; }
 	virtual QMap<quint32, CBoxedProcessPtr> GetAllProcesses() { return m_BoxedProxesses; }
@@ -257,6 +258,7 @@ protected:
 
 	QMap<QString, CSandBoxPtr> m_SandBoxes;
 	QMap<quint32, CBoxedProcessPtr> m_BoxedProxesses;
+	bool m_bProcessListInitialized;
 
 	QMap<quint32, SWndInfo> m_WindowMap;
 

--- a/SandboxiePlus/QSbieAPI/SbieAPI.h
+++ b/SandboxiePlus/QSbieAPI/SbieAPI.h
@@ -65,7 +65,7 @@ public:
 	virtual SB_STATUS		CreateBox(const QString& BoxName, bool bReLoad = true);
 
 	virtual SB_STATUS		UpdateProcesses(int iKeep, bool bAllSessions);
-	bool					IsProcessListInitialized() const { return m_bProcessListInitialized; }
+	bool					IsProcessListInitialized() const;
 
 	virtual QMap<QString, CSandBoxPtr> GetAllBoxes() { return m_SandBoxes; }
 	virtual QMap<quint32, CBoxedProcessPtr> GetAllProcesses() { return m_BoxedProxesses; }
@@ -258,7 +258,6 @@ protected:
 
 	QMap<QString, CSandBoxPtr> m_SandBoxes;
 	QMap<quint32, CBoxedProcessPtr> m_BoxedProxesses;
-	bool m_bProcessListInitialized;
 
 	QMap<quint32, SWndInfo> m_WindowMap;
 

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -2921,7 +2921,7 @@ void CSandMan::OnStatusChanged()
 
 			auto AllBoxes = theAPI->GetAllBoxes();
 
-			m_pBoxView->ClearUserUIConfig(AllBoxes);
+			m_pBoxView->ClearUserUIConfig(AllBoxes, true);
 
 			foreach(const QString & Key, theConf->ListKeys("SizeCache")) {
 				if (!AllBoxes.contains(Key.toLower()) || !theConf->GetBool("Options/WatchBoxSize", false))

--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -3051,7 +3051,7 @@ bool CSbieView::NormalizeGroups()
 	return Changed;
 }
 
-void CSbieView::ClearUserUIConfig(const QMap<QString, CSandBoxPtr> AllBoxes) 
+void CSbieView::ClearUserUIConfig(const QMap<QString, CSandBoxPtr> AllBoxes, bool bBoxesLoaded)
 {
 	if (!AllBoxes.isEmpty())
 	{
@@ -3068,16 +3068,18 @@ void CSbieView::ClearUserUIConfig(const QMap<QString, CSandBoxPtr> AllBoxes)
 	}
 
 	bool ExpandStateChanged = false;
-	for (auto I = m_BoxExpandState.begin(); I != m_BoxExpandState.end();) {
-		QString Name = I.key().mid(2);
-		bool Exists = I.key().startsWith("g|") ? m_Groups.contains(Name)
-			: AllBoxes.isEmpty() || AllBoxes.contains(Name.toLower());
-		if (!Exists) {
-			I = m_BoxExpandState.erase(I);
-			ExpandStateChanged = true;
+	if (bBoxesLoaded) {
+		for (auto I = m_BoxExpandState.begin(); I != m_BoxExpandState.end();) {
+			QString Name = I.key().mid(2);
+			bool Exists = I.key().startsWith("g|") ? m_Groups.contains(Name)
+				: AllBoxes.contains(Name.toLower());
+			if (!Exists) {
+				I = m_BoxExpandState.erase(I);
+				ExpandStateChanged = true;
+			}
+			else
+				++I;
 		}
-		else
-			++I;
 	}
 	if (ExpandStateChanged && theConf->GetInt("Options/BoxGroupHandling", 0) == 0)
 		SaveBoxExpandState();

--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -558,12 +558,7 @@ void CSbieView::Refresh()
 				if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
 					CBoxedProcessPtr pProcess = m_pSbieModel->GetProcess(ModelIndex);
 					QString Key = GetProcessExpandKey(pProcess);
-					bool bExpand;
-					if (bAutoExpand && !bLegacyAutoExpand)
-						bExpand = !m_AutoExpandCollapsed.contains(GetExpandStateKey(ModelIndex));
-					else
-						bExpand = m_ProcessExpandState.contains(Key)
-							? m_ProcessExpandState.value(Key) : bAutoExpand;
+					bool bExpand = m_ProcessExpandState.value(Key, bAutoExpand);
 					if (bExpand) {
 						m_HoldExpand = true;
 						m_pSbieTree->expand(m_pSortProxy->mapFromSource(ModelIndex));
@@ -577,18 +572,16 @@ void CSbieView::Refresh()
 				}
 				else
 				{
-					QString Name;
-					if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eGroup)
-						Name = m_pSbieModel->GetID(ModelIndex).toString();
-					else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eBox)
-						Name = m_pSbieModel->GetSandBox(ModelIndex)->GetName();
-
-					bool bExpand = bAutoExpand && !bLegacyAutoExpand
-						? !m_AutoExpandCollapsed.contains(GetExpandStateKey(ModelIndex))
-						: !m_Collapsed.contains(Name);
+					bool bExpand = m_BoxExpandState.value(GetExpandStateKey(ModelIndex),
+						bLegacyAutoExpand ? true : bAutoExpand);
 					if (bExpand) {
 						m_HoldExpand = true;
 						m_pSbieTree->expand(m_pSortProxy->mapFromSource(ModelIndex));
+						m_HoldExpand = false;
+					}
+					else {
+						m_HoldExpand = true;
+						m_pSbieTree->collapse(m_pSortProxy->mapFromSource(ModelIndex));
 						m_HoldExpand = false;
 					}
 				}
@@ -1022,8 +1015,16 @@ void CSbieView::RenameItem(const QString OldName, const QString NewName)
 	theConf->DelValue("SizeCache/" + OldName);
 	if(Size != -1) theConf->SetValue("SizeCache/" + NewName, Size);
 
-	if (m_Collapsed.remove(OldName))
-		m_Collapsed.insert(NewName);
+	bool ExpandStateChanged = false;
+	foreach(const QString& Prefix, QStringList() << "g|" << "b|") {
+		QString OldKey = Prefix + OldName;
+		if (m_BoxExpandState.contains(OldKey)) {
+			m_BoxExpandState.insert(Prefix + NewName, m_BoxExpandState.take(OldKey));
+			ExpandStateChanged = true;
+		}
+	}
+	if (ExpandStateChanged && theConf->GetInt("Options/BoxGroupHandling", 0) == 0)
+		SaveBoxExpandState();
 
 	for (auto I = m_Groups.begin(); I != m_Groups.end(); ++I)
 	{
@@ -1174,7 +1175,9 @@ void CSbieView::OnGroupAction(QAction* Action)
 						break;
 					}
 				}
-				m_Collapsed.remove(Group);
+				m_BoxExpandState.remove("g|" + Group);
+				if (theConf->GetInt("Options/BoxGroupHandling", 0) == 0)
+					SaveBoxExpandState();
 			}
 		}
 
@@ -1832,7 +1835,9 @@ void CSbieView::OnSandBoxAction(QAction* Action, const QList<CSandBoxPtr>& SandB
 
 			if (!Status.IsError()) {
 				theConf->DelValue("SizeCache/" + Name);
-				m_Collapsed.remove(Name);
+				m_BoxExpandState.remove("b|" + Name);
+				if (theConf->GetInt("Options/BoxGroupHandling", 0) == 0)
+					SaveBoxExpandState();
 				for (auto I = m_Groups.begin(); I != m_Groups.end(); ++I)
 				{
 					if (I.value().removeOne(Name)) {
@@ -2735,17 +2740,6 @@ void CSbieView::ChangeExpand(const QModelIndex& index, bool bExpand)
 		return;
 
 	QModelIndex ModelIndex = m_pSortProxy->mapToSource(index);
-	if (theGUI->IsAutoExpand()
-	 && !theConf->GetBool("Options/LegacyAutoExpandTree", false)) {
-		QString Key = GetExpandStateKey(ModelIndex);
-		if (!Key.isEmpty()) {
-			if (bExpand)
-				m_AutoExpandCollapsed.remove(Key);
-			else
-				m_AutoExpandCollapsed.insert(Key);
-		}
-		return;
-	}
 
 	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
 		QString Key = GetProcessExpandKey(m_pSbieModel->GetProcess(ModelIndex));
@@ -2756,29 +2750,15 @@ void CSbieView::ChangeExpand(const QModelIndex& index, bool bExpand)
 		return;
 	}
 
-	QString Name;
-	if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eGroup)
-		Name = m_pSbieModel->GetID(ModelIndex).toString();
-	else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eBox)
-		Name = m_pSbieModel->GetSandBox(ModelIndex)->GetName();
-
-	if(bExpand)
-		m_Collapsed.remove(Name);
-	else
-		m_Collapsed.insert(Name);
-
-	//QMap<QString, QStringList> Collapsed;
-	//Collapsed.insert("", SetToList(m_Collapsed));
-	//theAPI->GetUserSettings()->SetTextMap("CollapsedBoxes", Collapsed);
-
-	QString Collapsed = SetToList(m_Collapsed).join(",");
-	theConf->SetValue("UIConfig/BoxCollapsedView", Collapsed);
+	QString Key = GetExpandStateKey(ModelIndex);
+	if (!Key.isEmpty()) {
+		m_BoxExpandState.insert(Key, bExpand);
+		SaveBoxExpandState();
+	}
 }
 
 void CSbieView::SetAutoExpand(bool bExpand, bool bLegacy)
 {
-	m_AutoExpandCollapsed.clear();
-
 	if (bLegacy) {
 		if (bExpand)
 			m_pSbieTree->expandAll();
@@ -2788,37 +2768,26 @@ void CSbieView::SetAutoExpand(bool bExpand, bool bLegacy)
 	}
 
 	m_HoldExpand = true;
-	if (bExpand)
-		m_pSbieTree->expandAll();
-	else
-		ApplyExpandState(false);
+	ApplyExpandState(bExpand);
 	m_HoldExpand = false;
 }
 
-void CSbieView::ApplyExpandState(bool bAutoExpand, const QModelIndex& Parent)
+void CSbieView::ApplyExpandState(bool bDefaultExpand, const QModelIndex& Parent)
 {
 	for (int Row = 0; Row < m_pSortProxy->rowCount(Parent); ++Row) {
 		QModelIndex Index = m_pSortProxy->index(Row, 0, Parent);
 		QModelIndex ModelIndex = m_pSortProxy->mapToSource(Index);
 
 		bool bExpand;
-		if (bAutoExpand)
-			bExpand = !m_AutoExpandCollapsed.contains(GetExpandStateKey(ModelIndex));
-		else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
+		if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eProcess) {
 			QString Key = GetProcessExpandKey(m_pSbieModel->GetProcess(ModelIndex));
-			bExpand = m_ProcessExpandState.value(Key, false);
+			bExpand = m_ProcessExpandState.value(Key, bDefaultExpand);
 		}
-		else {
-			QString Name;
-			if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eGroup)
-				Name = m_pSbieModel->GetID(ModelIndex).toString();
-			else if (m_pSbieModel->GetType(ModelIndex) == CSbieModel::eBox)
-				Name = m_pSbieModel->GetSandBox(ModelIndex)->GetName();
-			bExpand = !m_Collapsed.contains(Name);
-		}
+		else
+			bExpand = m_BoxExpandState.value(GetExpandStateKey(ModelIndex), bDefaultExpand);
 
 		m_pSbieTree->setExpanded(Index, bExpand);
-		ApplyExpandState(bAutoExpand, Index);
+		ApplyExpandState(bDefaultExpand, Index);
 	}
 }
 
@@ -2842,6 +2811,29 @@ QString CSbieView::GetProcessExpandKey(const CBoxedProcessPtr& pProcess) const
 
 	return QString("%1|%2|%3").arg(pProcess->GetBoxName())
 		.arg(pProcess->GetProcessId()).arg(pProcess->GetTimeStamp().toMSecsSinceEpoch());
+}
+
+void CSbieView::SaveBoxExpandState()
+{
+	if (m_BoxExpandState.isEmpty()) {
+		theConf->DelValue("UIConfig/BoxTreeState");
+		theConf->DelValue("UIConfig/BoxCollapsedView");
+		return;
+	}
+
+	QStringList State;
+	QSet<QString> Collapsed;
+	for (auto I = m_BoxExpandState.constBegin(); I != m_BoxExpandState.constEnd(); ++I) {
+		State.append(QString(I.value() ? "e|" : "c|") + I.key());
+		if (!I.value())
+			Collapsed.insert(I.key().mid(2));
+	}
+	State.sort();
+	theConf->SetValue("UIConfig/BoxTreeState", State);
+	if (Collapsed.isEmpty())
+		theConf->DelValue("UIConfig/BoxCollapsedView");
+	else
+		theConf->SetValue("UIConfig/BoxCollapsedView", SetToList(Collapsed).join(","));
 }
 
 void CSbieView::SaveProcessExpandState()
@@ -2875,13 +2867,6 @@ void CSbieView::CleanupProcessExpandState()
 				LiveProcesses.insert(Key);
 		}
 	}
-	for (auto I = m_AutoExpandCollapsed.begin(); I != m_AutoExpandCollapsed.end();) {
-		if (I->startsWith("p|") && !LiveProcesses.contains(I->mid(2)))
-			I = m_AutoExpandCollapsed.erase(I);
-		else
-			++I;
-	}
-
 	bool Changed = false;
 	for (auto I = m_ProcessExpandState.begin(); I != m_ProcessExpandState.end();) {
 		if (!LiveProcesses.contains(I.key())) {
@@ -2906,7 +2891,7 @@ void CSbieView::UpdateColapsed()
 
 	foreach(const QString& Group, m_Groups.keys())
 	{
-		if (!m_Collapsed.contains(Group)) {
+		if (m_BoxExpandState.value("g|" + Group, true)) {
 			QModelIndex index = m_pSbieModel->FindGroupIndex(Group);
 			if(index.isValid())
 				m_pSbieTree->expand(m_pSortProxy->mapFromSource(index));
@@ -2931,20 +2916,33 @@ void CSbieView::ReloadUserConfig()
 	UpdateMoveMenu();
 
 	int Handling = theConf->GetInt("Options/BoxGroupHandling", 0);
-	if(Handling == 2)
-		m_Collapsed = ListToSet(m_Groups.keys());
-	else if(Handling == 1)
-		m_Collapsed.clear();
+	m_BoxExpandState.clear();
+	if(Handling == 1 || Handling == 2) {
+		foreach(const QString& Group, m_Groups.keys())
+			m_BoxExpandState.insert("g|" + Group, Handling == 1);
+	}
 	else if (Handling == 0)
 	{
-		//QMap<QString, QStringList> Collapsed = theAPI->GetUserSettings()->GetTextMap("CollapsedBoxes");
-		//m_Collapsed = ListToSet(Collapsed[""]);
-		//if (m_Collapsed.isEmpty()) { // try legacy entries
-		QString Collapsed = theConf->GetString("UIConfig/BoxCollapsedView");
-		//if (Collapsed.isEmpty())
-		//	Collapsed = theAPI->GetUserSettings()->GetText("BoxCollapsedView");
-			m_Collapsed = ListToSet(SplitStr(Collapsed, ","));
-		//}
+		QStringList BoxState = theConf->GetStringList("UIConfig/BoxTreeState");
+		if (BoxState.isEmpty()) {
+			QString State = theConf->GetString("UIConfig/BoxTreeState");
+			if (!State.isEmpty())
+				BoxState.append(State);
+		}
+		foreach(const QString& State, BoxState) {
+			if (State.length() > 4 && State.at(1) == '|'
+			 && (State.at(0) == 'e' || State.at(0) == 'c')
+			 && (State.mid(2, 2) == "g|" || State.mid(2, 2) == "b|"))
+				m_BoxExpandState.insert(State.mid(2), State.at(0) == 'e');
+		}
+		if (m_BoxExpandState.isEmpty()) {
+			foreach(const QString& Name, SplitStr(theConf->GetString("UIConfig/BoxCollapsedView"), ",")) {
+				if (m_Groups.contains(Name))
+					m_BoxExpandState.insert("g|" + Name, false);
+				if (!theAPI->GetBoxByName(Name).isNull())
+					m_BoxExpandState.insert("b|" + Name, false);
+			}
+		}
 	}
 
 	m_ProcessExpandState.clear();
@@ -3074,14 +3072,20 @@ void CSbieView::ClearUserUIConfig(const QMap<QString, CSandBoxPtr> AllBoxes)
 		}
 	}
 
-	QSet<QString> Temp = m_Collapsed;
-	foreach(QString Name, m_Collapsed)
-	{
-		if (m_Groups.end() == std::find_if(m_Groups.begin(), m_Groups.end(),
-					  [Name](const QStringList& item)->int { return item.contains(Name); }))
-			Temp.remove(Name);
+	bool ExpandStateChanged = false;
+	for (auto I = m_BoxExpandState.begin(); I != m_BoxExpandState.end();) {
+		QString Name = I.key().mid(2);
+		bool Exists = I.key().startsWith("g|") ? m_Groups.contains(Name)
+			: !theAPI->GetBoxByName(Name).isNull();
+		if (!Exists) {
+			I = m_BoxExpandState.erase(I);
+			ExpandStateChanged = true;
+		}
+		else
+			++I;
 	}
-	m_Collapsed = Temp;
+	if (ExpandStateChanged && theConf->GetInt("Options/BoxGroupHandling", 0) == 0)
+		SaveBoxExpandState();
 }
 
 void CSbieView::SaveBoxGrouping()

--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -33,7 +33,6 @@ CSbieView::CSbieView(QWidget* parent) : CPanelView(parent)
 	this->setLayout(m_pMainLayout);
 
 	m_HoldExpand = false;
-	m_ProcessStateCleanupPending = false;
 	m_MoveBatchPending = false;
 	m_MoveBatchChanged = false;
 
@@ -2852,13 +2851,10 @@ void CSbieView::SaveProcessExpandState()
 
 void CSbieView::CleanupProcessExpandState()
 {
-	QMap<quint32, CBoxedProcessPtr> Processes = theAPI->GetAllProcesses();
-	if (m_ProcessStateCleanupPending) {
-		m_ProcessStateCleanupPending = false;
-		if (Processes.isEmpty())
-			return;
-	}
+	if (!theAPI->IsProcessListInitialized())
+		return;
 
+	QMap<quint32, CBoxedProcessPtr> Processes = theAPI->GetAllProcesses();
 	QSet<QString> LiveProcesses;
 	foreach(const CBoxedProcessPtr& pProcess, Processes) {
 		if (!pProcess->IsTerminated()) {
@@ -2939,7 +2935,7 @@ void CSbieView::ReloadUserConfig()
 			foreach(const QString& Name, SplitStr(theConf->GetString("UIConfig/BoxCollapsedView"), ",")) {
 				if (m_Groups.contains(Name))
 					m_BoxExpandState.insert("g|" + Name, false);
-				if (!theAPI->GetBoxByName(Name).isNull())
+				else
 					m_BoxExpandState.insert("b|" + Name, false);
 			}
 		}
@@ -2957,7 +2953,6 @@ void CSbieView::ReloadUserConfig()
 		 && (State.at(0) == 'e' || State.at(0) == 'c'))
 			m_ProcessExpandState.insert(State.mid(2), State.at(0) == 'e');
 	}
-	m_ProcessStateCleanupPending = !m_ProcessExpandState.isEmpty();
 	if (m_ProcessExpandState.isEmpty())
 		theConf->DelValue("UIConfig/ProcessTreeState");
 
@@ -3076,7 +3071,7 @@ void CSbieView::ClearUserUIConfig(const QMap<QString, CSandBoxPtr> AllBoxes)
 	for (auto I = m_BoxExpandState.begin(); I != m_BoxExpandState.end();) {
 		QString Name = I.key().mid(2);
 		bool Exists = I.key().startsWith("g|") ? m_Groups.contains(Name)
-			: !theAPI->GetBoxByName(Name).isNull();
+			: AllBoxes.isEmpty() || AllBoxes.contains(Name.toLower());
 		if (!Exists) {
 			I = m_BoxExpandState.erase(I);
 			ExpandStateChanged = true;

--- a/SandboxiePlus/SandMan/Views/SbieView.h
+++ b/SandboxiePlus/SandMan/Views/SbieView.h
@@ -126,9 +126,8 @@ protected:
 	void						OnMoveTo(const QString& Group);
 
 	QMap<QString, QStringList>	m_Groups;
-	QSet<QString>				m_Collapsed;
+	QHash<QString, bool>		m_BoxExpandState;
 	QHash<QString, bool>		m_ProcessExpandState;
-	QSet<QString>				m_AutoExpandCollapsed;
 	bool						m_ProcessStateCleanupPending;
 	bool						m_HoldExpand;
 
@@ -155,9 +154,10 @@ private:
 	bool					IsParentOf(const QString& Name, const QString& Group);
 
 	void					ChangeExpand(const QModelIndex& index, bool bExpand);
-	void					ApplyExpandState(bool bAutoExpand, const QModelIndex& Parent = QModelIndex());
+	void					ApplyExpandState(bool bDefaultExpand, const QModelIndex& Parent = QModelIndex());
 	QString					GetExpandStateKey(const QModelIndex& ModelIndex) const;
 	QString					GetProcessExpandKey(const CBoxedProcessPtr& pProcess) const;
+	void					SaveBoxExpandState();
 	void					SaveProcessExpandState();
 	void					CleanupProcessExpandState();
 	QStringList				GetSelectedBoxNames();

--- a/SandboxiePlus/SandMan/Views/SbieView.h
+++ b/SandboxiePlus/SandMan/Views/SbieView.h
@@ -128,7 +128,6 @@ protected:
 	QMap<QString, QStringList>	m_Groups;
 	QHash<QString, bool>		m_BoxExpandState;
 	QHash<QString, bool>		m_ProcessExpandState;
-	bool						m_ProcessStateCleanupPending;
 	bool						m_HoldExpand;
 
 private:

--- a/SandboxiePlus/SandMan/Views/SbieView.h
+++ b/SandboxiePlus/SandMan/Views/SbieView.h
@@ -82,7 +82,7 @@ public slots:
 	void						Clear();
 	void						Refresh();
 	void						ReloadUserConfig();
-	void						ClearUserUIConfig(const QMap<QString, CSandBoxPtr> AllBoxes = QMap<QString, CSandBoxPtr>());
+	void						ClearUserUIConfig(const QMap<QString, CSandBoxPtr> AllBoxes = QMap<QString, CSandBoxPtr>(), bool bBoxesLoaded = false);
 	void						SaveBoxGrouping();
 
 private slots:


### PR DESCRIPTION
Changes #5491

Reworks SandMan tree-state handling so auto-expand acts as the default only for items without a saved preference, while explicit group, sandbox, and process expand/collapse choices keep winning across refreshes and renames. It also makes Find bar Expand All/Collapse All one-shot actions by blocking tree signals, preventing those commands from overwriting the saved state, and keeps the legacy behavior behind `Options/LegacyAutoExpandTree`.