### PR TITLE
Update Traditional Chinese translations for v1.18.4

### DIFF
--- a/SandboxiePlus/SandMan/sandman_zh_TW.ts
+++ b/SandboxiePlus/SandMan/sandman_zh_TW.ts
@@ -1435,17 +1435,17 @@ You can click Finish to close this wizard.</source>
     <message>
         <location filename="Windows/EditorSettingsWindow.cpp" line="46"/>
         <source>Show Future Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>顯示未來版本設定</translation>
     </message>
     <message>
         <location filename="Windows/EditorSettingsWindow.cpp" line="47"/>
         <source>Hidden</source>
-        <translation type="unfinished"></translation>
+        <translation>隱藏</translation>
     </message>
     <message>
         <location filename="Windows/EditorSettingsWindow.cpp" line="47"/>
         <source>Shown (default)</source>
-        <translation type="unfinished"></translation>
+        <translation>顯示（預設）</translation>
     </message>
     <message>
         <location filename="Windows/EditorSettingsWindow.cpp" line="58"/>
@@ -7183,12 +7183,12 @@ This is a temporary Patreon certificate, valid for 3 months. Once it nears expir
         <location filename="Windows/SettingsWindow.cpp" line="3342"/>
         <location filename="Windows/SettingsWindow.cpp" line="3343"/>
         <source>Disabled</source>
-        <translation>啟用</translation>
+        <translation>停用</translation>
     </message>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="324"/>
         <source>Arabic (Morocco) - LTR</source>
-        <translation type="unfinished"></translation>
+        <translation>阿拉伯文（摩洛哥，從左至右）</translation>
     </message>
     <message>
         <location filename="Windows/SettingsWindow.cpp" line="588"/>

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -13,7 +13,7 @@ To achieve this goal, Sandboxie has established a translation program that enabl
 |Arabic|Yes|Yes - Nov 21, 2024|No|No|
 |Bulgarian|Yes|No|No|No|
 |Chinese Simplified|Yes - Nov 22, 2024|Yes - Aug 30, 2026|Yes - Aug 23, 2026|Yes - 2025|
-|Chinese Traditional|Yes - Aug 13, 2026|Yes - Aug 31, 2026|Yes - Aug 23, 2026|Yes - Aug 23, 2026|
+|Chinese Traditional|Yes - Aug 13, 2026|Yes - Sep 4, 2026|Yes - Aug 23, 2026|Yes - Aug 23, 2026|
 |Croatian|Yes|No|No|No|
 |Czech|Yes|No|No|No|
 |Danish|Yes|No|No|No|


### PR DESCRIPTION
Translates the new editor settings strings, corrects an existing mistranslation of Disabled, and updates the Traditional Chinese status date.