### PR TITLE
Add auto-delete snapshot restore preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - added outside sandboxed-window border modes (`onoutside`, `ttloutside`, and `alloutside`) in SandMan; these draw the configured border outside the application frame, while the new `BorderInsideMaximized=y` setting (enabled by default) moves the border and label inside maximized or snapped windows so they remain visible
 - added persistence for manually expanded and collapsed SandMan process-tree branches across task-list refreshes and UI restarts [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)
+- added a SandMan setting to restore either the active or default snapshot after automatic deletion, consistently across synchronous and asynchronous cleanup, with Snapshot Manager access and refresh controls
 
 ### Changed
 - changed SandMan's Auto Expand Tree to temporarily expand box groups, sandboxes, and process branches without overwriting their saved manual expansion states; set the SandMan UI configuration option `Options/LegacyAutoExpandTree=true` to retain the previous expand-all/collapse-all behaviour [#5491](https://github.com/sandboxie-plus/Sandboxie/pull/5491)

--- a/Sandboxie/install/SbieSettings.ini
+++ b/Sandboxie/install/SbieSettings.ini
@@ -870,6 +870,19 @@ Syntax=[sn]=[bN]
 Description=Automatically deletes sandbox contents on close or exit.
 
 
+[AutoDeleteSnapshotTarget]
+AddedVersion=1.18.2
+RemovedVersion=
+ReAddedVersion=
+RenamedVersion=
+SupersededBy=
+Category=f
+Context=
+Requirements=<AutoDelete=y>
+Syntax=[sn]=Current|Default
+Description=Selects whether SandMan restores the active or default snapshot after automatic\ndeletion. The active state may be the empty sandbox rather than a saved snapshot. This\nsetting only applies when snapshots are retained and SandMan performs the automatic deletion.
+
+
 [AutoExec]
 AddedVersion=
 RemovedVersion=

--- a/SandboxiePlus/SandMan/BoxJob.cpp
+++ b/SandboxiePlus/SandMan/BoxJob.cpp
@@ -16,10 +16,7 @@ SB_PROGRESS CCleanUpJob::Start()
 	if (!m_DeleteSnapshots && pBox->HasSnapshots()) {
 		QString Current;
 		QString Default = pBox->GetDefaultSnapshot(&Current);
-		if (m_bOnAutoDelete) {
-			Default = Current; // on auto delete always return to the latest
-		}
-		Status = pBox->SelectSnapshot(Default);
+		Status = pBox->SelectSnapshot(m_UseCurrentSnapshot ? Current : Default);
 	}
 	else // if there are no snapshots jut use the normal cleaning procedure
 		Status = pBox->CleanBox();

--- a/SandboxiePlus/SandMan/BoxJob.h
+++ b/SandboxiePlus/SandMan/BoxJob.h
@@ -32,10 +32,10 @@ class CCleanUpJob : public CBoxJob
 {
 protected:
 	friend CSandBoxPlus;
-	CCleanUpJob(CSandBoxPlus* pBox, bool DeleteSnapshots = true, bool bOnAutoDelete = false) : CBoxJob((QObject*)pBox) { 
+	CCleanUpJob(CSandBoxPlus* pBox, bool DeleteSnapshots = true, bool UseCurrentSnapshot = false) : CBoxJob((QObject*)pBox) {
 		m_Description = tr("Deleting Content");
 		m_DeleteSnapshots = DeleteSnapshots; 
-		m_bOnAutoDelete = bOnAutoDelete;
+		m_UseCurrentSnapshot = UseCurrentSnapshot;
 	}
 
 	virtual SB_PROGRESS	Start();
@@ -43,7 +43,7 @@ protected:
 
 protected:
 	bool m_DeleteSnapshots;
-	bool m_bOnAutoDelete;
+	bool m_UseCurrentSnapshot;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -401,6 +401,54 @@
                  </property>
                 </widget>
                </item>
+               <item row="11" column="2">
+                <widget class="QLabel" name="lblAutoDeleteSnapshot">
+                 <property name="text">
+                  <string>After automatic deletion, restore from snapshot:</string>
+                 </property>
+                 <property name="buddy">
+                  <cstring>cmbAutoDeleteSnapshot</cstring>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="3">
+                <widget class="QComboBox" name="cmbAutoDeleteSnapshot"/>
+               </item>
+               <item row="11" column="4">
+                <widget class="QToolButton" name="btnAutoDeleteSnapshots">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>32</width>
+                   <height>32</height>
+                  </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>Open Snapshot Manager</string>
+                 </property>
+                 <property name="text">
+                  <string>...</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="5">
+                <spacer name="horizontalSpacerAutoDeleteSnapshot">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
                <item row="0" column="0">
                 <widget class="QLabel" name="lblStructure">
                  <property name="font">
@@ -414,7 +462,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="11" column="1" colspan="6">
+               <item row="12" column="1" colspan="6">
                 <widget class="QCheckBox" name="chkProtectBox">
                  <property name="toolTip">
                   <string>Partially checked means prevent box removal but not content deletion.</string>
@@ -437,7 +485,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="16" column="1">
+               <item row="17" column="1">
                 <spacer name="verticalSpacer_2">
                  <property name="orientation">
                   <enum>Qt::Orientation::Vertical</enum>
@@ -504,21 +552,27 @@
                  </property>
                 </widget>
                </item>
-               <item row="5" column="5">
+               <item row="5" column="3">
                 <widget class="QToolButton" name="btnPassword">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
                  <property name="text">
                   <string>Set Password</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="1" colspan="4">
+               <item row="5" column="1" colspan="2">
                 <widget class="QCheckBox" name="chkEncrypt">
                  <property name="text">
                   <string>Encrypt sandbox content</string>
                  </property>
                 </widget>
                </item>
-               <item row="14" column="2" colspan="5">
+               <item row="15" column="2" colspan="5">
                 <widget class="QCheckBox" name="chkRawDiskNotify">
                  <property name="text">
                   <string>Warn when an application opens a harddrive handle</string>
@@ -538,14 +592,14 @@
                  </property>
                 </widget>
                </item>
-               <item row="13" column="1" colspan="6">
+               <item row="14" column="1" colspan="6">
                 <widget class="QCheckBox" name="chkRawDiskRead">
                  <property name="text">
                   <string>Allow elevated sandboxed applications to read the harddrive</string>
                  </property>
                 </widget>
                </item>
-               <item row="12" column="0" colspan="2">
+               <item row="13" column="0" colspan="2">
                 <widget class="QLabel" name="lblRawDisk">
                  <property name="font">
                   <font>
@@ -558,7 +612,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="14" column="1">
+               <item row="15" column="1">
                 <widget class="QLabel" name="label_37">
                  <property name="maximumSize">
                   <size>
@@ -578,7 +632,7 @@
                  </property>
                 </widget>
                </item>
-               <item row="16" column="2" colspan="5">
+               <item row="17" column="2" colspan="5">
                 <spacer name="horizontalSpacer_4">
                  <property name="orientation">
                   <enum>Qt::Orientation::Horizontal</enum>
@@ -591,7 +645,7 @@
                  </property>
                 </spacer>
                </item>
-               <item row="15" column="1" colspan="2">
+               <item row="16" column="1" colspan="2">
                 <widget class="QCheckBox" name="chkAllowEfs">
                  <property name="text">
                   <string>Allow sandboxed processes to open files protected by EFS</string>
@@ -4425,11 +4479,11 @@ The process match level has a higher priority than the specificity and describes
                </item>
                <item row="7" column="0" colspan="2">
                 <widget class="QCheckBox" name="chkUseIgnoreForQuick">
-                 <property name="text">
-                  <string>Use the above exclusion list to hide matching files from the Quick Recovery window</string>
-                 </property>
                  <property name="toolTip">
                   <string>Requires the &quot;Show All&quot; checkbox to be unchecked in the recovery window.</string>
+                 </property>
+                 <property name="text">
+                  <string>Use the above exclusion list to hide matching files from the Quick Recovery window</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
@@ -6353,6 +6407,8 @@ Please note that this values are currently user specific and saved globally for 
   <tabstop>btnPassword</tabstop>
   <tabstop>chkForceProtection</tabstop>
   <tabstop>chkAutoEmpty</tabstop>
+  <tabstop>cmbAutoDeleteSnapshot</tabstop>
+  <tabstop>btnAutoDeleteSnapshots</tabstop>
   <tabstop>chkProtectBox</tabstop>
   <tabstop>chkRawDiskRead</tabstop>
   <tabstop>chkRawDiskNotify</tabstop>

--- a/SandboxiePlus/SandMan/Forms/SnapshotsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/SnapshotsWindow.ui
@@ -165,17 +165,17 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
+           <widget class="QPushButton" name="btnRefresh">
+            <property name="minimumSize">
              <size>
-              <width>20</width>
-              <height>40</height>
+              <width>0</width>
+              <height>23</height>
              </size>
             </property>
-           </spacer>
+            <property name="text">
+             <string>Refresh View</string>
+            </property>
+           </widget>
           </item>
           <item row="3" column="0">
            <widget class="QPushButton" name="btnRemove">
@@ -233,6 +233,7 @@
   <tabstop>chkDefault</tabstop>
   <tabstop>txtInfo</tabstop>
   <tabstop>btnTake</tabstop>
+  <tabstop>btnRefresh</tabstop>
   <tabstop>btnSelect</tabstop>
   <tabstop>btnRemove</tabstop>
  </tabstops>

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -2492,6 +2492,13 @@ SB_STATUS CSandMan::DeleteBoxContent(const CSandBoxPtr& pBox, EDelMode Mode, boo
 	}
 
 	auto pBoxEx = pBox.objectCast<CSandBoxPlus>();
+	const bool UseAsyncDelete = theConf->GetBool("Options/UseAsyncBoxOps", false) || theGUI->IsSilentMode();
+	QString AutoDeleteSnapshotTarget = pBox->GetText("AutoDeleteSnapshotTarget", QString(), true, true, true);
+	if (AutoDeleteSnapshotTarget.compare("Current", Qt::CaseInsensitive) != 0
+	 && AutoDeleteSnapshotTarget.compare("Default", Qt::CaseInsensitive) != 0)
+		AutoDeleteSnapshotTarget = UseAsyncDelete ? "Default" : "Current";
+	const bool UseCurrentSnapshot = Mode == eAuto
+		&& AutoDeleteSnapshotTarget.compare("Current", Qt::CaseInsensitive) == 0;
 
 	if (pBoxEx->UseImageFile()) {
 		if (pBoxEx->GetMountRoot().isEmpty()) {
@@ -2514,8 +2521,8 @@ SB_STATUS CSandMan::DeleteBoxContent(const CSandBoxPtr& pBox, EDelMode Mode, boo
 		// schedule async OnBoxDelete triggers and clean up
 		//
 
-		if (theConf->GetBool("Options/UseAsyncBoxOps", false) || theGUI->IsSilentMode())
-			return pBoxEx->DeleteContentAsync(DeleteSnapshots);
+		if (UseAsyncDelete)
+			return pBoxEx->DeleteContentAsync(DeleteSnapshots, UseCurrentSnapshot);
 	}
 
 	m_iDeletingContent++;
@@ -2550,10 +2557,10 @@ SB_STATUS CSandMan::DeleteBoxContent(const CSandBoxPtr& pBox, EDelMode Mode, boo
 		//
 
 		SB_PROGRESS Status;
-		if (Mode != eForDelete && !DeleteSnapshots && pBox->HasSnapshots()) { // in auto delete mode always return to last snapshot
+		if (Mode != eForDelete && !DeleteSnapshots && pBox->HasSnapshots()) {
 			QString Current;
 			QString Default = pBox->GetDefaultSnapshot(&Current);
-			Status = pBox->SelectSnapshot(Mode == eAuto ? Current : Default);
+			Status = pBox->SelectSnapshot(UseCurrentSnapshot ? Current : Default);
 		}
 		else // if there are no snapshots just use the normal cleaning procedure
 			Status = pBox->CleanBox();

--- a/SandboxiePlus/SandMan/SbiePlusAPI.cpp
+++ b/SandboxiePlus/SandMan/SbiePlusAPI.cpp
@@ -855,7 +855,7 @@ int	CSandBoxPlus::IsLeaderProgram(const QString& ProgName)
 	return FindInStrList(Programs, ProgName) != Programs.end() ? 1 : 0; 
 }
 
-SB_STATUS CSandBoxPlus::DeleteContentAsync(bool DeleteSnapshots, bool bOnAutoDelete)
+SB_STATUS CSandBoxPlus::DeleteContentAsync(bool DeleteSnapshots, bool UseCurrentSnapshot)
 {
 	if (GetBool("NeverDelete", false))
 		return SB_ERR(SB_DeleteProtect);
@@ -870,7 +870,7 @@ SB_STATUS CSandBoxPlus::DeleteContentAsync(bool DeleteSnapshots, bool bOnAutoDel
 		AddJobToQueue(pJob);
 	}
 
-	CBoxJob* pJob = new CCleanUpJob(this, DeleteSnapshots, bOnAutoDelete);
+	CBoxJob* pJob = new CCleanUpJob(this, DeleteSnapshots, UseCurrentSnapshot);
 	AddJobToQueue(pJob);
 
 	return SB_OK;

--- a/SandboxiePlus/SandMan/SbiePlusAPI.h
+++ b/SandboxiePlus/SandMan/SbiePlusAPI.h
@@ -166,7 +166,7 @@ public:
 	class CRecoveryWindow*	m_pRecoveryWnd;
 
 	bool					IsBoxBusy() const { return IsSizePending() || !m_JobQueue.isEmpty(); }
-	SB_STATUS				DeleteContentAsync(bool DeleteSnapshots = true, bool bOnAutoDelete = false);
+	SB_STATUS				DeleteContentAsync(bool DeleteSnapshots = true, bool UseCurrentSnapshot = false);
 
 	struct SLink {
 		SLink() :Url(false), IconIndex(0) {}

--- a/SandboxiePlus/SandMan/Views/SbieView.cpp
+++ b/SandboxiePlus/SandMan/Views/SbieView.cpp
@@ -1635,23 +1635,7 @@ void CSbieView::OnSandBoxAction(QAction* Action, const QList<CSandBoxPtr>& SandB
 	}
 	else if (Action == m_pMenuSnapshots)
 	{
-		CSandBoxPtr pBox = SandBoxes.first();
-
-		static QMap<void*, CSnapshotsWindow*> SnapshotWindows;
-		CSnapshotsWindow* pSnapshotsWindow = SnapshotWindows.value(pBox.data());
-		if (pSnapshotsWindow == NULL) {
-			pSnapshotsWindow = new CSnapshotsWindow(SandBoxes.first(), this);
-			connect(theGUI, SIGNAL(Closed()), pSnapshotsWindow, SLOT(close()));
-			SnapshotWindows.insert(pBox.data(), pSnapshotsWindow);
-			connect(pSnapshotsWindow, &CSnapshotsWindow::Closed, [this, pBox]() {
-				SnapshotWindows.remove(pBox.data());
-			});
-			CSandMan::SafeShow(pSnapshotsWindow);
-		}
-		else {
-			pSnapshotsWindow->setWindowState((pSnapshotsWindow->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
-			SetForegroundWindow((HWND)pSnapshotsWindow->winId());
-		}
+		ShowSnapshots(SandBoxes.first());
 	}
 	else if (Action == m_pMenuDuplicate || Action == m_pMenuDuplicateEx)
 	{
@@ -2773,6 +2757,29 @@ void CSbieView::ChangeExpand(const QModelIndex& index, bool bExpand)
 
 	QString Collapsed = SetToList(m_Collapsed).join(",");
 	theConf->SetValue("UIConfig/BoxCollapsedView", Collapsed);
+}
+
+void CSbieView::ShowSnapshots(const CSandBoxPtr& pBox)
+{
+	if (pBox.isNull())
+		return;
+
+	static QMap<void*, CSnapshotsWindow*> SnapshotWindows;
+	CSnapshotsWindow* pSnapshotsWindow = SnapshotWindows.value(pBox.data());
+	if (pSnapshotsWindow == NULL) {
+		pSnapshotsWindow = new CSnapshotsWindow(pBox, this);
+		connect(theGUI, SIGNAL(Closed()), pSnapshotsWindow, SLOT(close()));
+		SnapshotWindows.insert(pBox.data(), pSnapshotsWindow);
+		connect(pSnapshotsWindow, &CSnapshotsWindow::Closed, [pBox]() {
+			SnapshotWindows.remove(pBox.data());
+		});
+		CSandMan::SafeShow(pSnapshotsWindow);
+	}
+	else {
+		pSnapshotsWindow->Refresh();
+		pSnapshotsWindow->setWindowState((pSnapshotsWindow->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+		SetForegroundWindow((HWND)pSnapshotsWindow->winId());
+	}
 }
 
 void CSbieView::SetAutoExpand(bool bExpand, bool bLegacy)

--- a/SandboxiePlus/SandMan/Views/SbieView.h
+++ b/SandboxiePlus/SandMan/Views/SbieView.h
@@ -70,6 +70,7 @@ public:
 	virtual void				ShowOptions(const QString& Name);
 	virtual void				ShowOptions(const CSandBoxPtr& pBox);
 	virtual void				ShowBrowse(const CSandBoxPtr& pBox);
+	virtual void				ShowSnapshots(const CSandBoxPtr& pBox);
 
 	QMap<QString, QStringList>	GetGroups() { return m_Groups; }
 

--- a/SandboxiePlus/SandMan/Windows/OptionsGeneral.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsGeneral.cpp
@@ -10,6 +10,7 @@
 #include "Helpers/WinHelper.h"
 #include "Windows/BoxImageWindow.h"
 #include "AddonManager.h"
+#include "../Views/SbieView.h"
 #include "../../../SandboxieTools/ImBox/ImBox.h"
 
 class CCertBadge: public QLabel
@@ -67,6 +68,16 @@ void COptionsWindow::CreateGeneral()
 	ui.cmbBoxBorder->addItem(tr("Show only when title is in focus") + outsideSuffix, "ttloutside");
 	ui.cmbBoxBorder->addItem(tr("Always show (focused window only)") + outsideSuffix, "onoutside");
 	ui.cmbBoxBorder->addItem(tr("Show for all windows in this box") + outsideSuffix, "alloutside");
+
+	ui.cmbAutoDeleteSnapshot->addItem(tr("Active snapshot"), "Current");
+	ui.cmbAutoDeleteSnapshot->addItem(tr("Default snapshot"), "Default");
+	ui.cmbAutoDeleteSnapshot->setToolTip(tr("Selects the snapshot restored by SandMan after automatic deletion. The active state may be the empty sandbox rather than a saved snapshot."));
+	ui.btnAutoDeleteSnapshots->setIcon(CSandMan::GetIcon("Snapshots"));
+	connect(ui.btnAutoDeleteSnapshots, &QToolButton::clicked, this, [this]() {
+		auto pBox = m_pBox.objectCast<CSandBox>();
+		if (!pBox.isNull())
+			theGUI->GetBoxView()->ShowSnapshots(pBox);
+	});
 
 
 	ui.cmbBoxType->addItem(theGUI->GetBoxIcon(CSandBoxPlus::eHardenedPlus), tr("Hardened Sandbox with Data Protection"), (int)CSandBoxPlus::eHardenedPlus);
@@ -252,6 +263,7 @@ void COptionsWindow::CreateGeneral()
 
 	connect(ui.chkProtectBox, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
 	connect(ui.chkAutoEmpty, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
+	connect(ui.cmbAutoDeleteSnapshot, SIGNAL(currentIndexChanged(int)), this, SLOT(OnGeneralChanged()));
 
 	connect(ui.chkRawDiskRead, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
 	connect(ui.chkRawDiskNotify, SIGNAL(clicked(bool)), this, SLOT(OnGeneralChanged()));
@@ -438,6 +450,14 @@ void COptionsWindow::LoadGeneral()
 	else
 		ui.chkProtectBox->setCheckState(Qt::Unchecked);
 	ui.chkAutoEmpty->setChecked(m_pBox->GetBool("AutoDelete", false));
+	QString AutoDeleteSnapshotTarget = m_pBox->GetText("AutoDeleteSnapshotTarget", QString(), true, true, true);
+	if (AutoDeleteSnapshotTarget.compare("Current", Qt::CaseInsensitive) == 0)
+		AutoDeleteSnapshotTarget = "Current";
+	else if (AutoDeleteSnapshotTarget.compare("Default", Qt::CaseInsensitive) == 0)
+		AutoDeleteSnapshotTarget = "Default";
+	else
+		AutoDeleteSnapshotTarget = theConf->GetBool("Options/UseAsyncBoxOps", false) ? "Default" : "Current";
+	ui.cmbAutoDeleteSnapshot->setCurrentIndex(ui.cmbAutoDeleteSnapshot->findData(AutoDeleteSnapshotTarget));
 
 	ui.chkRawDiskRead->setChecked(m_pBox->GetBool("AllowRawDiskRead", false));
 	ui.chkRawDiskNotify->setChecked(m_pBox->GetBool("NotifyDirectDiskAccess", false));
@@ -599,6 +619,7 @@ void COptionsWindow::SaveGeneral()
 		m_pBox->DelValue("NeverRemove");
 	}
 	WriteAdvancedCheck(ui.chkAutoEmpty, "AutoDelete", "y", "");
+	WriteText("AutoDeleteSnapshotTarget", ui.cmbAutoDeleteSnapshot->currentData().toString());
 
 	WriteAdvancedCheck(ui.chkRawDiskRead, "AllowRawDiskRead", "y", "");
 	WriteAdvancedCheck(ui.chkRawDiskNotify, "NotifyDirectDiskAccess", "y", "");
@@ -932,6 +953,9 @@ void COptionsWindow::OnGeneralChanged()
 	ui.chkNoCopyWarn->setEnabled(ui.chkCopyLimit->isChecked() && !ui.chkCopyPrompt->isChecked());
 
 	ui.chkAutoEmpty->setEnabled(ui.chkProtectBox->checkState() != Qt::Checked);
+	ui.lblAutoDeleteSnapshot->setEnabled(ui.chkAutoEmpty->isEnabled() && ui.chkAutoEmpty->isChecked());
+	ui.cmbAutoDeleteSnapshot->setEnabled(ui.chkAutoEmpty->isEnabled() && ui.chkAutoEmpty->isChecked());
+	ui.btnAutoDeleteSnapshots->setEnabled(ui.cmbAutoDeleteSnapshot->isEnabled() && !m_pBox.objectCast<CSandBox>().isNull());
 
 	ui.chkOpenSpooler->setEnabled(!ui.chkBlockSpooler->isChecked() && !ui.chkNoSecurityIsolation->isChecked());
 	ui.chkPrintToFile->setEnabled(!ui.chkBlockSpooler->isChecked() && !ui.chkNoSecurityFiltering->isChecked());

--- a/SandboxiePlus/SandMan/Windows/SnapshotsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SnapshotsWindow.cpp
@@ -52,12 +52,14 @@ CSnapshotsWindow::CSnapshotsWindow(const CSandBoxPtr& pBox, QWidget *parent)
 	connect(ui.treeSnapshots, SIGNAL(doubleClicked(const QModelIndex&)), this, SLOT(OnSelectSnapshot()));
 
 	
+	ui.btnRefresh->setIcon(CSandMan::GetIcon("Refresh"));
 	QMenu* pSelMenu = new QMenu(ui.btnSelect);
 	pSelMenu->addAction(tr("Revert to empty box"), this, SLOT(OnSelectEmpty()));
 	ui.btnSelect->setPopupMode(QToolButton::MenuButtonPopup);
 	ui.btnSelect->setMenu(pSelMenu);
 
 	connect(ui.btnTake, SIGNAL(clicked(bool)), this, SLOT(OnTakeSnapshot()));
+	connect(ui.btnRefresh, &QPushButton::clicked, this, &CSnapshotsWindow::Refresh);
 	connect(ui.btnSelect, SIGNAL(clicked(bool)), this, SLOT(OnSelectSnapshot()));
 	connect(ui.btnRemove, SIGNAL(clicked(bool)), this, SLOT(OnRemoveSnapshot()));
 	
@@ -88,6 +90,12 @@ void CSnapshotsWindow::closeEvent(QCloseEvent *e)
 {
 	emit Closed();
 	this->deleteLater();
+}
+
+void CSnapshotsWindow::Refresh()
+{
+	OnSaveInfo();
+	UpdateSnapshots(true);
 }
 
 void CSnapshotsWindow::UpdateSnapshots(bool AndSelect)
@@ -127,10 +135,23 @@ void CSnapshotsWindow::UpdateSnapshots(bool AndSelect)
 
 	if (AndSelect)
 	{
+		QSignalBlocker Blocker(ui.treeSnapshots->selectionModel());
 		QModelIndex CurIndex = m_pSnapshotModel->FindIndex(m_CurSnapshot);
 		if (CurIndex.isValid()) {
-			ui.treeSnapshots->selectionModel()->select(CurIndex, QItemSelectionModel::ClearAndSelect);
+			ui.treeSnapshots->setCurrentIndex(CurIndex);
 			UpdateSnapshot(CurIndex);
+		}
+		else {
+			ui.treeSnapshots->clearSelection();
+			m_SelectedID.clear();
+			m_SaveInfoPending = -1;
+			ui.txtName->clear();
+			ui.chkDefault->setChecked(false);
+			ui.txtInfo->clear();
+			m_SaveInfoPending = 0;
+			ui.groupBox->setEnabled(false);
+			ui.btnSelect->setEnabled(false);
+			ui.btnRemove->setEnabled(false);
 		}
 	}
 }

--- a/SandboxiePlus/SandMan/Windows/SnapshotsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/SnapshotsWindow.h
@@ -12,6 +12,7 @@ class CSnapshotsWindow : public QDialog
 public:
 	CSnapshotsWindow(const CSandBoxPtr& pBox, QWidget *parent = Q_NULLPTR);
 	~CSnapshotsWindow();
+	void Refresh();
 
 	virtual void accept() {}
 	virtual void reject() { this->close(); }


### PR DESCRIPTION
Introduces `AutoDeleteSnapshotTarget` to choose whether sandbox auto-delete restores the active or default snapshot, and applies it consistently in both synchronous and asynchronous cleanup paths.

SandMan now exposes this in box options, adds quick access to Snapshot Manager, and adds refresh behavior/UI updates in the snapshots window to keep snapshot state current.