### PR TITLE
Format embedded box names in SandMan messages

### DIFF
--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -3476,6 +3476,27 @@ QString CSandMan::FormatSbieMessage(quint32 MsgCode, const QStringList& MsgData,
 		return Value.left(OpenBracket + 2) + DisplayName + Value.mid(CloseBracket);
 	};
 
+	auto FormatBracketedBoxWithValue = [&](const QString& Value) {
+		const int OpenBracket = Value.lastIndexOf(" [");
+		if (OpenBracket <= 0)
+			return Value;
+
+		const int ValueSeparator = Value.indexOf(" /", OpenBracket + 2);
+		if (ValueSeparator <= OpenBracket + 2)
+			return Value;
+
+		const int CloseBracket = Value.indexOf(']', ValueSeparator + 2);
+		if (CloseBracket < 0 || !Value.mid(CloseBracket + 1).isEmpty())
+			return Value;
+
+		const QString BoxName = Value.mid(OpenBracket + 2, ValueSeparator - OpenBracket - 2);
+		QString DisplayName;
+		if (!ResolveBoxDisplayName(BoxName, DisplayName))
+			return Value;
+
+		return Value.left(OpenBracket + 2) + DisplayName + Value.mid(ValueSeparator);
+	};
+
 	auto FormatLeadingBox = [&](const QString& Value, const QString& Separator) {
 		const int SeparatorPos = Value.indexOf(Separator);
 		if (SeparatorPos <= 0)
@@ -3509,6 +3530,12 @@ QString CSandMan::FormatSbieMessage(quint32 MsgCode, const QStringList& MsgData,
 			case 1308:
 			case 1313:
 				Value = FormatBracketedBox(Value, ImageSuffix);
+				break;
+			case 2102:
+			case 2113:
+			case 2114:
+			case 2115:
+				Value = FormatBracketedBoxWithValue(Value);
 				break;
 			case 2103:
 				Value = FormatBracketedBox(Value, ServiceSuffix);

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -3440,6 +3440,55 @@ void CSandMan::OnMessageLogDblClick(QTreeWidgetItem* pItem, int Column)
 QString CSandMan::FormatSbieMessage(quint32 MsgCode, const QStringList& MsgData, QString ProcessName, QString* pLink)
 {
 	QString Message;
+	const quint32 MessageId = MsgCode & 0xFFFF;
+
+	auto ResolveBoxDisplayName = [this](const QString& BoxName, QString& DisplayName) {
+		CSandBoxPtr pBox = theAPI->GetBoxByName(BoxName);
+		if (!pBox)
+			return false;
+
+		DisplayName = GetBoxDisplayName(pBox);
+		return true;
+	};
+
+	const QStringList NoSuffix = QStringList() << "";
+	const QStringList ImageSuffix = QStringList() << "" << " *";
+	const QStringList ServiceSuffix = QStringList() << " (NtLoadDriver)" << " (StartService)";
+
+	auto FormatBracketedBox = [&](const QString& Value, const QStringList& AllowedSuffixes) {
+		const int OpenBracket = Value.lastIndexOf(" [");
+		if (OpenBracket <= 0)
+			return Value;
+
+		const int CloseBracket = Value.indexOf(']', OpenBracket + 2);
+		if (CloseBracket < 0)
+			return Value;
+
+		const QString Suffix = Value.mid(CloseBracket + 1);
+		if (!AllowedSuffixes.contains(Suffix))
+			return Value;
+
+		const QString BoxName = Value.mid(OpenBracket + 2, CloseBracket - OpenBracket - 2);
+		QString DisplayName;
+		if (!ResolveBoxDisplayName(BoxName, DisplayName))
+			return Value;
+
+		return Value.left(OpenBracket + 2) + DisplayName + Value.mid(CloseBracket);
+	};
+
+	auto FormatLeadingBox = [&](const QString& Value, const QString& Separator) {
+		const int SeparatorPos = Value.indexOf(Separator);
+		if (SeparatorPos <= 0)
+			return Value;
+
+		const QString BoxName = Value.left(SeparatorPos);
+		QString DisplayName;
+		if (!ResolveBoxDisplayName(BoxName, DisplayName))
+			return Value;
+
+		return DisplayName + Value.mid(SeparatorPos);
+	};
+
 	if (MsgCode != 0) {
 		Message = theAPI->GetSbieMsgStr(MsgCode, m_LanguageId);
 		if (pLink) {
@@ -3452,7 +3501,36 @@ QString CSandMan::FormatSbieMessage(quint32 MsgCode, const QStringList& MsgData,
 		Message = MsgData[0];
 
 	for (int i = 1; i < MsgData.size(); i++) {
-		Message = Message.arg(GetBoxDisplayName(MsgData[i]));
+		QString Value = MsgData[i];
+		if (i == 1) {
+			// These messages embed BoxName in their first formatted argument.
+			switch (MessageId) {
+			case 1307:
+			case 1308:
+			case 1313:
+				Value = FormatBracketedBox(Value, ImageSuffix);
+				break;
+			case 2103:
+				Value = FormatBracketedBox(Value, ServiceSuffix);
+				break;
+			case 2104:
+			case 2219:
+			case 2224:
+				Value = FormatBracketedBox(Value, NoSuffix);
+				break;
+			case 2227:
+				Value = FormatLeadingBox(Value, " (");
+				break;
+			case 2230:
+				Value = FormatLeadingBox(Value, " [");
+				break;
+			default:
+				break;
+			}
+		}
+		if (Value == MsgData[i])
+			Value = GetBoxDisplayName(Value);
+		Message = Message.arg(Value);
 	}
 
 	if (ProcessName != "System") // if it's not from the driver, add the pid

--- a/SandboxiePlus/SandMan/Windows/PopUpWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/PopUpWindow.cpp
@@ -495,7 +495,7 @@ void CPopUpWindow::AddUserPrompt(quint32 RequestId, const QVariantMap& Data, qui
 	{
 	case CSbieAPI::eFileMigration:
 		Message = tr("Do you want to allow %4 (%5) to copy a %1 large file into sandbox: %2?\nFile name: %3")
-			.arg(FormatSize(Data["fileSize"].toULongLong())).arg(pProcess->GetBoxName())
+			.arg(FormatSize(Data["fileSize"].toULongLong())).arg(CSandMan::GetBoxDisplayName(pProcess->GetBoxName()))
 			.arg(Data["fileName"].toString())
 			.arg(pProcess->GetProcessName()).arg(pProcess->GetProcessId());
 		break;


### PR DESCRIPTION
Improves #5522

Improve `FormatSbieMessage` to correctly resolve and display sandbox display names when message arguments contain embedded box identifiers (e.g., bracketed or leading box names with known suffix patterns). The change adds message-ID-specific parsing for affected events so log messages show user-friendly box names instead of raw box names.