### PR TITLE
Fix duplicate separators in the Sandbox menu

### DIFF
--- a/Sandboxie/apps/control/MyFrame.cpp
+++ b/Sandboxie/apps/control/MyFrame.cpp
@@ -1728,6 +1728,11 @@ void CMyFrame::InitSandboxMenu1(
             }
         }
 
+        if (!ChildMenu.GetSafeHmenu()) {
+            order_entry = order_entry->next;
+            continue;
+        }
+
         if (MenuIndex <= 36) {
             title += L"\t          &";
             if (MenuIndex >= 1 && MenuIndex <= 10)


### PR DESCRIPTION
Avoids inserting entries without a valid submenu in Sandboxie Control, preventing blank separators from accumulating while the cached box list is out of date. Fixes #913.