### PR TITLE
SandMan: add native proxy profiles and experimental tunnel manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.18.4 / 5.73.4] - 2026-09-??
 
 ### Added
+- added a native proxy profile/tunnel review prototype in SandMan; tunnel activation remains disabled pending Windows routing and failure qualification
 - added low-noise `SbieTrace` logging for `Shell_NotifyIconW` calls, including the message, icon identity (`NIF_GUID`/GUID or `HWND`/`uID`), and effective direct/proxy route
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 
 ### Fixed
+- preserved unavailable adapter bindings when saving unrelated network options
+- propagated socket bind errors before proceeding with a bound connection
 - fixed stale INI completion-popup candidate tooltips during editing and limited `Template`/`TemplateReject` tooltips to setting-name text
 - fixed SandMan File Panel "Create Shortcut" producing a shortcut without a working directory, so the sandboxed program inherited SandMan's current directory and applications that open their data files by relative path failed to find them [#5542](https://github.com/sandboxie-plus/Sandboxie/issues/5542)
 - fixed wrong return type ein sbiesvc

--- a/Sandboxie/core/dll/net.c
+++ b/Sandboxie/core/dll/net.c
@@ -812,6 +812,7 @@ _FX int WSA_bind(
     int            namelen)
 {
     BOOLEAN new_name = WSA_HandleAfUnix(&name, &namelen);
+    BOOLEAN forced_bind = FALSE;
 
     if (WSA_BindIP) {
         const SOCKADDR* sa = (const SOCKADDR*)name;
@@ -898,7 +899,7 @@ _FX int WSA_bind(
                     ((BYTE*)&WSA_BindIP4.sin_addr)[0], ((BYTE*)&WSA_BindIP4.sin_addr)[1],
                     ((BYTE*)&WSA_BindIP4.sin_addr)[2], ((BYTE*)&WSA_BindIP4.sin_addr)[3]);
                 memcpy(&addr_in->sin_addr, &WSA_BindIP4.sin_addr, sizeof(WSA_BindIP4.sin_addr));
-                WSA_GetSock(s, TRUE)->Bound = TRUE;
+                forced_bind = TRUE;
             }
         }
         else if (namelen >= sizeof(SOCKADDR_IN6_LH) && name && ((short*)name)[0] == AF_INET6) {
@@ -944,12 +945,15 @@ _FX int WSA_bind(
                     orig[0],orig[1],orig[2],orig[3],orig[4],orig[5],orig[6],orig[7],orig[8],orig[9],orig[10],orig[11],orig[12],orig[13],orig[14],orig[15],
                     repl[0],repl[1],repl[2],repl[3],repl[4],repl[5],repl[6],repl[7],repl[8],repl[9],repl[10],repl[11],repl[12],repl[13],repl[14],repl[15]);
                 memcpy(&addr6_in->sin6_addr, &WSA_BindIP6.sin6_addr, sizeof(WSA_BindIP6.sin6_addr));
-                WSA_GetSock(s, TRUE)->Bound = TRUE;
+                forced_bind = TRUE;
             }
         }
     }
 
     int ret = __sys_bind(s, name, namelen);
+
+    if (ret != SOCKET_ERROR && forced_bind)
+        WSA_GetSock(s, TRUE)->Bound = TRUE;
 
     if (new_name) Dll_Free((void*)name);
 

--- a/Sandboxie/core/dll/net.c
+++ b/Sandboxie/core/dll/net.c
@@ -1001,7 +1001,8 @@ _FX int WSA_bind_ip(
         }
         // Double-check the structure is valid before binding
         if (WSA_BindIP4.sin_family == AF_INET) {
-            __sys_bind(s, &WSA_BindIP4, sizeof(WSA_BindIP4));
+            if (__sys_bind(s, &WSA_BindIP4, sizeof(WSA_BindIP4)) == SOCKET_ERROR)
+                return -1; // Preserve the bind error; never continue with an unbound socket.
             pSock->Bound = TRUE;
         }
     }
@@ -1025,7 +1026,8 @@ _FX int WSA_bind_ip(
         }
         // Double-check the structure is valid before binding
         if (WSA_BindIP6.sin6_family == AF_INET6) {
-            __sys_bind(s, &WSA_BindIP6, sizeof(WSA_BindIP6));
+            if (__sys_bind(s, &WSA_BindIP6, sizeof(WSA_BindIP6)) == SOCKET_ERROR)
+                return -1; // Preserve the bind error; never continue with an unbound socket.
             pSock->Bound = TRUE;
         }
     }

--- a/Sandboxie/install/Templates.ini
+++ b/Sandboxie/install/Templates.ini
@@ -4109,6 +4109,16 @@ Tmpl.Class=Misc
 #BlockPort=137,138,139,445
 NetworkAccess=*,Block;Port=137,138,139,445
 
+[Template_ProxyTunnelGuard]
+Tmpl.Title=Managed proxy tunnel (experimental IPv4 TCP only)
+Tmpl.Class=Network
+StrictBindIP=y
+NetworkDnsFilter=*
+ClosedIpcPath=\RPC Control\DNSResolver
+NetworkAccess=*,Block;Protocol=UDP
+NetworkAccess=*,Block;Protocol=ICMP
+NetworkAccess=*,Block;Port=53
+
 [Template_BlockDNS]
 Tmpl.Title=Block DNS
 Tmpl.Class=Misc

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.cpp
@@ -134,8 +134,11 @@ QString CProxyIntegration::ModificationError(const QString& Id) const
 
 bool CProxyIntegration::Assign(const QString& BoxName, const QString& Id, QString& Error)
 {
-	Error = ActivationError();
-	if (!Error.isEmpty()) return false;
+	if (!theAPI || !theAPI->IsConnected()) { Error = CProxyWindow::tr("Sandboxie is not connected."); return false; }
+	if (!Id.isEmpty()) {
+		Error = ActivationError();
+		if (!Error.isEmpty()) return false;
+	}
 	const auto Box = theAPI->GetBoxByName(BoxName);
 	if (!Box) { Error = CProxyWindow::tr("The sandbox no longer exists."); return false; }
 	if (Box->GetActiveProcessCount() != 0) { Error = CProxyWindow::tr("Stop all sandbox processes before changing its network association."); return false; }
@@ -145,8 +148,11 @@ bool CProxyIntegration::Assign(const QString& BoxName, const QString& Id, QStrin
 		Error = CProxyWindow::tr("Existing adapter bindings must be reviewed in sandbox options; they were not overwritten."); return false;
 	}
 	if (Id.isEmpty()) {
-		if (Bindings.isEmpty()) return true;
-		if (Box->DelValue("BindAdapter", Bindings.first()).IsError()) { Error = CProxyWindow::tr("Cannot remove the managed binding. Check Sandboxie configuration permissions."); return false; }
+		if (!Bindings.isEmpty() && Box->DelValue("BindAdapter", Bindings.first()).IsError()) { Error = CProxyWindow::tr("Cannot remove the managed binding. Check Sandboxie configuration permissions."); return false; }
+		if (!Box->GetTemplates().contains(Guard)) return true;
+		if (!Box->GetTextList("Template", false).contains(Guard)) {
+			Error = CProxyWindow::tr("The managed binding was removed, but the restrictive guard is inherited and was left unchanged."); return false;
+		}
 		if (Box->DelValue("Template", Guard).IsError()) { Error = CProxyWindow::tr("The binding was removed, but the restrictive guard remains. Review sandbox options."); return false; }
 		return true;
 	}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.cpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#include "stdafx.h"
+#include "ProxyIntegration.h"
+#include "ProxyWindow.h"
+#include "SandMan.h"
+#include "Helpers/WinAdmin.h"
+#include "AddonManager.h"
+#include "Windows/SettingsWindow.h"
+#include <QCoreApplication>
+#include <QDir>
+#include <QSet>
+#include <QUuid>
+
+namespace
+{
+	const QString Guard = QStringLiteral("ProxyTunnelGuard");
+	QString ProfileId(QString Binding)
+	{
+		Binding = Binding.section(',', -1).trimmed();
+		if (!Binding.startsWith("SbieProxy-", Qt::CaseInsensitive)) return QString();
+		const QUuid Id(Binding.mid(10));
+		return Id.isNull() ? QString() : Id.toString(QUuid::WithoutBraces);
+	}
+	QString PolicyError(const CSandBoxPtr& Box)
+	{
+		if (Box->GetBool("NoSecurityIsolation", false, true, true) || Box->GetBool("NoSecurityFiltering", false, true, true))
+			return CProxyWindow::tr("Security-isolation bypass settings are incompatible with managed tunnels.");
+		const auto Bindings = Box->GetTextList("BindAdapter", true, false, true);
+		if (Bindings.size() != 1 || Bindings.first().contains(',') || ProfileId(Bindings.first()).isEmpty()
+			|| !Box->GetTextList("BindAdapterIP", true, false, true).isEmpty()
+			|| !Box->GetTextList("NetworkUseProxy", true, false, true).isEmpty())
+			return CProxyWindow::tr("The managed binding conflicts with another network binding or proxy setting.");
+		if (!Box->GetTemplates().contains(Guard)) return CProxyWindow::tr("The managed tunnel guard template is missing.");
+		const auto Strict = Box->GetTextList("StrictBindIP", true, false, true);
+		for (const auto& Value : Strict) if (Value.compare("y", Qt::CaseInsensitive) != 0)
+			return CProxyWindow::tr("Strict binding has an incompatible override.");
+		if (Strict.isEmpty() || Box->GetTextList("NetworkDnsFilter", true, false, true) != QStringList{"*"})
+			return CProxyWindow::tr("The DNS/binding guard is missing or overridden.");
+		QStringList Rules = Box->GetTextList("NetworkAccess", true, false, true);
+		QStringList Expected{"*,Block;Protocol=UDP", "*,Block;Protocol=ICMP", "*,Block;Port=53"};
+		Rules.sort(); Expected.sort();
+		if (Rules != Expected || !Box->GetTextList("ClosedIpcPath", true, false, true).contains("\\RPC Control\\DNSResolver"))
+			return CProxyWindow::tr("The managed network restrictions changed. Review the sandbox settings.");
+		return QString();
+	}
+}
+
+CProxyIntegration::CProxyIntegration(CSandMan* Gui) : QObject(Gui), m_Gui(Gui), m_Manager(nullptr)
+{
+	SProxyHooks Hooks;
+	Hooks.ActivationError = [this]() { return ActivationError(); };
+	Hooks.Boxes = [this]() { return Boxes(); };
+	Hooks.ModificationError = [this](const QString& Id) { return ModificationError(Id); };
+	Hooks.Assign = [this](const QString& Box, const QString& Id, QString& Error) { return Assign(Box, Id, Error); };
+	Hooks.DependencyDirectory = []() { return QDir(QCoreApplication::applicationDirPath()).filePath("Addons/ProxyTunnels"); };
+	Hooks.InstallDependencies = [this](QString& Error) {
+		auto Addons = m_Gui->GetAddonManager();
+		Addons->GetAddons();
+		if (!Addons->GetAddon("ProxyTunnels", CAddonManager::eAny)) {
+			Error = CProxyWindow::tr("The ProxyTunnels package is not present in the official add-on catalog. No executable was downloaded. Maintainer packaging approval is pending.");
+			return false;
+		}
+		const auto Status = Addons->TryInstallAddon("ProxyTunnels", m_Gui);
+		if (Status.IsError()) { Error = CProxyWindow::tr("Dependency installation was cancelled or failed. See the existing add-on progress/error dialog."); return false; }
+		return true;
+	};
+	Hooks.Log = [this](const QString& Message) { m_Gui->OnLogMessage(Message); };
+	m_Manager = new CProxyManager(QDir(theConf->GetConfigDir()).filePath("ProxyProfiles.json"), std::move(Hooks), this);
+}
+
+CProxyIntegration::~CProxyIntegration()
+{
+	delete m_Window.data();
+	delete m_Manager; // Stop and join owned workers before SandMan releases the API.
+}
+
+void CProxyIntegration::Show()
+{
+	if (!m_Window) m_Window = new CProxyWindow(m_Manager, m_Gui);
+	m_Window->show(); m_Window->raise(); m_Window->activateWindow();
+}
+
+QString CProxyIntegration::ActivationError() const
+{
+#ifndef SBIE_PROXY_TUNNELS_LAB
+	return CProxyWindow::tr("This review prototype does not enable tunnels or change sandbox bindings. Windows routing, ownership, DNS, and fail-closed qualification are still pending.");
+#else
+	if (!theAPI || !theAPI->IsConnected()) return CProxyWindow::tr("Sandboxie is not connected.");
+	if (!IsElevated()) return CProxyWindow::tr("Adapter setup requires an administrator. Restart SandMan using its existing elevation command.");
+	if (!g_CertInfo.active || !g_CertInfo.opt_net) return CProxyWindow::tr("The existing advanced-network certificate requirement is not satisfied.");
+	if (!m_Gui->IsWFPEnabled()) return CProxyWindow::tr("Windows Filtering Platform must already be enabled. The tunnel manager will not change this setting.");
+	for (const auto& Box : theAPI->GetAllBoxes()) {
+		bool Managed = false;
+		for (const auto& Binding : Box->GetTextList("BindAdapter", true, false, true)) Managed |= !ProfileId(Binding).isEmpty();
+		if (Managed) { const QString Error = PolicyError(Box); if (!Error.isEmpty()) return Error; }
+	}
+	return QString();
+#endif
+}
+
+QList<SProxyBox> CProxyIntegration::Boxes() const
+{
+	QList<SProxyBox> Result;
+	if (!theAPI || !theAPI->IsConnected()) return Result;
+	for (const auto& Box : theAPI->GetAllBoxes()) {
+		QSet<QString> Seen;
+		const auto Bindings = Box->GetTextList("BindAdapter", true, false, true);
+		for (const auto& Binding : Bindings) {
+			const QString Id = ProfileId(Binding);
+			if (Id.isEmpty() || Seen.contains(Id)) continue;
+			Seen.insert(Id);
+			QString Detail = PolicyError(Box);
+			if (Detail.isEmpty()) Detail = CProxyWindow::tr("Saved binding; tunnel runtime is shown above.");
+			Result.append({Box->GetName(), Id, Detail});
+		}
+		if (Seen.isEmpty()) Result.append({Box->GetName(), QString(), Bindings.isEmpty()
+			? CProxyWindow::tr("No managed association.") : CProxyWindow::tr("An unmanaged adapter binding is configured.")});
+	}
+	return Result;
+}
+
+QString CProxyIntegration::ModificationError(const QString& Id) const
+{
+	if (!theAPI || !theAPI->IsConnected()) return CProxyWindow::tr("Connect to Sandboxie to check all profile references before changing this profile.");
+	for (const auto& Box : theAPI->GetAllBoxes()) {
+		for (const auto& Binding : Box->GetTextList("BindAdapter", true, false, true)) {
+			if (ProfileId(Binding) == Id && Box->GetActiveProcessCount() != 0)
+				return CProxyWindow::tr("Stop every process in the associated sandboxes before editing the profile.");
+		}
+	}
+	return QString();
+}
+
+bool CProxyIntegration::Assign(const QString& BoxName, const QString& Id, QString& Error)
+{
+	Error = ActivationError();
+	if (!Error.isEmpty()) return false;
+	const auto Box = theAPI->GetBoxByName(BoxName);
+	if (!Box) { Error = CProxyWindow::tr("The sandbox no longer exists."); return false; }
+	if (Box->GetActiveProcessCount() != 0) { Error = CProxyWindow::tr("Stop all sandbox processes before changing its network association."); return false; }
+	const auto Bindings = Box->GetTextList("BindAdapter", true, false, true);
+	const auto LocalBindings = Box->GetTextList("BindAdapter", false);
+	if (Bindings != LocalBindings || Bindings.size() > 1 || (!Bindings.isEmpty() && ProfileId(Bindings.first()).isEmpty())) {
+		Error = CProxyWindow::tr("Existing adapter bindings must be reviewed in sandbox options; they were not overwritten."); return false;
+	}
+	if (Id.isEmpty()) {
+		if (Bindings.isEmpty()) return true;
+		if (Box->DelValue("BindAdapter", Bindings.first()).IsError()) { Error = CProxyWindow::tr("Cannot remove the managed binding. Check Sandboxie configuration permissions."); return false; }
+		if (Box->DelValue("Template", Guard).IsError()) { Error = CProxyWindow::tr("The binding was removed, but the restrictive guard remains. Review sandbox options."); return false; }
+		return true;
+	}
+	if (Box->GetBool("NoSecurityIsolation", false, true, true) || Box->GetBool("NoSecurityFiltering", false, true, true)) {
+		Error = CProxyWindow::tr("The sandbox disables security isolation or filtering."); return false;
+	}
+	if (!Box->GetTextList("BindAdapterIP", true, false, true).isEmpty() || !Box->GetTextList("NetworkUseProxy", true, false, true).isEmpty()) {
+		Error = CProxyWindow::tr("Remove conflicting direct-IP bindings or built-in proxy rules before associating a managed tunnel."); return false;
+	}
+	if (!Box->GetTemplates().contains(Guard)) {
+		if (!Box->GetTextList("NetworkAccess", true, false, true).isEmpty() || !Box->GetTextList("NetworkDnsFilter", true, false, true).isEmpty()
+			|| !Box->GetTextList("StrictBindIP", true, false, true).isEmpty()) {
+			Error = CProxyWindow::tr("Existing network restrictions or overrides need manual review; no rules were replaced."); return false;
+		}
+		if (Box->AppendText("Template", Guard).IsError()) { Error = CProxyWindow::tr("Cannot add the tunnel guard template. Check Sandboxie configuration permissions."); return false; }
+	}
+	// The guard is applied first. Failed writes leave restrictive settings, not a silent direct fallback.
+	if (Box->SetText("BindAdapter", QStringLiteral("SbieProxy-") + Id).IsError()) {
+		Error = CProxyWindow::tr("Cannot save the tunnel binding. The guard may remain active; review sandbox options."); return false;
+	}
+	Error = PolicyError(Box);
+	return Error.isEmpty();
+}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.cpp
@@ -84,7 +84,7 @@ void CProxyIntegration::Show()
 QString CProxyIntegration::ActivationError() const
 {
 #ifndef SBIE_PROXY_TUNNELS_LAB
-	return CProxyWindow::tr("This review prototype does not enable tunnels or change sandbox bindings. Windows routing, ownership, DNS, and fail-closed qualification are still pending.");
+	return CProxyWindow::tr("This review prototype cannot start tunnels or create sandbox bindings. A stopped sandbox may detach a local managed binding to recover its configuration. Windows routing, ownership, DNS, and fail-closed qualification are still pending.");
 #else
 	if (!theAPI || !theAPI->IsConnected()) return CProxyWindow::tr("Sandboxie is not connected.");
 	if (!IsElevated()) return CProxyWindow::tr("Adapter setup requires an administrator. Restart SandMan using its existing elevation command.");

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.h
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyIntegration.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#pragma once
+#include <QObject>
+#include <QPointer>
+#include "ProxyManager.h"
+class CSandMan;
+class CProxyWindow;
+
+class CProxyIntegration : public QObject
+{
+public:
+	explicit CProxyIntegration(CSandMan* Gui);
+	~CProxyIntegration() override;
+	void Show();
+private:
+	QString ActivationError() const;
+	QList<SProxyBox> Boxes() const;
+	QString ModificationError(const QString& Id) const;
+	bool Assign(const QString& BoxName, const QString& Id, QString& Error);
+	CSandMan* m_Gui;
+	CProxyManager* m_Manager;
+	QPointer<CProxyWindow> m_Window;
+};

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyManager.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyManager.cpp
@@ -114,8 +114,10 @@ bool CProxyManager::Remove(const QString& Id, QString& Error)
 
 bool CProxyManager::Assign(const QString& Box, const QString& Id, QString& Error)
 {
-	Error = ActivationError();
-	if (!Error.isEmpty()) return false;
+	if (!Id.isEmpty()) {
+		Error = ActivationError();
+		if (!Error.isEmpty()) return false;
+	}
 	if (!Id.isEmpty() && Find(Id) < 0) { Error = tr("The profile no longer exists."); return false; }
 	if (!m_Hooks.Assign) { Error = tr("Sandbox association is unavailable."); return false; }
 	if (!m_Hooks.Assign(Box, Id, Error)) return false;

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyManager.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyManager.cpp
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#ifdef PROXY_TUNNELS_STANDALONE
+#include <QtCore>
+#else
+#include "stdafx.h"
+#endif
+#include "ProxyManager.h"
+
+CProxyManager::CProxyManager(const QString& Path, SProxyHooks Hooks, QObject* Parent, TFactory Factory)
+	: QObject(Parent), m_Path(Path), m_Hooks(std::move(Hooks)), m_Factory(std::move(Factory))
+{
+	m_Lock.reset(new QLockFile(Path + QStringLiteral(".lock")));
+	m_Lock->setStaleLockTime(0);
+	if (!m_Lock->tryLock(0)) m_StorageError = tr("Another manager owns this profile store, or the store is not writable.");
+	QString Error;
+	if (!ProxyProfiles::Load(Path, m_Profiles, Error)) m_StorageError = Error;
+	if (!m_Factory) m_Factory = [](const SProxyProfile& Profile, const QString& Directory, QObject* Parent) {
+		return new CProxyTunnel(Profile, Directory, Parent);
+	};
+	connect(&m_Timer, &QTimer::timeout, this, &CProxyManager::Revalidate);
+	m_Timer.start(1000);
+}
+
+CProxyManager::~CProxyManager()
+{
+	m_Timer.stop();
+	const auto Workers = m_Workers;
+	for (auto Worker : Workers) { Worker->disconnect(this); Worker->RequestStop(); }
+	for (auto Worker : Workers) { Worker->wait(); delete Worker; }
+	m_Workers.clear();
+}
+
+int CProxyManager::Find(const QString& Id) const
+{
+	for (int i = 0; i < m_Profiles.size(); ++i) if (m_Profiles[i].Id == Id) return i;
+	return -1;
+}
+
+QList<SProxyBox> CProxyManager::Boxes() const { return m_Hooks.Boxes ? m_Hooks.Boxes() : QList<SProxyBox>(); }
+
+QStringList CProxyManager::Users(const QString& Id) const
+{
+	QStringList Names;
+	for (const SProxyBox& Box : Boxes()) if (Box.ProfileId == Id) Names.append(Box.Name);
+	return Names;
+}
+
+QString CProxyManager::ActivationError() const
+{
+	if (!m_StorageError.isEmpty()) return m_StorageError;
+	return m_Hooks.ActivationError ? m_Hooks.ActivationError() : tr("No sandbox policy integration is available.");
+}
+
+bool CProxyManager::Persist(const QList<SProxyProfile>& Profiles, QString& Error)
+{
+	if (!m_StorageError.isEmpty()) { Error = m_StorageError; return false; }
+	if (!ProxyProfiles::Save(m_Path, Profiles, Error)) return false;
+	m_Profiles = Profiles;
+	emit Changed();
+	return true;
+}
+
+bool CProxyManager::SaveProfile(const SProxyInput& Input, QString& Id, QString& Error)
+{
+	QList<SProxyProfile> Updated = m_Profiles;
+	int Index = Find(Id);
+	if (!Id.isEmpty() && Index < 0) { Error = tr("The profile no longer exists."); return false; }
+	if (m_Workers.contains(Id)) { Error = tr("Stop the tunnel before editing this profile."); return false; }
+	if (!Id.isEmpty() && m_Hooks.ModificationError) {
+		Error = m_Hooks.ModificationError(Id);
+		if (!Error.isEmpty()) return false;
+	}
+	SProxyProfile Profile = Index < 0 ? SProxyProfile() : Updated[Index];
+	if (!ProxyProfiles::Protect(Input, Profile, Error)) return false;
+	if (Index < 0) Updated.append(Profile); else Updated[Index] = Profile;
+	if (!Persist(Updated, Error)) return false;
+	Id = Profile.Id;
+	return true;
+}
+
+bool CProxyManager::Import(const QString& Text, QList<SProxyImportError>& Errors, int& Added, QString& Error)
+{
+	Added = 0;
+	const auto Inputs = ProxyProfiles::ParseList(Text, Errors);
+	if (Inputs.isEmpty()) { Error = tr("No valid proxy entries were found."); return false; }
+	QList<SProxyProfile> Updated = m_Profiles;
+	for (const auto& Input : Inputs) {
+		SProxyProfile Profile;
+		if (!ProxyProfiles::Protect(Input, Profile, Error)) return false;
+		Updated.append(Profile);
+	}
+	if (!Persist(Updated, Error)) return false;
+	Added = Inputs.size();
+	return true;
+}
+
+bool CProxyManager::Remove(const QString& Id, QString& Error)
+{
+	const int Index = Find(Id);
+	if (Index < 0) { Error = tr("The profile no longer exists."); return false; }
+	if (m_Workers.contains(Id)) { Error = tr("Stop the tunnel before removing this profile."); return false; }
+	if (!Users(Id).isEmpty()) { Error = tr("Detach all sandbox references before removing this profile."); return false; }
+	if (m_Hooks.ModificationError) {
+		Error = m_Hooks.ModificationError(Id);
+		if (!Error.isEmpty()) return false;
+	}
+	QList<SProxyProfile> Updated = m_Profiles;
+	Updated.removeAt(Index);
+	if (!Persist(Updated, Error)) return false;
+	m_Runtime.remove(Id);
+	return true;
+}
+
+bool CProxyManager::Assign(const QString& Box, const QString& Id, QString& Error)
+{
+	Error = ActivationError();
+	if (!Error.isEmpty()) return false;
+	if (!Id.isEmpty() && Find(Id) < 0) { Error = tr("The profile no longer exists."); return false; }
+	if (!m_Hooks.Assign) { Error = tr("Sandbox association is unavailable."); return false; }
+	if (!m_Hooks.Assign(Box, Id, Error)) return false;
+	emit Changed();
+	return true;
+}
+
+void CProxyManager::SetState(const QString& Id, int State, const QString& Detail)
+{
+	auto& Runtime = m_Runtime[Id];
+	Runtime.State = State;
+	Runtime.Detail = Detail;
+	if (State == CProxyTunnel::Starting || State == CProxyTunnel::Stopped || State == CProxyTunnel::Failed) {
+		Runtime.Egress.clear();
+		Runtime.CheckedAt = QDateTime();
+	}
+	if (m_Hooks.Log) m_Hooks.Log(tr("Proxy tunnel [%1]: %2").arg(Id, Detail));
+	emit Changed();
+}
+
+bool CProxyManager::Start(const QString& Id, QString& Error)
+{
+	Error = ActivationError();
+	if (!Error.isEmpty()) return false;
+	const int Index = Find(Id);
+	if (Index < 0) { Error = tr("The profile no longer exists."); return false; }
+	if (m_Workers.contains(Id)) { Error = tr("This tunnel is already starting, running, or stopping."); return false; }
+	if (m_Workers.size() >= 16) { Error = tr("This prototype supports at most 16 simultaneous tunnels."); return false; }
+	const QString Directory = m_Hooks.DependencyDirectory ? m_Hooks.DependencyDirectory() : QString();
+	CProxyTunnel* Worker = m_Factory(m_Profiles[Index], Directory, this);
+	if (!Worker) { Error = tr("Cannot allocate the tunnel worker."); return false; }
+	m_Workers.insert(Id, Worker);
+	SetState(Id, CProxyTunnel::Starting, tr("Starting the owned tunnel worker."));
+	connect(Worker, &CProxyTunnel::StateChanged, this, [this, Worker, Id](const QString&, int State, const QString& Detail) {
+		if (m_Workers.value(Id) != Worker) return;
+		// Do not turn a cancelled startup back into a green status.
+		if (m_Runtime.value(Id).State == CProxyTunnel::Stopping && State != CProxyTunnel::Stopped && State != CProxyTunnel::Failed) return;
+		SetState(Id, State, Detail);
+	});
+	connect(Worker, &CProxyTunnel::EgressChecked, this, [this, Worker, Id](const QString&, const QString& Address) {
+		if (m_Workers.value(Id) != Worker || m_Runtime.value(Id).State == CProxyTunnel::Stopping) return;
+		m_Runtime[Id].Egress = Address;
+		m_Runtime[Id].CheckedAt = QDateTime::currentDateTimeUtc();
+		emit Changed();
+	});
+	connect(Worker, &QThread::finished, this, [this, Worker, Id]() {
+		if (m_Workers.value(Id) != Worker) return;
+		m_Workers.remove(Id);
+		if (m_Runtime.value(Id).State != CProxyTunnel::Failed)
+			SetState(Id, CProxyTunnel::Stopped, tr("Tunnel stopped. Sandbox associations were retained."));
+		Worker->deleteLater();
+		emit Changed();
+	});
+	Worker->start();
+	return true;
+}
+
+void CProxyManager::Stop(const QString& Id)
+{
+	if (auto Worker = m_Workers.value(Id, nullptr)) {
+		SetState(Id, CProxyTunnel::Stopping, tr("Stopping the owned worker; sandbox bindings remain configured."));
+		Worker->RequestStop();
+	}
+}
+
+void CProxyManager::StopAll() { const auto Ids = m_Workers.keys(); for (const QString& Id : Ids) Stop(Id); }
+void CProxyManager::Check(const QString& Id) { if (auto Worker = m_Workers.value(Id, nullptr)) Worker->RequestCheck(); }
+
+void CProxyManager::Revalidate()
+{
+	if (m_Workers.isEmpty()) return;
+	const QString Error = ActivationError();
+	if (Error.isEmpty()) return;
+	for (auto It = m_Workers.begin(); It != m_Workers.end(); ++It) {
+		if (m_Runtime.value(It.key()).State == CProxyTunnel::Stopping) continue;
+		SetState(It.key(), CProxyTunnel::Stopping, Error);
+		It.value()->RequestStop();
+	}
+}
+
+bool CProxyManager::InstallDependencies(QString& Error)
+{
+	if (!m_Hooks.InstallDependencies) { Error = tr("No dependency installer is configured."); return false; }
+	return m_Hooks.InstallDependencies(Error);
+}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyManager.h
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyManager.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#pragma once
+#include "ProxyTunnel.h"
+#include <QDateTime>
+#include <QLockFile>
+#include <QMap>
+#include <QTimer>
+#include <functional>
+#include <memory>
+
+struct SProxyBox
+{
+	QString Name;
+	QString ProfileId;
+	QString Detail;
+};
+
+// SandMan supplies policy/INI access; the controller never writes Sandboxie.ini directly.
+struct SProxyHooks
+{
+	std::function<QString()> ActivationError;
+	std::function<QList<SProxyBox>()> Boxes;
+	std::function<bool(const QString&, const QString&, QString&)> Assign;
+	std::function<QString(const QString&)> ModificationError;
+	std::function<QString()> DependencyDirectory;
+	std::function<bool(QString&)> InstallDependencies;
+	std::function<void(const QString&)> Log;
+};
+
+struct SProxyRuntime
+{
+	int State = CProxyTunnel::Stopped;
+	QString Detail;
+	QString Egress;
+	QDateTime CheckedAt;
+};
+
+class CProxyManager : public QObject
+{
+	Q_OBJECT
+public:
+	using TFactory = std::function<CProxyTunnel*(const SProxyProfile&, const QString&, QObject*)>;
+	CProxyManager(const QString& Path, SProxyHooks Hooks, QObject* Parent = nullptr, TFactory Factory = TFactory());
+	~CProxyManager() override;
+	QList<SProxyProfile> Profiles() const { return m_Profiles; }
+	QList<SProxyBox> Boxes() const;
+	QStringList Users(const QString& Id) const;
+	SProxyRuntime Runtime(const QString& Id) const { return m_Runtime.value(Id); }
+	QString StorageError() const { return m_StorageError; }
+	QString ActivationError() const;
+	bool SaveProfile(const SProxyInput& Input, QString& Id, QString& Error);
+	bool Import(const QString& Text, QList<SProxyImportError>& Errors, int& Added, QString& Error);
+	bool Remove(const QString& Id, QString& Error);
+	bool Assign(const QString& Box, const QString& Id, QString& Error);
+	bool Start(const QString& Id, QString& Error);
+	void Stop(const QString& Id);
+	void StopAll();
+	void Check(const QString& Id);
+	bool InstallDependencies(QString& Error);
+	bool HasWorker(const QString& Id) const { return m_Workers.contains(Id); }
+
+signals:
+	void Changed();
+
+private:
+	int Find(const QString& Id) const;
+	bool Persist(const QList<SProxyProfile>& Profiles, QString& Error);
+	void SetState(const QString& Id, int State, const QString& Detail);
+	void Revalidate();
+	QString m_Path;
+	QString m_StorageError;
+	std::unique_ptr<QLockFile> m_Lock;
+	QList<SProxyProfile> m_Profiles;
+	QMap<QString, SProxyRuntime> m_Runtime;
+	QMap<QString, CProxyTunnel*> m_Workers;
+	SProxyHooks m_Hooks;
+	TFactory m_Factory;
+	QTimer m_Timer;
+};

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyProfile.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyProfile.cpp
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#ifdef PROXY_TUNNELS_STANDALONE
+#include <QtCore>
+#else
+#include "stdafx.h"
+#endif
+#include "ProxyProfile.h"
+#include <QCoreApplication>
+#include <QHostAddress>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QSet>
+#include <QUrl>
+#include <QUuid>
+#ifdef Q_OS_WIN
+#include <windows.h>
+#include <wincrypt.h>
+#endif
+
+namespace
+{
+	QString Text(const char* Value) { return QCoreApplication::translate("ProxyProfiles", Value); }
+	bool Fail(QString& Error, const char* Message) { Error = Text(Message); return false; }
+	bool HasControls(const QString& Value)
+	{
+		for (QChar Ch : Value) {
+			if (Ch.unicode() < 32 || Ch.unicode() == 127) return true;
+		}
+		return false;
+	}
+	bool ValidId(const QString& Id)
+	{
+		QUuid Uuid(Id);
+		return !Uuid.isNull() && Uuid.toString(QUuid::WithoutBraces) == Id;
+	}
+#ifdef Q_OS_WIN
+	void Wipe(QByteArray& Data)
+	{
+		Data.detach();
+		SecureZeroMemory(Data.data(), size_t(Data.size()));
+		Data.clear();
+	}
+#endif
+}
+
+QString SProxyProfile::AdapterName() const { return QStringLiteral("SbieProxy-") + Id; }
+
+QJsonObject SProxyProfile::ToJson() const
+{
+	return {{"id", Id}, {"name", Name}, {"scheme", Scheme}, {"host", Host},
+		{"port", int(Port)}, {"dpapi", QString::fromLatin1(ProtectedAuth.toBase64())}};
+}
+
+bool SProxyProfile::FromJson(const QJsonObject& Object, SProxyProfile& Profile, QString& Error)
+{
+	static const QSet<QString> Keys = {"id", "name", "scheme", "host", "port", "dpapi"};
+	for (auto It = Object.begin(); It != Object.end(); ++It) {
+		if (!Keys.contains(It.key())) return Fail(Error, "Unknown profile field; the file was not modified.");
+	}
+	if (!Object.value("port").isDouble() || Object.value("port").toDouble() != Object.value("port").toInt()
+		|| !Object.value("dpapi").isString())
+		return Fail(Error, "Invalid saved proxy profile.");
+	SProxyInput Input;
+	Input.Name = Object.value("name").toString();
+	Input.Scheme = Object.value("scheme").toString();
+	Input.Host = Object.value("host").toString();
+	Input.Port = Object.value("port").toInt();
+	if (!ValidId(Object.value("id").toString()) || !ProxyProfiles::Validate(Input, Error))
+		return Fail(Error, "Invalid saved proxy profile; the file was not modified.");
+	const QString Encoded = Object.value("dpapi").toString();
+	if (!QRegularExpression(QStringLiteral("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$")).match(Encoded).hasMatch()
+		|| Encoded.size() > 16384)
+		return Fail(Error, "Invalid protected credentials.");
+	Profile.Id = Object.value("id").toString();
+	Profile.Name = Input.Name;
+	Profile.Host = Input.Host;
+	Profile.Scheme = Input.Scheme;
+	Profile.Port = quint16(Input.Port);
+	Profile.ProtectedAuth = QByteArray::fromBase64(Encoded.toLatin1());
+	return true;
+}
+
+bool ProxyProfiles::Validate(const SProxyInput& Input, QString& Error)
+{
+	Error.clear();
+	if (Input.Name.trimmed().isEmpty() || Input.Name.size() > 100 || HasControls(Input.Name))
+		return Fail(Error, "Use a profile name of 1 to 100 characters without control characters.");
+	if (Input.Scheme != "socks5" && Input.Scheme != "http")
+		return Fail(Error, "Only SOCKS5 and HTTP CONNECT proxies are supported.");
+	if (Input.Port < 1 || Input.Port > 65535)
+		return Fail(Error, "The proxy port must be between 1 and 65535.");
+	if (Input.Host.isEmpty() || Input.Host.size() > 253 || HasControls(Input.Host) || Input.Host != Input.Host.trimmed())
+		return Fail(Error, "Invalid proxy host.");
+	QHostAddress Address;
+	if (Address.setAddress(Input.Host)) {
+		if (Address == QHostAddress::AnyIPv4 || Address == QHostAddress::AnyIPv6 || Address.isMulticast() || Input.Host.contains('%')
+			|| Address == QHostAddress(QStringLiteral("255.255.255.255")))
+			return Fail(Error, "Use a unicast proxy address without a scope identifier.");
+	} else {
+		const QString Host = QString::fromLatin1(QUrl::toAce(Input.Host));
+		if (Host.isEmpty() || Host.size() > 253 || QRegularExpression(QStringLiteral("^[0-9.]+$")).match(Host).hasMatch())
+			return Fail(Error, "Invalid proxy host.");
+		for (const QString& Label : Host.split('.')) {
+			if (!QRegularExpression(QStringLiteral("^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")).match(Label).hasMatch())
+				return Fail(Error, "Invalid proxy host.");
+		}
+	}
+	if (HasControls(Input.User) || HasControls(Input.Password) || Input.User.toUtf8().size() > 255 || Input.Password.toUtf8().size() > 255)
+		return Fail(Error, "Credentials must not contain control characters or exceed 255 UTF-8 bytes.");
+	if (Input.User.isEmpty() && !Input.Password.isEmpty())
+		return Fail(Error, "A password requires a username.");
+	return true;
+}
+
+bool ProxyProfiles::ParseLine(const QString& Line, SProxyInput& Input, QString& Error)
+{
+	const QString Value = Line.trimmed();
+	Input = SProxyInput();
+	Input.Name = Text("Imported proxy");
+	if (Value.size() > 4096 || HasControls(Line))
+		return Fail(Error, "The entry is too long or contains control characters.");
+	if (Value.contains("://")) {
+		QUrl Url(Value, QUrl::StrictMode);
+		if (!Url.isValid() || !Url.path().isEmpty() || Url.hasQuery() || Url.hasFragment())
+			return Fail(Error, "Use a proxy URL without a path, query, or fragment.");
+		Input.Scheme = Url.scheme().toLower();
+		Input.Host = Url.host();
+		Input.Port = Url.port(-1);
+		Input.User = Url.userName();
+		Input.Password = Url.password();
+	} else {
+		// IPv6 must use brackets; a legacy password may contain colons.
+		const auto Match = QRegularExpression(QStringLiteral("^(?:\\[([^\\]]+)\\]|([^:\\s]+)):([0-9]{1,5})(?::([^:]*):(.*))?$")).match(Value);
+		if (!Match.hasMatch()) return Fail(Error, "Use host:port, host:port:user:password, or a SOCKS5/HTTP proxy URL.");
+		Input.Host = Match.captured(1).isEmpty() ? Match.captured(2) : Match.captured(1);
+		Input.Port = Match.captured(3).toInt();
+		Input.User = Match.captured(4);
+		Input.Password = Match.captured(5);
+	}
+	return Validate(Input, Error);
+}
+
+QList<SProxyInput> ProxyProfiles::ParseList(const QString& TextValue, QList<SProxyImportError>& Errors)
+{
+	QList<SProxyInput> Inputs;
+	Errors.clear();
+	if (TextValue.toUtf8().size() > 1024 * 1024) {
+		Errors.append({0, Text("The import exceeds 1 MiB.")});
+		return Inputs;
+	}
+	int Number = 0;
+	for (QString Line : TextValue.split('\n')) {
+		++Number;
+		if (Line.endsWith('\r')) Line.chop(1);
+		if (Line.trimmed().isEmpty() || Line.trimmed().startsWith('#')) continue;
+		SProxyInput Input;
+		QString Error;
+		if (Inputs.size() >= 1000) Errors.append({Number, Text("The import limit is 1000 profiles.")});
+		else if (!ParseLine(Line, Input, Error)) Errors.append({Number, Error});
+		else {
+			Input.Name = Text("Proxy %1").arg(Number);
+			Inputs.append(Input); // Do not collapse distinct sessions sharing an ingress host.
+		}
+	}
+	return Inputs;
+}
+
+bool ProxyProfiles::Protect(const SProxyInput& Input, SProxyProfile& Profile, QString& Error)
+{
+	if (!Validate(Input, Error)) return false;
+	SProxyProfile Updated = Profile;
+	if (Updated.Id.isEmpty()) Updated.Id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+	if (!ValidId(Updated.Id)) return Fail(Error, "Invalid profile identity.");
+	Updated.Name = Input.Name.trimmed();
+	Updated.Host = Input.Host;
+	Updated.Port = quint16(Input.Port);
+	Updated.Scheme = Input.Scheme;
+	Updated.ProtectedAuth.clear();
+	if (!Input.User.isEmpty()) {
+#ifdef Q_OS_WIN
+		QByteArray Plain = QJsonDocument(QJsonObject{{"user", Input.User}, {"password", Input.Password}}).toJson(QJsonDocument::Compact);
+		QByteArray Entropy = Updated.Id.toUtf8();
+		DATA_BLOB Source = {DWORD(Plain.size()), reinterpret_cast<BYTE*>(Plain.data())};
+		DATA_BLOB Salt = {DWORD(Entropy.size()), reinterpret_cast<BYTE*>(Entropy.data())};
+		DATA_BLOB Result = {};
+		BOOL Ok = CryptProtectData(&Source, L"Sandboxie Plus proxy credentials", &Salt, nullptr, nullptr, CRYPTPROTECT_UI_FORBIDDEN, &Result);
+		Wipe(Plain);
+		if (!Ok) return Fail(Error, "Windows could not protect the credentials. Nothing was saved.");
+		Updated.ProtectedAuth = QByteArray(reinterpret_cast<const char*>(Result.pbData), int(Result.cbData));
+		SecureZeroMemory(Result.pbData, Result.cbData);
+		LocalFree(Result.pbData);
+#else
+		return Fail(Error, "Credential storage requires Windows DPAPI.");
+#endif
+	}
+	Profile = Updated;
+	return true;
+}
+
+bool ProxyProfiles::Reveal(const SProxyProfile& Profile, SProxyInput& Input, QString& Error)
+{
+	Input = SProxyInput();
+	Input.Name = Profile.Name;
+	Input.Host = Profile.Host;
+	Input.Port = Profile.Port;
+	Input.Scheme = Profile.Scheme;
+	if (!Profile.ProtectedAuth.isEmpty()) {
+#ifdef Q_OS_WIN
+		QByteArray Cipher = Profile.ProtectedAuth;
+		QByteArray Entropy = Profile.Id.toUtf8();
+		DATA_BLOB Source = {DWORD(Cipher.size()), reinterpret_cast<BYTE*>(Cipher.data())};
+		DATA_BLOB Salt = {DWORD(Entropy.size()), reinterpret_cast<BYTE*>(Entropy.data())};
+		DATA_BLOB Result = {};
+		if (!CryptUnprotectData(&Source, nullptr, &Salt, nullptr, nullptr, CRYPTPROTECT_UI_FORBIDDEN, &Result))
+			return Fail(Error, "Credentials are unavailable for this Windows user or computer. Re-enter them.");
+		QByteArray Plain(reinterpret_cast<const char*>(Result.pbData), int(Result.cbData));
+		SecureZeroMemory(Result.pbData, Result.cbData);
+		LocalFree(Result.pbData);
+		QJsonParseError ParseError;
+		const QJsonDocument Doc = QJsonDocument::fromJson(Plain, &ParseError);
+		Wipe(Plain);
+		if (ParseError.error != QJsonParseError::NoError || !Doc.isObject()
+			|| !Doc.object().value("user").isString() || !Doc.object().value("password").isString())
+			return Fail(Error, "Invalid protected credential data.");
+		Input.User = Doc.object().value("user").toString();
+		Input.Password = Doc.object().value("password").toString();
+#else
+		return Fail(Error, "Credential storage requires Windows DPAPI.");
+#endif
+	}
+	return Validate(Input, Error);
+}
+
+QString ProxyProfiles::ProxyUrl(const SProxyInput& Input)
+{
+	QUrl Url;
+	Url.setScheme(Input.Scheme);
+	Url.setHost(Input.Host);
+	Url.setPort(Input.Port);
+	if (!Input.User.isEmpty()) {
+		Url.setUserName(Input.User);
+		Url.setPassword(Input.Password);
+	}
+	return Url.toString(QUrl::FullyEncoded);
+}
+
+bool ProxyProfiles::Load(const QString& Path, QList<SProxyProfile>& Profiles, QString& Error)
+{
+	QFile File(Path);
+	if (!File.exists()) { Profiles.clear(); return true; }
+	if (!File.open(QIODevice::ReadOnly) || File.size() > 4 * 1024 * 1024)
+		return Fail(Error, "Cannot read the proxy profile file, or it exceeds 4 MiB.");
+	QJsonParseError ParseError;
+	const QJsonDocument Doc = QJsonDocument::fromJson(File.readAll(), &ParseError);
+	if (ParseError.error != QJsonParseError::NoError || !Doc.isObject() || Doc.object().value("version").toDouble() != 1
+		|| !Doc.object().value("profiles").isArray() || Doc.object().value("profiles").toArray().size() > 1000)
+		return Fail(Error, "Invalid proxy profile file. The original file was not modified.");
+	QList<SProxyProfile> Loaded;
+	QSet<QString> Ids;
+	for (const auto& Value : Doc.object().value("profiles").toArray()) {
+		SProxyProfile Profile;
+		if (!Value.isObject()) return Fail(Error, "Invalid saved proxy profile.");
+		if (!SProxyProfile::FromJson(Value.toObject(), Profile, Error)) return false;
+		if (Ids.contains(Profile.Id)) return Fail(Error, "Duplicate profile identity in the saved file.");
+		Ids.insert(Profile.Id);
+		Loaded.append(Profile);
+	}
+	Profiles = Loaded;
+	return true;
+}
+
+bool ProxyProfiles::Save(const QString& Path, const QList<SProxyProfile>& Profiles, QString& Error)
+{
+	if (Profiles.size() > 1000) return Fail(Error, "At most 1000 profiles can be saved.");
+	QJsonArray Array;
+	QSet<QString> Ids;
+	for (const SProxyProfile& Profile : Profiles) {
+		SProxyProfile Check;
+		if (!SProxyProfile::FromJson(Profile.ToJson(), Check, Error) || Ids.contains(Profile.Id))
+			return Fail(Error, "Cannot save an invalid or duplicate profile identity.");
+		Ids.insert(Profile.Id);
+		Array.append(Profile.ToJson());
+	}
+	const QByteArray Data = QJsonDocument(QJsonObject{{"version", 1}, {"profiles", Array}}).toJson();
+	if (Data.size() > 4 * 1024 * 1024) return Fail(Error, "The profile store exceeds 4 MiB.");
+	QSaveFile File(Path);
+	File.setDirectWriteFallback(false);
+	if (!File.open(QIODevice::WriteOnly) || File.write(Data) != Data.size() || !File.commit())
+		return Fail(Error, "Cannot save proxy profiles atomically. The previous file was retained.");
+	return true;
+}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyProfile.h
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyProfile.h
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#pragma once
+#include <QByteArray>
+#include <QJsonObject>
+#include <QList>
+#include <QString>
+
+struct SProxyInput
+{
+	QString Name;
+	QString Scheme = QStringLiteral("socks5");
+	QString Host;
+	int Port = 1080;
+	QString User;
+	QString Password;
+};
+
+struct SProxyProfile
+{
+	QString Id;
+	QString Name;
+	QString Scheme;
+	QString Host;
+	quint16 Port = 0;
+	QByteArray ProtectedAuth;
+
+	QString AdapterName() const;
+	QJsonObject ToJson() const;
+	static bool FromJson(const QJsonObject& Object, SProxyProfile& Profile, QString& Error);
+};
+
+struct SProxyImportError
+{
+	int Line = 0;
+	QString Reason; // Never contains the input line or credentials.
+};
+
+namespace ProxyProfiles
+{
+	bool Validate(const SProxyInput& Input, QString& Error);
+	bool ParseLine(const QString& Line, SProxyInput& Input, QString& Error);
+	QList<SProxyInput> ParseList(const QString& Text, QList<SProxyImportError>& Errors);
+	bool Protect(const SProxyInput& Input, SProxyProfile& Profile, QString& Error);
+	bool Reveal(const SProxyProfile& Profile, SProxyInput& Input, QString& Error);
+	QString ProxyUrl(const SProxyInput& Input);
+	bool Load(const QString& Path, QList<SProxyProfile>& Profiles, QString& Error);
+	bool Save(const QString& Path, const QList<SProxyProfile>& Profiles, QString& Error);
+}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyTunnel.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyTunnel.cpp
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#ifdef PROXY_TUNNELS_STANDALONE
+#include <QtCore>
+#else
+#include "stdafx.h"
+#endif
+#include "ProxyTunnel.h"
+#include <QCryptographicHash>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QHostInfo>
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QNetworkProxy>
+#include <QSet>
+#include <QSslSocket>
+#include <QUuid>
+#include <QJsonDocument>
+#include <memory>
+#ifdef Q_OS_WIN
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#include <iphlpapi.h>
+#include <netioapi.h>
+#endif
+
+CProxyTunnel::CProxyTunnel(const SProxyProfile& Profile, const QString& Directory, QObject* Parent)
+	: QThread(Parent), m_Profile(Profile), m_Directory(Directory) {}
+
+CProxyTunnel::~CProxyTunnel() { RequestStop(); wait(); }
+
+QString CProxyTunnel::StateText(int State)
+{
+	switch (State) {
+	case Starting: return tr("Starting");
+	case Running: return tr("Running (TCP checked)");
+	case Checking: return tr("Checking tunnel");
+	case Stopping: return tr("Stopping");
+	case Failed: return tr("Failed / offline");
+	default: return tr("Stopped");
+	}
+}
+
+void CProxyTunnel::run()
+{
+	emit StateChanged(m_Profile.Id, Starting, tr("Preparing the managed tunnel."));
+	const QString Error = RunWindows();
+	if (!Error.isEmpty() && !m_Stop.load()) emit StateChanged(m_Profile.Id, Failed, Error);
+	else emit StateChanged(m_Profile.Id, Stopped, tr("Tunnel stopped. Sandbox bindings were retained."));
+}
+
+#if defined(Q_OS_WIN) && defined(SBIE_PROXY_TUNNELS_LAB)
+namespace
+{
+	QString Message(const char* Text) { return QCoreApplication::translate("ProxyTunnel", Text); }
+	QString WinError(const char* Stage, DWORD Code = GetLastError())
+	{
+		// Never include a command line, proxy URL, exception text, or child output.
+		return Message("%1 (Windows error %2).").arg(Message(Stage)).arg(Code);
+	}
+
+	struct SHandle
+	{
+		HANDLE Value = nullptr;
+		~SHandle() { if (Value && Value != INVALID_HANDLE_VALUE) CloseHandle(Value); }
+		SHandle() = default;
+		SHandle(const SHandle&) = delete;
+		SHandle& operator=(const SHandle&) = delete;
+	};
+
+	struct SChild
+	{
+		SHandle Job;
+		SHandle Process;
+		DWORD Pid = 0;
+		~SChild()
+		{
+			// Process is exclusively a handle returned by our own CreateProcessW call.
+			if (Process.Value) {
+				TerminateProcess(Process.Value, ERROR_CANCELLED);
+				WaitForSingleObject(Process.Value, 5000);
+			}
+		}
+		bool Alive() const { return Process.Value && WaitForSingleObject(Process.Value, 0) == WAIT_TIMEOUT; }
+	};
+
+	bool VerifyAndLock(const QString& Path, const QByteArray& Expected, SHandle& File)
+	{
+		const std::wstring Native = QDir::toNativeSeparators(Path).toStdWString();
+		// Refuse replacement/deletion while the verified file is in use.
+		File.Value = CreateFileW(Native.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+		if (File.Value == INVALID_HANDLE_VALUE) return false;
+		QCryptographicHash Hash(QCryptographicHash::Sha256);
+		char Buffer[65536];
+		DWORD Read = 0;
+		qint64 Total = 0;
+		for (;;) {
+			if (!ReadFile(File.Value, Buffer, sizeof(Buffer), &Read, nullptr)) return false;
+			if (Read == 0) break;
+			Total += Read;
+			if (Total > 64 * 1024 * 1024) return false;
+			Hash.addData(Buffer, int(Read));
+		}
+		return Hash.result().toHex() == Expected;
+	}
+
+	bool Launch(const QString& Exe, const QString& Pipe, SChild& Child, QString& Error)
+	{
+		Child.Job.Value = CreateJobObjectW(nullptr, nullptr);
+		if (!Child.Job.Value) { Error = WinError("Cannot create the tunnel job"); return false; }
+		JOBOBJECT_EXTENDED_LIMIT_INFORMATION Limit = {};
+		Limit.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+		if (!SetInformationJobObject(Child.Job.Value, JobObjectExtendedLimitInformation, &Limit, sizeof(Limit))) {
+			Error = WinError("Cannot configure the tunnel job"); return false;
+		}
+		SECURITY_ATTRIBUTES Attributes = {sizeof(Attributes), nullptr, TRUE};
+		SHandle Null;
+		Null.Value = CreateFileW(L"NUL", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+			&Attributes, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+		if (Null.Value == INVALID_HANDLE_VALUE) { Error = WinError("Cannot isolate tunnel output"); return false; }
+		SIZE_T Size = 0;
+		InitializeProcThreadAttributeList(nullptr, 1, 0, &Size);
+		QByteArray Storage(int(Size), 0);
+		auto List = reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(Storage.data());
+		if (!InitializeProcThreadAttributeList(List, 1, 0, &Size)) { Error = WinError("Cannot create the process attribute list"); return false; }
+		struct SAttributes { LPPROC_THREAD_ATTRIBUTE_LIST Value; ~SAttributes() { DeleteProcThreadAttributeList(Value); } } AttributeGuard{List};
+		HANDLE Inherited[] = {Null.Value};
+		if (!UpdateProcThreadAttribute(List, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, Inherited, sizeof(Inherited), nullptr, nullptr)) {
+			Error = WinError("Cannot restrict inherited handles"); return false;
+		}
+		STARTUPINFOEXW Info = {};
+		Info.StartupInfo.cb = sizeof(Info);
+		Info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+		Info.StartupInfo.hStdInput = Info.StartupInfo.hStdOutput = Info.StartupInfo.hStdError = Null.Value;
+		Info.lpAttributeList = List;
+		const std::wstring Executable = QDir::toNativeSeparators(Exe).toStdWString();
+		// Paths cannot contain quotes on Windows. Pipe names are internally generated UUIDs.
+		std::wstring Command = L"\"" + Executable + L"\" -loglevel silent -config \"" + Pipe.toStdWString() + L"\"";
+		wchar_t SystemDirectory[MAX_PATH] = {};
+		if (!GetSystemDirectoryW(SystemDirectory, MAX_PATH)) { Error = WinError("Cannot locate the system directory"); return false; }
+		PROCESS_INFORMATION Process = {};
+		if (!CreateProcessW(Executable.c_str(), &Command[0], nullptr, nullptr, TRUE,
+			CREATE_SUSPENDED | CREATE_NO_WINDOW | EXTENDED_STARTUPINFO_PRESENT,
+			nullptr, SystemDirectory, &Info.StartupInfo, &Process)) {
+			Error = WinError("Cannot start tun2socks"); return false;
+		}
+		Child.Process.Value = Process.hProcess;
+		Child.Pid = Process.dwProcessId;
+		SHandle Thread;
+		Thread.Value = Process.hThread;
+		if (!AssignProcessToJobObject(Child.Job.Value, Child.Process.Value)) {
+			Error = WinError("Cannot attach the tunnel to its lifetime job"); return false;
+		}
+		if (ResumeThread(Thread.Value) == DWORD(-1)) { Error = WinError("Cannot resume the tunnel process"); return false; }
+		return true;
+	}
+
+	bool BestHostRoute(NET_LUID& Luid)
+	{
+		SOCKADDR_INET Destination = {};
+		Destination.Ipv4.sin_family = AF_INET;
+		InetPtonW(AF_INET, L"1.1.1.1", &Destination.Ipv4.sin_addr);
+		MIB_IPFORWARD_ROW2 Route = {};
+		SOCKADDR_INET Source = {};
+		if (GetBestRoute2(nullptr, 0, nullptr, &Destination, 0, &Route, &Source) != NO_ERROR) return false;
+		Luid = Route.InterfaceLuid;
+		return true;
+	}
+
+	struct SNetwork
+	{
+		NET_LUID Luid = {};
+		GUID Guid = {};
+		MIB_UNICASTIPADDRESS_ROW Address = {};
+		MIB_IPFORWARD_ROW2 Route = {};
+		bool AddedAddress = false;
+		bool AddedRoute = false;
+		~SNetwork()
+		{
+			MIB_IF_ROW2 Current = {};
+			Current.InterfaceLuid = Luid;
+			// Never clean up by a reusable numeric interface index or an alias alone.
+			if (GetIfEntry2(&Current) != NO_ERROR || !IsEqualGUID(Guid, Current.InterfaceGuid)) return;
+			if (AddedRoute) DeleteIpForwardEntry2(&Route);
+			if (AddedAddress) DeleteUnicastIpAddressEntry(&Address);
+		}
+		bool Ready() const
+		{
+			MIB_IF_ROW2 Current = {};
+			Current.InterfaceLuid = Luid;
+			if (GetIfEntry2(&Current) != NO_ERROR || !IsEqualGUID(Guid, Current.InterfaceGuid)
+				|| Current.OperStatus != IfOperStatusUp) return false;
+			MIB_UNICASTIPADDRESS_ROW Check = Address;
+			if (GetUnicastIpAddressEntry(&Check) != NO_ERROR || Check.DadState != IpDadStatePreferred) return false;
+			PMIB_UNICASTIPADDRESS_TABLE Table = nullptr;
+			if (GetUnicastIpAddressTable(AF_INET6, &Table) != NO_ERROR) return false;
+			bool Valid = true;
+			for (ULONG i = 0; i < Table->NumEntries; ++i) {
+				const auto& Row = Table->Table[i];
+				if (Row.InterfaceLuid.Value == Luid.Value && !IN6_IS_ADDR_LINKLOCAL(&Row.Address.Ipv6.sin6_addr)) Valid = false;
+			}
+			FreeMibTable(Table);
+			return Valid;
+		}
+	};
+
+	bool Configure(SNetwork& Network, QString& Error)
+	{
+		MIB_IF_ROW2 Adapter = {};
+		Adapter.InterfaceLuid = Network.Luid;
+		DWORD Code = GetIfEntry2(&Adapter);
+		if (Code) { Error = WinError("Cannot identify the new tunnel adapter", Code); return false; }
+		Network.Guid = Adapter.InterfaceGuid;
+		MIB_IPINTERFACE_ROW Interface = {};
+		InitializeIpInterfaceEntry(&Interface);
+		Interface.Family = AF_INET;
+		Interface.InterfaceLuid = Network.Luid;
+		Code = GetIpInterfaceEntry(&Interface);
+		if (Code) { Error = WinError("Cannot read the tunnel interface", Code); return false; }
+		Interface.WeakHostSend = FALSE;
+		Interface.WeakHostReceive = FALSE;
+		Interface.UseAutomaticMetric = FALSE;
+		Interface.Metric = 9999;
+		Interface.SitePrefixLength = 0;
+		Code = SetIpInterfaceEntry(&Interface);
+		if (Code) { Error = WinError("Cannot configure strong-host mode", Code); return false; }
+		PMIB_UNICASTIPADDRESS_TABLE Table = nullptr;
+		Code = GetUnicastIpAddressTable(AF_INET, &Table);
+		if (Code) { Error = WinError("Cannot allocate a tunnel address", Code); return false; }
+		QSet<quint32> Used;
+		for (ULONG i = 0; i < Table->NumEntries; ++i) Used.insert(Table->Table[i].Address.Ipv4.sin_addr.S_un.S_addr);
+		FreeMibTable(Table);
+		InitializeUnicastIpAddressEntry(&Network.Address);
+		Network.Address.InterfaceLuid = Network.Luid;
+		Network.Address.Address.Ipv4.sin_family = AF_INET;
+		Network.Address.OnLinkPrefixLength = 32;
+		Network.Address.PrefixOrigin = IpPrefixOriginManual;
+		Network.Address.SuffixOrigin = IpSuffixOriginManual;
+		Network.Address.SkipAsSource = TRUE;
+		Network.Address.ValidLifetime = Network.Address.PreferredLifetime = 0xffffffff;
+		// /32 avoids installing an overlapping connected /15 route on the host.
+		for (quint32 Index = 1; Index < 65535; ++Index) {
+			const quint32 Ip = htonl(0xc6120000u + Index); // 198.18.0.0/16, benchmarking range
+			if (Used.contains(Ip)) continue;
+			Network.Address.Address.Ipv4.sin_addr.S_un.S_addr = Ip;
+			Code = CreateUnicastIpAddressEntry(&Network.Address);
+			if (Code == ERROR_OBJECT_ALREADY_EXISTS) continue;
+			if (Code) { Error = WinError("Cannot assign the tunnel address", Code); return false; }
+			Network.AddedAddress = true;
+			break;
+		}
+		if (!Network.AddedAddress) { Error = Message("No free tunnel address is available."); return false; }
+		InitializeIpForwardEntry(&Network.Route);
+		Network.Route.InterfaceLuid = Network.Luid;
+		Network.Route.DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
+		Network.Route.DestinationPrefix.PrefixLength = 0;
+		Network.Route.NextHop.Ipv4.sin_family = AF_INET;
+		Network.Route.Metric = 9999;
+		Network.Route.Protocol = MIB_IPPROTO_NETMGMT;
+		Code = CreateIpForwardEntry2(&Network.Route);
+		if (Code) { Error = WinError("Cannot add the interface-scoped tunnel route", Code); return false; }
+		Network.AddedRoute = true;
+		return true;
+	}
+
+	QString CheckEgress(const SNetwork& Network, const std::atomic<bool>& Stop, QString& Address)
+	{
+		QSslSocket Socket;
+		Socket.setProxy(QNetworkProxy::NoProxy);
+		const quint32 Source = ntohl(Network.Address.Address.Ipv4.sin_addr.S_un.S_addr);
+		if (!Socket.bind(QHostAddress(Source))) return Message("Cannot bind the egress check to the tunnel address.");
+		NET_IFINDEX Index = 0;
+		if (ConvertInterfaceLuidToIndex(&Network.Luid, &Index) != NO_ERROR) return Message("The tunnel interface disappeared.");
+		DWORD NativeIndex = htonl(Index);
+		if (setsockopt(SOCKET(Socket.socketDescriptor()), IPPROTO_IP, IP_UNICAST_IF,
+			reinterpret_cast<const char*>(&NativeIndex), sizeof(NativeIndex)) != 0)
+			return Message("Cannot pin the egress check to the tunnel interface.");
+		// Numeric TLS endpoint: no host DNS lookup, no inherited system proxy, no insecure TLS fallback.
+		Socket.connectToHostEncrypted(QStringLiteral("1.1.1.1"), 443);
+		if (!Socket.waitForEncrypted(7000) || Stop.load()) return Message("The tunnel TCP/TLS check failed. Check the proxy and its credentials.");
+		const QByteArray Request("GET /cdn-cgi/trace HTTP/1.1\r\nHost: 1.1.1.1\r\nConnection: close\r\n\r\n");
+		if (Socket.write(Request) != Request.size() || (Socket.bytesToWrite() && !Socket.waitForBytesWritten(3000))) return Message("The tunnel check could not send its request.");
+		QByteArray Reply;
+		QElapsedTimer Deadline;
+		Deadline.start();
+		while (!Stop.load() && Deadline.elapsed() < 7000 && Reply.size() <= 16384) {
+			Reply += Socket.readAll();
+			if (Socket.state() == QAbstractSocket::UnconnectedState) break;
+			Socket.waitForReadyRead(100);
+		}
+		Reply += Socket.readAll();
+		if (Stop.load() || Reply.size() > 16384 || !Reply.startsWith("HTTP/1.1 200 ") || !Reply.contains("\r\n\r\n"))
+			return Message("The tunnel check returned no valid HTTPS response.");
+		const QByteArray Body = Reply.mid(Reply.indexOf("\r\n\r\n") + 4);
+		for (const QByteArray& Line : Body.split('\n')) {
+			if (!Line.startsWith("ip=")) continue;
+			QHostAddress Ip(QString::fromLatin1(Line.mid(3).trimmed()));
+			if (Ip.protocol() != QAbstractSocket::IPv4Protocol || Ip.isNull() || Ip.isMulticast() || Ip.isLoopback()) break;
+			Address = Ip.toString();
+			return QString();
+		}
+		return Message("The tunnel check returned no valid IPv4 address.");
+	}
+}
+#endif
+
+QString CProxyTunnel::RunWindows()
+{
+#if !defined(Q_OS_WIN)
+	return tr("Tunnel execution is available only on Windows.");
+#elif !defined(SBIE_PROXY_TUNNELS_LAB)
+	return tr("Tunnel activation is disabled pending Windows routing and failure qualification.");
+#else
+	if (!QSslSocket::supportsSsl()) return tr("TLS support is unavailable. No tunnel was started.");
+	const QString Exe = QDir(m_Directory).absoluteFilePath(QStringLiteral("tun2socks.exe"));
+	const QString Dll = QDir(m_Directory).absoluteFilePath(QStringLiteral("wintun.dll"));
+#if defined(_M_ARM64) || defined(__aarch64__)
+	const QByteArray ExeHash("559eb3ee0935f628a6ab9952976b30ca7c3706dfe5fd9f1095fbe5692f3a13fa");
+	const QByteArray DllHash("f7ba89005544be9d85231a9e0d5f23b2d15b3311667e2dad0debd344918a3f80");
+#elif defined(_WIN64)
+	const QByteArray ExeHash("076b3c3d6a372bae3f49f2b415a4105f70c30a3ed3caaed7979390e649892559");
+	const QByteArray DllHash("e5da8447dc2c320edc0fc52fa01885c103de8c118481f683643cacc3220dafce");
+#else
+	const QByteArray ExeHash("bd964c932ca9969026f3ff47790d614f10186536c2e1330dc5cb4352f589cfa5");
+	const QByteArray DllHash("d694fa46ab4cfebcb2632d094c7aa97278eef2f8052438621766d863ae98a931");
+#endif
+	SHandle ExeFile, DllFile;
+	if (!VerifyAndLock(Exe, ExeHash, ExeFile) || !VerifyAndLock(Dll, DllHash, DllFile))
+		return tr("The official, pinned tunnel dependencies are missing, changed, or in use. Install the ProxyTunnels add-on.");
+	SProxyInput Input;
+	QString Error;
+	if (!ProxyProfiles::Reveal(m_Profile, Input, Error)) return Error;
+	QHostAddress Endpoint(Input.Host);
+	if (Endpoint.protocol() != QAbstractSocket::IPv4Protocol) {
+		// Lookup is for the proxy endpoint, not a sandbox application's DNS request.
+		QEventLoop Loop;
+		QTimer Timeout, Cancel;
+		Timeout.setSingleShot(true);
+		connect(&Timeout, &QTimer::timeout, &Loop, &QEventLoop::quit);
+		connect(&Cancel, &QTimer::timeout, &Loop, [&]() { if (m_Stop.load()) Loop.quit(); });
+		const int Lookup = QHostInfo::lookupHost(Input.Host, &Loop, [&](const QHostInfo& Info) {
+			for (const auto& Candidate : Info.addresses()) {
+				if (Candidate.protocol() == QAbstractSocket::IPv4Protocol) { Endpoint = Candidate; break; }
+			}
+			Loop.quit();
+		});
+		Timeout.start(5000);
+		Cancel.start(100);
+		Loop.exec();
+		QHostInfo::abortHostLookup(Lookup);
+	}
+	if (m_Stop.load()) return QString();
+	if (Endpoint.protocol() != QAbstractSocket::IPv4Protocol) return tr("This prototype requires an IPv4-reachable proxy endpoint.");
+	Input.Host = Endpoint.toString();
+	NET_LUID OriginalHostRoute = {};
+	if (!BestHostRoute(OriginalHostRoute)) return tr("No usable host route exists. The tunnel will not become the host default.");
+	SOCKADDR_INET Destination = {};
+	Destination.Ipv4.sin_family = AF_INET;
+	Destination.Ipv4.sin_addr.S_un.S_addr = htonl(Endpoint.toIPv4Address());
+	MIB_IPFORWARD_ROW2 UpstreamRoute = {};
+	SOCKADDR_INET UpstreamSource = {};
+	DWORD Code = GetBestRoute2(nullptr, 0, nullptr, &Destination, 0, &UpstreamRoute, &UpstreamSource);
+	if (Code) return WinError("No route to the proxy endpoint", Code);
+	wchar_t UpstreamAlias[IF_MAX_STRING_SIZE + 1] = {};
+	Code = ConvertInterfaceLuidToAlias(&UpstreamRoute.InterfaceLuid, UpstreamAlias, IF_MAX_STRING_SIZE + 1);
+	if (Code) return WinError("Cannot identify the upstream interface", Code);
+	if (QString::fromWCharArray(UpstreamAlias).startsWith(QStringLiteral("SbieProxy-"), Qt::CaseInsensitive))
+		return tr("A managed tunnel cannot be used as the upstream interface of another tunnel.");
+	const std::wstring Alias = m_Profile.AdapterName().toStdWString();
+	NET_LUID Existing = {};
+	if (ConvertInterfaceAliasToLuid(Alias.c_str(), &Existing) == NO_ERROR)
+		return tr("An adapter already has this profile's name. It was not adopted, modified, or removed. Resolve the stale adapter before retrying.");
+	QLocalServer Server;
+	Server.setSocketOptions(QLocalServer::UserAccessOption);
+	const QString PipeName = QStringLiteral("SbieProxyConfig-") + QUuid::createUuid().toString(QUuid::WithoutBraces);
+	if (!Server.listen(PipeName)) return tr("Cannot create the private configuration pipe.");
+	SChild Child;
+	if (!Launch(Exe, Server.fullServerName(), Child, Error)) return Error;
+	QElapsedTimer Deadline;
+	Deadline.start();
+	while (!m_Stop.load() && Child.Alive() && Deadline.elapsed() < 10000 && !Server.hasPendingConnections()) Server.waitForNewConnection(100);
+	std::unique_ptr<QLocalSocket> Socket(Server.nextPendingConnection());
+	if (!Socket || m_Stop.load()) return tr("tun2socks did not open its private configuration pipe.");
+	ULONG ClientPid = 0;
+	if (!GetNamedPipeClientProcessId(HANDLE(Socket->socketDescriptor()), &ClientPid) || ClientPid != Child.Pid)
+		return tr("The configuration pipe peer is not the owned tunnel process. No credentials were sent.");
+	QJsonObject Config{{"device", m_Profile.AdapterName()}, {"proxy", ProxyProfiles::ProxyUrl(Input)},
+		{"interface", QString::fromWCharArray(UpstreamAlias)}, {"loglevel", "silent"}, {"mtu", 1500}};
+	QByteArray Bytes = QJsonDocument(Config).toJson(QJsonDocument::Compact); // JSON is valid YAML.
+	Input.Password.fill(QChar(0));
+	Input.Password.clear();
+	Input.User.clear();
+	Config = QJsonObject();
+	bool Sent = Socket->write(Bytes) == Bytes.size() && (!Socket->bytesToWrite() || Socket->waitForBytesWritten(3000));
+	Bytes.detach();
+	SecureZeroMemory(Bytes.data(), size_t(Bytes.size()));
+	Bytes.clear();
+	if (!Sent) return tr("Cannot deliver the tunnel configuration.");
+	Socket->disconnectFromServer();
+	if (Socket->state() != QLocalSocket::UnconnectedState) Socket->waitForDisconnected(3000);
+	Server.close();
+	SNetwork Network;
+	Deadline.restart();
+	while (!m_Stop.load() && Child.Alive() && Deadline.elapsed() < 15000) {
+		if (ConvertInterfaceAliasToLuid(Alias.c_str(), &Network.Luid) == NO_ERROR) break;
+		msleep(100);
+	}
+	if (m_Stop.load()) return QString();
+	if (!Child.Alive() || Network.Luid.Value == 0) return tr("The tunnel process exited or did not create its adapter. Child output was discarded to protect credentials.");
+	if (!Configure(Network, Error)) return Error;
+	NET_LUID HostRoute = {};
+	if (!BestHostRoute(HostRoute) || HostRoute.Value != OriginalHostRoute.Value)
+		return tr("The host's selected route changed. The owned tunnel route was rolled back; host routes were not rewritten.");
+	Deadline.restart();
+	while (!m_Stop.load() && Child.Alive() && !Network.Ready() && Deadline.elapsed() < 5000) msleep(100);
+	QElapsedTimer LastCheck;
+	LastCheck.start();
+	m_Check.store(true);
+	while (!m_Stop.load()) {
+		if (!Child.Alive()) return tr("The owned tunnel process exited unexpectedly. Sandbox bindings remain in place.");
+		if (!Network.Ready()) return tr("The tunnel adapter or its address disappeared, or unsupported IPv6 configuration was detected.");
+		if (!BestHostRoute(HostRoute) || HostRoute.Value != OriginalHostRoute.Value)
+			return tr("The host route changed. The tunnel was stopped rather than changing the host's preferred route.");
+		if (m_Check.exchange(false) || LastCheck.elapsed() >= 60000) {
+			emit StateChanged(m_Profile.Id, Checking, tr("Checking IPv4 TCP over this adapter; this is not a leak-proofness test."));
+			QString PublicAddress;
+			Error = CheckEgress(Network, m_Stop, PublicAddress);
+			if (!Error.isEmpty()) return Error;
+			emit EgressChecked(m_Profile.Id, PublicAddress);
+			emit StateChanged(m_Profile.Id, Running, tr("The adapter and owned process are active; the last IPv4 TCP check passed."));
+			LastCheck.restart();
+		}
+		msleep(100);
+	}
+	emit StateChanged(m_Profile.Id, Stopping, tr("Stopping the owned process and rolling back only this tunnel's IP configuration."));
+	return QString();
+#endif
+}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyTunnel.h
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyTunnel.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#pragma once
+#include "ProxyProfile.h"
+#include <QThread>
+#include <atomic>
+
+class CProxyTunnel : public QThread
+{
+	Q_OBJECT
+public:
+	enum EState { Stopped, Starting, Running, Checking, Stopping, Failed };
+	CProxyTunnel(const SProxyProfile& Profile, const QString& Directory, QObject* Parent = nullptr);
+	~CProxyTunnel() override;
+	void RequestStop() { m_Stop.store(true); requestInterruption(); }
+	void RequestCheck() { m_Check.store(true); }
+	static QString StateText(int State);
+
+signals:
+	void StateChanged(const QString& Id, int State, const QString& Message);
+	void EgressChecked(const QString& Id, const QString& Address);
+
+protected:
+	void run() override;
+
+private:
+	QString RunWindows();
+	SProxyProfile m_Profile;
+	QString m_Directory;
+	std::atomic<bool> m_Stop{false};
+	std::atomic<bool> m_Check{false};
+};

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.cpp
@@ -60,7 +60,7 @@ CProxyWindow::CProxyWindow(CProxyManager* Manager, QWidget* Parent) : QDialog(Pa
 	Layout->addWidget(m_Boxes, 2);
 	Buttons = new QHBoxLayout();
 	Layout->addLayout(Buttons);
-	AddButton(tr("Assign selected profile to selected sandboxes"), [this]() { Assign(false); });
+	m_ActivationButtons.append(AddButton(tr("Assign selected profile to selected sandboxes"), [this]() { Assign(false); }));
 	AddButton(tr("Detach selected sandboxes"), [this]() { Assign(true); });
 	AddButton(tr("Install dependencies"), [this]() { QString Message; if (!m_Manager->InstallDependencies(Message)) Error(Message); });
 	Buttons->addStretch();
@@ -100,6 +100,7 @@ QStringList CProxyWindow::Selected() const
 
 void CProxyWindow::Refresh()
 {
+	if (!isVisible()) return;
 	const QStringList ProfileSelection = Selected();
 	QStringList BoxSelection;
 	for (const auto Item : m_Boxes->selectedItems()) BoxSelection.append(Item->text(0));

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.cpp
@@ -9,6 +9,7 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QFormLayout>
+#include <QHostAddress>
 #include <QLineEdit>
 #include <QLabel>
 #include <QTreeWidget>
@@ -41,15 +42,16 @@ CProxyWindow::CProxyWindow(CProxyManager* Manager, QWidget* Parent) : QDialog(Pa
 		auto Button = new QPushButton(Text, this);
 		connect(Button, &QPushButton::clicked, this, [Action]() { Action(); });
 		Buttons->addWidget(Button);
+		return Button;
 	};
 	AddButton(tr("Add"), [this]() { Edit(true); });
 	AddButton(tr("Edit"), [this]() { Edit(false); });
 	AddButton(tr("Remove"), [this]() { Remove(); });
 	AddButton(tr("Import list"), [this]() { Import(); });
-	AddButton(tr("Start selected"), [this]() { Run(0, false); });
+	m_ActivationButtons.append(AddButton(tr("Start selected"), [this]() { Run(0, false); }));
 	AddButton(tr("Stop selected"), [this]() { Run(1, false); });
-	AddButton(tr("Check exit IP"), [this]() { Run(2, false); });
-	AddButton(tr("Start all"), [this]() { Run(0, true); });
+	m_ActivationButtons.append(AddButton(tr("Check exit IP"), [this]() { Run(2, false); }));
+	m_ActivationButtons.append(AddButton(tr("Start all"), [this]() { Run(0, true); }));
 	AddButton(tr("Stop all"), [this]() { Run(1, true); });
 	m_Boxes = new QTreeWidget(this);
 	m_Boxes->setHeaderLabels({tr("Sandbox"), tr("Proxy profile"), tr("Association status")});
@@ -65,8 +67,20 @@ CProxyWindow::CProxyWindow(CProxyManager* Manager, QWidget* Parent) : QDialog(Pa
 	AddButton(tr("Close"), [this]() { close(); });
 	connect(m_Manager, &CProxyManager::Changed, this, &CProxyWindow::Refresh);
 	connect(&m_Timer, &QTimer::timeout, this, &CProxyWindow::Refresh);
+	Refresh();
+}
+
+void CProxyWindow::showEvent(QShowEvent* Event)
+{
+	QDialog::showEvent(Event);
 	m_Timer.start(1000);
 	Refresh();
+}
+
+void CProxyWindow::hideEvent(QHideEvent* Event)
+{
+	m_Timer.stop();
+	QDialog::hideEvent(Event);
 }
 
 void CProxyWindow::Error(const QString& Message)
@@ -90,25 +104,36 @@ void CProxyWindow::Refresh()
 	QStringList BoxSelection;
 	for (const auto Item : m_Boxes->selectedItems()) BoxSelection.append(Item->text(0));
 	const QString Gate = m_Manager->ActivationError();
+	for (auto Button : m_ActivationButtons) {
+		Button->setEnabled(Gate.isEmpty());
+		Button->setToolTip(Gate);
+	}
 	m_Notice->setText(Gate.isEmpty()
 		? tr("Experimental IPv4 TCP tunnels. Profiles and associations are saved; running state is not. DNS/IPv6/UDP coverage is restricted. A successful IP check is not proof of leak protection.")
 		: tr("Activation unavailable: %1\nProfiles can still be reviewed. No tunnel is considered active just because its configuration is saved.").arg(Gate));
+	const QList<SProxyBox> Boxes = m_Manager->Boxes();
+	QMap<QString, QStringList> Users;
+	for (const SProxyBox& Box : Boxes) if (!Box.ProfileId.isEmpty()) Users[Box.ProfileId].append(Box.Name);
 	m_Profiles->clear();
 	QMap<QString, QString> Names;
 	for (const SProxyProfile& Profile : m_Manager->Profiles()) {
 		Names.insert(Profile.Id, Profile.Name);
 		const auto Runtime = m_Manager->Runtime(Profile.Id);
 		const QString Endpoint = Profile.Host.contains(':') ? QString("[%1]:%2").arg(Profile.Host).arg(Profile.Port) : QString("%1:%2").arg(Profile.Host).arg(Profile.Port);
+		const bool IPv6Only = QHostAddress(Profile.Host).protocol() == QAbstractSocket::IPv6Protocol;
+		const QString State = IPv6Only && Runtime.State == CProxyTunnel::Stopped
+			? tr("Stored only (laboratory backend requires IPv4 ingress)") : CProxyTunnel::StateText(Runtime.State);
 		QString Egress = Runtime.Egress;
 		if (!Egress.isEmpty()) Egress += "  " + Runtime.CheckedAt.toLocalTime().toString(Qt::ISODate);
 		auto Item = new QTreeWidgetItem(m_Profiles, {Profile.Name, Profile.Scheme + "://" + Endpoint,
-			CProxyTunnel::StateText(Runtime.State), Egress, m_Manager->Users(Profile.Id).join(", ")});
+			State, Egress, Users.value(Profile.Id).join(", ")});
 		Item->setData(0, Qt::UserRole, Profile.Id);
+		if (IPv6Only) Item->setToolTip(1, tr("This profile is valid for storage, but the laboratory backend requires an IPv4-reachable proxy endpoint."));
 		Item->setToolTip(2, Runtime.Detail.toHtmlEscaped());
 		Item->setSelected(ProfileSelection.contains(Profile.Id));
 	}
 	m_Boxes->clear();
-	for (const SProxyBox& Box : m_Manager->Boxes()) {
+	for (const SProxyBox& Box : Boxes) {
 		auto Item = new QTreeWidgetItem(m_Boxes, {Box.Name, Box.ProfileId.isEmpty() ? tr("Unassigned") : Names.value(Box.ProfileId, tr("Missing profile")), Box.Detail});
 		Item->setSelected(BoxSelection.contains(Box.Name));
 	}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.cpp
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.cpp
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#ifdef PROXY_TUNNELS_STANDALONE
+#include <QtCore>
+#else
+#include "stdafx.h"
+#endif
+#include "ProxyWindow.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QFormLayout>
+#include <QLineEdit>
+#include <QLabel>
+#include <QTreeWidget>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QDialogButtonBox>
+#include <QComboBox>
+#include <QSpinBox>
+#include <QPlainTextEdit>
+
+
+CProxyWindow::CProxyWindow(CProxyManager* Manager, QWidget* Parent) : QDialog(Parent), m_Manager(Manager)
+{
+	setWindowTitle(tr("Proxy tunnels (experimental)"));
+	resize(1000, 620);
+	auto Layout = new QVBoxLayout(this);
+	m_Notice = new QLabel(this);
+	m_Notice->setTextFormat(Qt::PlainText);
+	m_Notice->setWordWrap(true);
+	Layout->addWidget(m_Notice);
+	m_Profiles = new QTreeWidget(this);
+	m_Profiles->setHeaderLabels({tr("Profile"), tr("Endpoint"), tr("State"), tr("Last IPv4 TCP exit check"), tr("Sandboxes")});
+	m_Profiles->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	m_Profiles->setRootIsDecorated(false);
+	m_Profiles->setAllColumnsShowFocus(true);
+	Layout->addWidget(m_Profiles, 3);
+	auto Buttons = new QHBoxLayout();
+	Layout->addLayout(Buttons);
+	auto AddButton = [&](const QString& Text, std::function<void()> Action) {
+		auto Button = new QPushButton(Text, this);
+		connect(Button, &QPushButton::clicked, this, [Action]() { Action(); });
+		Buttons->addWidget(Button);
+	};
+	AddButton(tr("Add"), [this]() { Edit(true); });
+	AddButton(tr("Edit"), [this]() { Edit(false); });
+	AddButton(tr("Remove"), [this]() { Remove(); });
+	AddButton(tr("Import list"), [this]() { Import(); });
+	AddButton(tr("Start selected"), [this]() { Run(0, false); });
+	AddButton(tr("Stop selected"), [this]() { Run(1, false); });
+	AddButton(tr("Check exit IP"), [this]() { Run(2, false); });
+	AddButton(tr("Start all"), [this]() { Run(0, true); });
+	AddButton(tr("Stop all"), [this]() { Run(1, true); });
+	m_Boxes = new QTreeWidget(this);
+	m_Boxes->setHeaderLabels({tr("Sandbox"), tr("Proxy profile"), tr("Association status")});
+	m_Boxes->setSelectionMode(QAbstractItemView::ExtendedSelection);
+	m_Boxes->setRootIsDecorated(false);
+	Layout->addWidget(m_Boxes, 2);
+	Buttons = new QHBoxLayout();
+	Layout->addLayout(Buttons);
+	AddButton(tr("Assign selected profile to selected sandboxes"), [this]() { Assign(false); });
+	AddButton(tr("Detach selected sandboxes"), [this]() { Assign(true); });
+	AddButton(tr("Install dependencies"), [this]() { QString Message; if (!m_Manager->InstallDependencies(Message)) Error(Message); });
+	Buttons->addStretch();
+	AddButton(tr("Close"), [this]() { close(); });
+	connect(m_Manager, &CProxyManager::Changed, this, &CProxyWindow::Refresh);
+	connect(&m_Timer, &QTimer::timeout, this, &CProxyWindow::Refresh);
+	m_Timer.start(1000);
+	Refresh();
+}
+
+void CProxyWindow::Error(const QString& Message)
+{
+	QMessageBox Box(QMessageBox::Warning, tr("Proxy tunnels"), QString(), QMessageBox::Ok, this);
+	Box.setTextFormat(Qt::PlainText);
+	Box.setText(Message);
+	Box.exec();
+}
+
+QStringList CProxyWindow::Selected() const
+{
+	QStringList Ids;
+	for (const auto Item : m_Profiles->selectedItems()) Ids.append(Item->data(0, Qt::UserRole).toString());
+	return Ids;
+}
+
+void CProxyWindow::Refresh()
+{
+	const QStringList ProfileSelection = Selected();
+	QStringList BoxSelection;
+	for (const auto Item : m_Boxes->selectedItems()) BoxSelection.append(Item->text(0));
+	const QString Gate = m_Manager->ActivationError();
+	m_Notice->setText(Gate.isEmpty()
+		? tr("Experimental IPv4 TCP tunnels. Profiles and associations are saved; running state is not. DNS/IPv6/UDP coverage is restricted. A successful IP check is not proof of leak protection.")
+		: tr("Activation unavailable: %1\nProfiles can still be reviewed. No tunnel is considered active just because its configuration is saved.").arg(Gate));
+	m_Profiles->clear();
+	QMap<QString, QString> Names;
+	for (const SProxyProfile& Profile : m_Manager->Profiles()) {
+		Names.insert(Profile.Id, Profile.Name);
+		const auto Runtime = m_Manager->Runtime(Profile.Id);
+		const QString Endpoint = Profile.Host.contains(':') ? QString("[%1]:%2").arg(Profile.Host).arg(Profile.Port) : QString("%1:%2").arg(Profile.Host).arg(Profile.Port);
+		QString Egress = Runtime.Egress;
+		if (!Egress.isEmpty()) Egress += "  " + Runtime.CheckedAt.toLocalTime().toString(Qt::ISODate);
+		auto Item = new QTreeWidgetItem(m_Profiles, {Profile.Name, Profile.Scheme + "://" + Endpoint,
+			CProxyTunnel::StateText(Runtime.State), Egress, m_Manager->Users(Profile.Id).join(", ")});
+		Item->setData(0, Qt::UserRole, Profile.Id);
+		Item->setToolTip(2, Runtime.Detail.toHtmlEscaped());
+		Item->setSelected(ProfileSelection.contains(Profile.Id));
+	}
+	m_Boxes->clear();
+	for (const SProxyBox& Box : m_Manager->Boxes()) {
+		auto Item = new QTreeWidgetItem(m_Boxes, {Box.Name, Box.ProfileId.isEmpty() ? tr("Unassigned") : Names.value(Box.ProfileId, tr("Missing profile")), Box.Detail});
+		Item->setSelected(BoxSelection.contains(Box.Name));
+	}
+	for (int i = 0; i < m_Profiles->columnCount(); ++i) m_Profiles->resizeColumnToContents(i);
+	for (int i = 0; i < m_Boxes->columnCount(); ++i) m_Boxes->resizeColumnToContents(i);
+}
+
+void CProxyWindow::Edit(bool Add)
+{
+	QString Id, Message;
+	SProxyInput Input;
+	if (!Add) {
+		const QStringList Ids = Selected();
+		if (Ids.size() != 1) { Error(tr("Select exactly one profile to edit.")); return; }
+		Id = Ids.first();
+		for (const auto& Profile : m_Manager->Profiles()) {
+			if (Profile.Id == Id && !ProxyProfiles::Reveal(Profile, Input, Message))
+				Error(Message + tr("\nRe-enter the credentials. Saving will replace the unavailable protected authentication."));
+		}
+	}
+	QDialog Dialog(this);
+	Dialog.setWindowTitle(Add ? tr("Add proxy profile") : tr("Edit proxy profile"));
+	auto Layout = new QFormLayout(&Dialog);
+	QLineEdit Name(Input.Name), Host(Input.Host), User(Input.User), Password(Input.Password);
+	QComboBox Scheme; Scheme.addItems({"socks5", "http"}); Scheme.setCurrentText(Input.Scheme);
+	QSpinBox Port; Port.setRange(1, 65535); Port.setValue(Input.Port);
+	Password.setEchoMode(QLineEdit::Password);
+	Layout->addRow(tr("Name"), &Name); Layout->addRow(tr("Protocol"), &Scheme);
+	Layout->addRow(tr("Server"), &Host); Layout->addRow(tr("Port"), &Port);
+	Layout->addRow(tr("Username"), &User); Layout->addRow(tr("Password"), &Password);
+	QLabel Notice(tr("Authentication is protected for this Windows user, not stored as plaintext. SOCKS5/HTTP authentication is not inherently encrypted on the network."));
+	Notice.setWordWrap(true); Layout->addRow(&Notice);
+	QDialogButtonBox Buttons(QDialogButtonBox::Save | QDialogButtonBox::Cancel);
+	Layout->addRow(&Buttons);
+	connect(&Buttons, &QDialogButtonBox::rejected, &Dialog, &QDialog::reject);
+	connect(&Buttons, &QDialogButtonBox::accepted, &Dialog, [&]() {
+		Input.Name = Name.text(); Input.Scheme = Scheme.currentText(); Input.Host = Host.text();
+		Input.Port = Port.value(); Input.User = User.text(); Input.Password = Password.text();
+		if (!m_Manager->SaveProfile(Input, Id, Message)) { Error(Message); return; }
+		Dialog.accept();
+	});
+	Dialog.exec();
+	Password.clear(); User.clear(); Input.Password.fill(QChar(0)); Input.User.clear();
+}
+
+void CProxyWindow::Import()
+{
+	QDialog Dialog(this); Dialog.setWindowTitle(tr("Import proxy list")); Dialog.resize(650, 430);
+	auto Layout = new QVBoxLayout(&Dialog);
+	QLabel Help(tr("One entry per line: host:port, host:port:user:password, or socks5:// / http:// URLs. Use brackets for IPv6 and percent-encoding for special URL credentials. Invalid lines are reported by number without echoing secrets."));
+	Help.setWordWrap(true); Layout->addWidget(&Help);
+	QPlainTextEdit Text; Layout->addWidget(&Text);
+	QDialogButtonBox Buttons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel); Layout->addWidget(&Buttons);
+	connect(&Buttons, &QDialogButtonBox::rejected, &Dialog, &QDialog::reject);
+	connect(&Buttons, &QDialogButtonBox::accepted, &Dialog, [&]() {
+		QList<SProxyImportError> Errors; int Added = 0; QString Message;
+		const bool Saved = m_Manager->Import(Text.toPlainText(), Errors, Added, Message);
+		QString Report = Saved ? tr("Saved %1 profiles.").arg(Added) : Message;
+		for (int i = 0; i < qMin(100, int(Errors.size())); ++i) Report += tr("\nLine %1: %2").arg(Errors[i].Line).arg(Errors[i].Reason);
+		if (Errors.size() > 100) Report += tr("\n%1 additional invalid lines.").arg(Errors.size() - 100);
+		Error(Report);
+		if (Saved) Dialog.accept();
+	});
+	Dialog.exec(); Text.clear();
+}
+
+void CProxyWindow::Remove()
+{
+	const auto Ids = Selected();
+	if (Ids.isEmpty()) { Error(tr("Select a profile first.")); return; }
+	if (QMessageBox::question(this, tr("Remove profiles"), tr("Remove the selected profiles? Assigned profiles cannot be removed.")) != QMessageBox::Yes) return;
+	QStringList Errors;
+	for (const auto& Id : Ids) { QString Message; if (!m_Manager->Remove(Id, Message)) Errors.append(Message); }
+	if (!Errors.isEmpty()) Error(Errors.join('\n'));
+}
+
+void CProxyWindow::Run(int Action, bool All)
+{
+	QStringList Ids = Selected();
+	if (All) { Ids.clear(); for (const auto& Profile : m_Manager->Profiles()) Ids.append(Profile.Id); }
+	if (Ids.isEmpty()) { Error(tr("Select a profile first.")); return; }
+	QStringList Errors;
+	for (const auto& Id : Ids) {
+		if (Action == 1) m_Manager->Stop(Id);
+		else if (Action == 2) m_Manager->Check(Id);
+		else { QString Message; if (!m_Manager->Start(Id, Message)) Errors.append(Message); }
+	}
+	Errors.removeDuplicates(); if (!Errors.isEmpty()) Error(Errors.join('\n'));
+}
+
+void CProxyWindow::Assign(bool Detach)
+{
+	QString Id;
+	if (!Detach) { const auto Ids = Selected(); if (Ids.size() != 1) { Error(tr("Select one proxy profile.")); return; } Id = Ids.first(); }
+	QStringList Boxes;
+	for (auto Item : m_Boxes->selectedItems()) Boxes.append(Item->text(0));
+	if (Boxes.isEmpty()) { Error(tr("Select one or more sandboxes.")); return; }
+	if (QMessageBox::question(this, tr("Change sandbox network association"), Detach
+		? tr("Detach these stopped sandboxes? Removing the tunnel binding permits the normal host connection again, subject to other sandbox rules.")
+		: tr("Associate these stopped sandboxes with the selected profile? The experimental guard blocks ordinary DNS, UDP, and ICMP. Applications need their own tunneled encrypted DNS. Read the coverage document first.")) != QMessageBox::Yes) return;
+	QStringList Errors;
+	for (const auto& Box : Boxes) { QString Message; if (!m_Manager->Assign(Box, Id, Message)) Errors.append(Box + ": " + Message); }
+	if (!Errors.isEmpty()) Error(Errors.join('\n'));
+}

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.h
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+// See ../LICENSE for the SandMan license.
+#pragma once
+#include <QDialog>
+#include "ProxyManager.h"
+class QTreeWidget;
+class QLabel;
+class CProxyWindow : public QDialog
+{
+	Q_OBJECT
+public:
+	explicit CProxyWindow(CProxyManager* Manager, QWidget* Parent = nullptr);
+private:
+	void Refresh();
+	void Edit(bool Add);
+	void Import();
+	void Remove();
+	void Run(int Action, bool All);
+	void Assign(bool Detach);
+	void Error(const QString& Message);
+	QStringList Selected() const;
+	CProxyManager* m_Manager;
+	QTreeWidget* m_Profiles;
+	QTreeWidget* m_Boxes;
+	QLabel* m_Notice;
+	QTimer m_Timer;
+};

--- a/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.h
+++ b/SandboxiePlus/SandMan/ProxyTunnels/ProxyWindow.h
@@ -5,12 +5,17 @@
 #include "ProxyManager.h"
 class QTreeWidget;
 class QLabel;
+class QPushButton;
+class QShowEvent;
+class QHideEvent;
 class CProxyWindow : public QDialog
 {
 	Q_OBJECT
 public:
 	explicit CProxyWindow(CProxyManager* Manager, QWidget* Parent = nullptr);
 private:
+	void showEvent(QShowEvent* Event) override;
+	void hideEvent(QHideEvent* Event) override;
 	void Refresh();
 	void Edit(bool Add);
 	void Import();
@@ -24,4 +29,5 @@ private:
 	QTreeWidget* m_Boxes;
 	QLabel* m_Notice;
 	QTimer m_Timer;
+	QList<QPushButton*> m_ActivationButtons;
 };

--- a/SandboxiePlus/SandMan/ProxyTunnels/docs/DEPENDENCIES.md
+++ b/SandboxiePlus/SandMan/ProxyTunnels/docs/DEPENDENCIES.md
@@ -1,0 +1,69 @@
+# Dependency provenance and packaging proposal
+
+No executable from `Artjosh/tun2proxy-bindsandboxie` was executed, reused or trusted.
+The reference has no provenance sufficient to treat its bundled EXE/DLL as our
+release dependency. This patch contains no tunnel binary.
+
+## Inspected official artifacts
+
+- tun2socks **v2.7.0**, official release published July 12, 2026:
+  https://github.com/xjasonlyu/tun2socks/releases/tag/v2.7.0
+- The matching official source archive was inspected (`main.go`, engine/device
+  paths, key parsing and license). The source archive directory identifies commit
+  prefix `8dda19e`. Source-to-binary reproducibility was not established.
+- Wintun **0.14.1**, https://www.wintun.net/ and
+  https://www.wintun.net/builds/wintun-0.14.1.zip
+- Wintun archive SHA-256:
+  `07c256185d6ee3652e09fa55c0b673e2624b565e02c4b9091c79ca7d2f24ef51`
+
+The official versioned downloads were inspected by this Windows Actions run:
+https://github.com/Kizuno18/sbxie/actions/runs/34013729680
+
+That job compared each tun2socks ZIP to the official release asset digest, checked
+the Wintun ZIP hash, hashed the extracted executables/DLLs and used Windows
+`Get-AuthenticodeSignature` on the Wintun DLLs. All four Wintun architecture DLLs
+reported `Valid` with WireGuard LLC as signer. The job did not execute tun2socks,
+install Wintun, configure an adapter or run traffic through a tunnel.
+
+| Artifact | ZIP SHA-256 | Executable SHA-256 |
+|---|---|---|
+| tun2socks Windows amd64 | `c5d46e9452f6c9cc7c15ab9158d6d6a0169ceecd6bca019ce476b49337d2be43` | `076b3c3d6a372bae3f49f2b415a4105f70c30a3ed3caaed7979390e649892559` |
+| tun2socks Windows arm64 | `74497771068da13f42921adfc540f2abb9ac822404582c8cbe34d30e8c0ea1f5` | `559eb3ee0935f628a6ab9952976b30ca7c3706dfe5fd9f1095fbe5692f3a13fa` |
+| tun2socks Windows 386 | `ad870a2ca99d617e004ec09f8f5cca2c134b4d16ae12b4eac0ff6d9fe05d9044` | `bd964c932ca9969026f3ff47790d614f10186536c2e1330dc5cb4352f589cfa5` |
+
+| Wintun DLL architecture | SHA-256 |
+|---|---|
+| amd64 | `e5da8447dc2c320edc0fc52fa01885c103de8c118481f683643cacc3220dafce` |
+| arm64 | `f7ba89005544be9d85231a9e0d5f23b2d15b3311667e2dad0debd344918a3f80` |
+| x86 | `d694fa46ab4cfebcb2632d094c7aa97278eef2f8052438621766d863ae98a931` |
+
+The laboratory backend pins the extracted file hashes in compiled source and holds
+non-write-sharing read handles across their use. It does not accept an arbitrary
+executable path, current-directory fallback, renamed reference binary or a new
+hash from a user-editable manifest. Hash/signature verification proves artifact
+identity under those trust assumptions, not the absence of upstream defects.
+
+## Licenses and integration
+
+The official tun2socks license is MIT (Jason Lyu); package that notice with the
+binary and consider transitive dependency notices. SandMan retains its own custom
+license; this feature is not a relicensing of SandMan or the core.
+
+Wintun source is GPLv2, but the **official prebuilt archive** contains its own
+`LICENSE.txt` redistribution terms. Do not replace those terms with a generic
+“MIT/GPL” label. Review and preserve that exact notice and the unmodified DLLs, use
+only the permitted API, and package alongside the application using the driver.
+This inspection does not constitute a complete legal review of a distributable
+add-on. No Wintun binary or copied source is bundled in the patch.
+
+The intended package ID is `ProxyTunnels`; the proposed installation directory is
+`Addons/ProxyTunnels` below the application directory, containing architecture-
+matched `tun2socks.exe`, `wintun.dll` and notices. This is a proposal, **not an
+existing published add-on**. The button delegates to `CAddonManager` and its normal
+updater/consent/progress path only when the catalog actually contains the package;
+otherwise it reports the missing package without downloading anything.
+
+Before publication, maintainers must approve packaging, catalog/update trust,
+architecture selection, supported Windows versions, license notices and hash
+updates. A privileged installation directory and pinned files should not replace
+an actual installer security review. No unsigned reference executable is a fallback.

--- a/SandboxiePlus/SandMan/ProxyTunnels/docs/README.md
+++ b/SandboxiePlus/SandMan/ProxyTunnels/docs/README.md
@@ -1,0 +1,176 @@
+# Native proxy profiles and tunnel review prototype
+
+**Status: experimental review prototype, not a completed feature.**
+The normal build exposes a native Qt profile panel, but deliberately refuses tunnel
+activation and sandbox reassignment. Do not present this code as leak protection.
+
+Baseline reviewed: `00ae8850d681962cf1864055c551faaf3ba77770` in
+`Kizuno18/sbxie` / `sandboxie-plus/Sandboxie`, September 6, 2026.
+The root `AGENTS.md`, contribution/build instructions, relevant SandMan/QSbieAPI,
+network DLL hooks, DNS hooks, templates, dependency/add-on and build code were read.
+The reference Go implementation was inspected, not copied or executed.
+
+## Components and intended data path
+
+```text
+SandMan (Qt widgets)
+  -> CProxyManager (profiles, independent runtime state, batches, ownership lock)
+  -> CProxyIntegration (QSbieAPI / permissions / certificates / add-ons)
+  -> CProxyTunnel worker (Windows laboratory backend, disabled by default)
+
+Box A ---- BindAdapter=SbieProxy-<UUID-A> ---- virtual adapter A ---- proxy A
+Box B --+-- BindAdapter=SbieProxy-<UUID-B> ---- virtual adapter B ---- proxy B
+Box C --+
+```
+
+`ProxyProfile` validates imports and stores name, protocol, server, port, UUID and a
+current-user DPAPI-protected authentication blob. Usernames and passwords are both
+inside that blob. Endpoint equality never deduplicates profiles: even identical
+server/port/authentication inputs receive independent UUIDs. The adapter alias is
+stable across profile edits; deleting an associated profile is rejected.
+
+`ProxyProfiles.json` is in the existing SandMan configuration directory, not a new
+registry/INI backend. `QSaveFile` replaces the whole profile set atomically, without
+direct-write fallback. Invalid/corrupt files and unavailable locks make the store
+read-only; the original file is retained. A `QLockFile` prevents two controllers
+using the same profile store concurrently. No PID, live adapter observation, exit
+IP or running status is persisted. SandMan restart starts all profiles as stopped.
+It does not adopt processes or adapters from persisted names/PIDs.
+
+The window provides add/edit/remove, a validated batch import with line-specific
+errors, selected/all start/stop commands, an adapter-bound exit check command and
+both directions of the profile/sandbox mapping. The controller is testable with a
+worker factory and explicit integration callbacks. Production callbacks always use
+SandMan, never a localhost HTTP service. Closing the panel does not close the
+controller. SandMan shutdown cancels and joins its workers.
+
+Assignments use existing `BindAdapter` values as the authority, not a second
+independently persisted association map. Multiple boxes may reference one UUID.
+Existing process-specific, inherited, built-in proxy or direct-IP bindings are not
+silently overwritten. Changing a box requires it to have no running processes and
+uses the existing authenticated configuration API. Every write status is checked;
+partial writes leave restrictive rules and display an error, rather than rolling
+back to unprotected direct access. This is not a transaction against concurrent
+launchers or external INI edits; those races require Windows qualification.
+
+## Scope and release gate
+
+No driver change, new privileged service, local HTTP server, HWID spoofing, process
+whitelisting or IP-reputation feature is included. Two small companion changes are
+present: retain an unavailable NIC in the existing network-options combo, and
+propagate `bind()` errors before marking the socket bound. The latter touches the
+user-mode hook DLL and still requires its Windows regression/build tests.
+
+`SBIE_PROXY_TUNNELS_LAB` is an intentionally absent compile-time definition. It is not
+an INI setting or a UI preference. A normal build cannot launch a tunnel or change
+box associations through this panel. The source behind that laboratory gate is a
+proposal for review on an isolated Windows test machine, not a supported opt-in
+feature. Do not ship with the gate enabled until the blockers below are resolved.
+
+### Blockers before activation can be enabled
+
+1. **Host routing invariant.** The proposed backend adds an on-link `0.0.0.0/0`
+   route on the TUN interface, with a high metric and a `/32` SkipAsSource address.
+   This is still a route in the global Windows table. Checking that the selected
+   route to `1.1.1.1` remains unchanged does not prove every host destination,
+   protocol, compartment or uplink-failure path remains unaffected. It must not be
+   described as satisfying a strict “never change host output” requirement. Prove
+   an adequate source/interface-specific design, or redesign this part before
+   enabling it. The prototype never rewrites the host's routes to “fix” selection.
+2. **Adapter ownership.** The official child creates Wintun. Observing a new unique
+   alias, recording its LUID/GUID and rejecting a pre-existing alias does not prove
+   ownership in a concurrent creation race. A stronger ownership handshake/native
+   helper contract is needed before configuring that adapter. Cleanup never calls
+   `Remove-NetAdapter`, removes by name prefix, or deletes the Wintun driver.
+3. **Named-pipe configuration.** The official helper reads a path with Go
+   `os.ReadFile`. The proposed current-user-only, PID-checked Windows named pipe
+   keeps credentials out of disk files and the command line, but actual Go/Qt
+   pipe open, EOF, cancellation and peer validation behavior has not been tested.
+   Do not fall back to a plaintext temporary YAML file or command-line secrets.
+4. **DNS and non-hooked traffic.** The restrictive template is not a complete
+   transparent DNS implementation. See the coverage matrix. License/WFP changes,
+   cached socket state, raw APIs and brokered services require explicit tests.
+5. **Distribution and compatibility.** No official `ProxyTunnels` add-on entry has
+   been published by this change. MSVC/Qt6, Win32/x64/ARM64 and actual helper OS
+   requirements remain unqualified. Do not drop the main application's Windows 7
+   compatibility just to support a dependency built with a newer Go toolchain.
+
+## Coverage matrix
+
+The statuses describe design intent behind the laboratory gate, not proven
+end-to-end guarantees. In a normal build the backend is disabled for all traffic.
+
+| Traffic/path | Laboratory design | Actual validation |
+|---|---|---|
+| IPv4 TCP via intercepted Winsock | Strict BindAdapter to an IPv4 TUN, then SOCKS5 or HTTP CONNECT | Code inspected; no Windows packets tested |
+| Shared profile across boxes | One runtime UUID/adapter/worker; many BindAdapter references | Controller mapping/lifecycle tested using fake workers |
+| Public exit-IP check | No system proxy; bind TUN source plus IP_UNICAST_IF; numeric HTTPS endpoint; verify TLS | Source implemented; actual route and TLS test not executed |
+| Ordinary DNS / port 53 | Wildcard NetworkDnsFilter, DNSResolver IPC closure, TCP/UDP port-53 block | Template/source analysis only; not universal DNS interception |
+| App-owned DoH/DoT over TCP | May traverse the same tunnel with a suitable bootstrap configuration | Not validated; application-specific setup still required |
+| UDP, including QUIC and normal UDP DNS | Intended block through existing WFP NetworkAccess rules, even for SOCKS5 | Real filtering and IPv6 variants not tested |
+| IPv6 application traffic | No usable IPv6 TUN address; StrictBindIP should reject covered Winsock paths | Not a kernel-wide IPv6 guarantee; untested |
+| IPv6-only proxy ingress | Profiles parse and persist; laboratory backend requires an IPv4-reachable endpoint | Not supported for execution |
+| ICMP / raw sockets / non-Winsock APIs | ICMP block proposed; no full raw/bypass interception claim | Unvalidated; release blocker |
+| Brokered/out-of-box services | Not automatically attributable to or routed with the box | Outside the demonstrated coverage |
+| Host DNS for proxy ingress hostname | Explicit host-side bootstrap lookup for the proxy server itself | Intentional; distinct from sandbox application DNS |
+
+`BindAdapter` is a user-mode hook mechanism, with positive adapter-validity caching
+and existing socket-state behavior. A passed IP check is only a bounded IPv4 TCP
+sample at a timestamp. It proves neither DNS/IPv6 coverage nor an enforcement
+boundary against a hostile sandbox process, external privileged actor, policy edit
+or certificate expiry. Periodic health polling is not a kernel kill switch.
+
+## Runtime failure handling in the proposal
+
+Only handles returned by the manager's own suspended `CreateProcessW` call may be
+terminated. The child is assigned to a kill-on-job-close job before being resumed;
+only an explicit NUL handle is inherited. No process enumeration, process-name kill,
+PID-file adoption or port eviction exists. Child output is discarded because it
+could include the proxy URL. UI/log errors are stage names and numeric Windows
+codes, never command lines, input lines, usernames or passwords.
+
+The laboratory worker checks child liveness, adapter/address state, the sampled
+host route, and a bounded HTTPS probe; probe failure stops the owned runtime.
+Configuration delivery/startup are bounded, and cancellation is cooperative.
+SandMan does not clear `BindAdapter` or the guard on stop, timeout or child failure.
+Tunnels are never silently restarted as direct host connections.
+
+Normal cleanup tracks exactly the address/route it created, with LUID/GUID checks,
+not every object on an interface. The helper owns the adapter lifetime. Abrupt
+process termination and driver cleanup behavior have not been qualified. A stale
+alias is refused instead of adopted/deleted; automatic stale-adapter recovery is
+therefore **not complete**. Host interfaces changing underneath a tunnel are also
+unqualified. These are reasons to retain the release gate, not just UI warnings.
+
+## Credentials
+
+DPAPI is current-user scoped with the profile UUID as entropy. There is no
+plaintext fallback on Linux, decryption failure or a different Windows identity.
+Copying the JSON to another user/machine does not provide a working password store;
+the edit dialog permits explicit credential replacement. DPAPI does not protect
+against a process already running as the same user, an administrator, process
+memory inspection, Qt implicit-sharing copies, paging or crash dumps. Best-effort
+buffer wiping is not a claim of complete memory erasure. SOCKS5 and HTTP proxy
+credentials are not inherently encrypted on the network; use trusted transport.
+
+## Build and tests
+
+The existing qmake and Visual Studio projects include the new sources and Crypt32.
+Main-app dependency versions are unchanged. These project edits and the native
+QSbieAPI bridge were not compiled with MSVC in this environment.
+
+For the isolated profile/controller/widget tests, with a supported Qt SDK:
+
+```sh
+cmake -S SandboxiePlus/SandMan/Tests/ProxyTunnels -B build/proxy-tests
+cmake --build build/proxy-tests --config Release
+ctest --test-dir build/proxy-tests -C Release --output-on-failure
+```
+
+The CMake recipe is supplied for reproduction. Here the same sources were compiled
+with GCC, the downloaded Debian Qt 5.15.15 development headers/tools and installed
+Qt runtime, using `-Wall -Wextra -Werror`. The Qt widget smoke test ran offscreen.
+Test evidence is in the delivery package. See `VALIDATION.md` for what was and was
+not executed. The test factory is in-process; it does not pretend to exercise
+Wintun or a real proxy. CI dependency/tool acquisition success is not a SandMan
+build result.

--- a/SandboxiePlus/SandMan/ProxyTunnels/docs/README.md
+++ b/SandboxiePlus/SandMan/ProxyTunnels/docs/README.md
@@ -2,7 +2,9 @@
 
 **Status: experimental review prototype, not a completed feature.**
 The normal build exposes a native Qt profile panel, but deliberately refuses tunnel
-activation and sandbox reassignment. Do not present this code as leak protection.
+activation and new sandbox assignments. It permits a confirmed recovery detach for
+a stopped sandbox with a local managed binding. Do not present this code as leak
+protection.
 
 Baseline reviewed: `00ae8850d681962cf1864055c551faaf3ba77770` in
 `Kizuno18/sbxie` / `sandboxie-plus/Sandboxie`, September 6, 2026.
@@ -62,10 +64,12 @@ propagate `bind()` errors before marking the socket bound. The latter touches th
 user-mode hook DLL and still requires its Windows regression/build tests.
 
 `SBIE_PROXY_TUNNELS_LAB` is an intentionally absent compile-time definition. It is not
-an INI setting or a UI preference. A normal build cannot launch a tunnel or change
-box associations through this panel. The source behind that laboratory gate is a
-proposal for review on an isolated Windows test machine, not a supported opt-in
-feature. Do not ship with the gate enabled until the blockers below are resolved.
+an INI setting or a UI preference. A normal build cannot launch a tunnel or create
+new box associations through this panel; it only permits removal of a local managed
+association so a stopped sandbox can recover from a broken configuration. The
+source behind that laboratory gate is a proposal for review on an isolated Windows
+test machine, not a supported opt-in feature. Do not ship with the gate enabled
+until the blockers below are resolved.
 
 ### Blockers before activation can be enabled
 

--- a/SandboxiePlus/SandMan/ProxyTunnels/docs/VALIDATION.md
+++ b/SandboxiePlus/SandMan/ProxyTunnels/docs/VALIDATION.md
@@ -79,6 +79,7 @@ a successful Sandboxie build or successful packet-flow test.
 | DNS matrix | GetAddrInfo, DNS APIs, resolver service, browser DoH/DoT, TCP/UDP 53 packet capture | Not executed |
 | IPv4/IPv6/UDP/QUIC/ICMP/raw | Explicit support/block coverage, including pre-existing and nonblocking sockets | Not executed |
 | Cert/WFP/admin/settings changes | Respect existing gates without a temporary direct-network escape | Source/fake-policy review only |
+| Managed detach recovery | Binding removal, local guard cleanup, inherited guard preservation, retry after partial failure | Manager gate covered with a fake hook; SandMan integration path not executed |
 | Offline adapter in options | Saving unrelated settings retains BindAdapter, including inherited/process cases | Code reviewed; Windows UI not run |
 | Stale adapter recovery | Automatic, ownership-proven recovery without manual adapter management | Not implemented/qualified |
 

--- a/SandboxiePlus/SandMan/ProxyTunnels/docs/VALIDATION.md
+++ b/SandboxiePlus/SandMan/ProxyTunnels/docs/VALIDATION.md
@@ -1,0 +1,79 @@
+# Validation record — September 6, 2026
+
+## Executed locally
+
+Environment: Debian 13, x86-64, GCC 14.2.0, Qt/QtTest 5.15.15. Qt development tools
+were acquired as official Debian packages using the fork's read-only Actions
+preparation workflow; existing runtime libraries were used locally.
+
+Compiled the actual profile, controller, default-gated tunnel and widget sources
+with `-std=c++17 -fPIC -Wall -Wextra -Werror`, plus Qt meta-object output. Ran the
+Qt test executable with the offscreen widget platform.
+
+**Latest result: 44 passed, 0 failed, 1 skipped.** Qt's total includes setup and
+cleanup, data-driven parser rows and controller/widget cases; it is not a count
+of 44 independent Windows network experiments.
+
+Covered by executed tests:
+
+- SOCKS5/HTTP and legacy import parsing, bracketed IPv6, IDN, URL encoding, invalid
+  ports/hosts/protocols, wildcard/multicast/broadcast addresses, credential/control
+  limits, line-specific errors, partial import and the 1000-profile cap.
+- Different sessions/endpoints are not deduplicated by host. Separately created
+  equal endpoints also receive distinct persistent UUIDs and adapter names.
+- Atomic profile round trips, rejected duplicate IDs/invalid JSON fields, failed
+  writes, corruption preservation, exclusive store lock and absence of persisted
+  running/PID/password fields.
+- Refusal of authenticated storage on Linux, without a plaintext fallback.
+- One fake worker shared by two sandbox associations, duplicate-start rejection,
+  edits/deletes rejected while in use, simulated worker failure, immediate stop,
+  retry after failure, policy revocation, batch stop and joined shutdown.
+- Manager reconstruction retains profiles and external association fixtures but
+  does not restore running state or adopt a worker.
+- Default real worker implementation refuses activation; no exit result is emitted.
+- Native Qt window construction and its profile-to-two-box display.
+
+The single skipped case is the **Windows DPAPI round trip/tamper test**. Its Linux
+refusal assertion ran before the skip. Do not record DPAPI encryption/decryption
+as executed successfully on Windows.
+
+Static checks executed: `git diff --check`; XML parsing of both Visual Studio
+project files; resolution of all ten new source/header entries in each; comparison
+of all six compiled dependency file-hash pins with the actual downloaded official
+artifacts. The patch was also checked for application to its clean baseline.
+
+## Executed using Windows Actions
+
+The dependency inspection job downloaded official tun2socks v2.7.0 artifacts and
+Wintun 0.14.1. It checked archive SHA-256 values, computed extracted hashes and
+validated Wintun Authenticode signatures. See `DEPENDENCIES.md` and the included
+inspection JSON for provenance. **This did not compile the feature or run a tunnel.**
+
+Source/toolchain archival jobs also completed. A green preparation workflow is not
+a successful Sandboxie build or successful packet-flow test.
+
+## Not executed / required before removing the release gate
+
+| Required experiment | Acceptance criteria | Current result |
+|---|---|---|
+| Full SandMan Qt6/MSVC build | Clean qmake/Jom and VS builds, x64/Win32/ARM64 | Not executed |
+| Core hook DLL build/regression | Win32/x64/ARM64/ARM64EC as applicable; sandbox start/process/file recovery unaffected | Not executed |
+| Real DPAPI lifecycle | Same-user round trip; tamper, other-user/computer refusal; no plaintext on disk/logs/CLI | Not executed on Windows |
+| Dependency failure | Missing/wrong-arch/replaced binary and bad hash refuse launch before side effects | Source reviewed only |
+| Private configuration pipe | Correct Go/Qt EOF, genuine peer PID, competing peer denied, cancellation and timeouts | Not executed |
+| Concurrent adapter creation | No unowned adapter may be adopted, configured, or removed | Ownership proof remains incomplete |
+| Two proxies + shared box pair | A exits via A; B/C share B; stopping A never alters B/C or unrelated processes | Fake-controller portion only; no packets |
+| Proxy refusal/auth failure/drop | Useful sanitized errors; no direct-host traffic in full packet capture | Not executed |
+| Owned child killed externally | Preserved BindAdapter, other tunnels unaffected, no unowned-process kill | Fake-controller portion only |
+| Adapter removal/replacement | Stop cleanly without touching the replacement/unrelated adapters | Source reviewed only |
+| Manager exit/crash/restart | Job cleanup, no orphan adoption, persistent association and no direct fallback | Orderly fake-controller portion only |
+| Host route / uplink changes | Host output must not switch to any managed tunnel, even during route churn | Unproven; architecture blocker |
+| DNS matrix | GetAddrInfo, DNS APIs, resolver service, browser DoH/DoT, TCP/UDP 53 packet capture | Not executed |
+| IPv4/IPv6/UDP/QUIC/ICMP/raw | Explicit support/block coverage, including pre-existing and nonblocking sockets | Not executed |
+| Cert/WFP/admin/settings changes | Respect existing gates without a temporary direct-network escape | Source/fake-policy review only |
+| Offline adapter in options | Saving unrelated settings retains BindAdapter, including inherited/process cases | Code reviewed; Windows UI not run |
+| Stale adapter recovery | Automatic, ownership-proven recovery without manual adapter management | Not implemented/qualified |
+
+None of these pending rows may be inferred from an IP-check result or the unit-test
+count. The runtime stays disabled in ordinary builds until the required architecture
+and Windows qualification work is complete.

--- a/SandboxiePlus/SandMan/ProxyTunnels/docs/VALIDATION.md
+++ b/SandboxiePlus/SandMan/ProxyTunnels/docs/VALIDATION.md
@@ -1,6 +1,6 @@
 # Validation record — September 6, 2026
 
-## Executed locally
+## Packaged Qt result, not the current branch commit
 
 Environment: Debian 13, x86-64, GCC 14.2.0, Qt/QtTest 5.15.15. Qt development tools
 were acquired as official Debian packages using the fork's read-only Actions
@@ -10,8 +10,11 @@ Compiled the actual profile, controller, default-gated tunnel and widget sources
 with `-std=c++17 -fPIC -Wall -Wextra -Werror`, plus Qt meta-object output. Ran the
 Qt test executable with the offscreen widget platform.
 
-**Latest result: 44 passed, 0 failed, 1 skipped.** Qt's total includes setup and
-cleanup, data-driven parser rows and controller/widget cases; it is not a count
+The source-review package applied the patch to
+`00ae8850d681962cf1864055c551faaf3ba77770` before this branch added direct Qt
+includes and recovery/UI updates. Its result was **44 passed, 0 failed, 1
+skipped.** Qt's total includes setup and cleanup, data-driven parser rows and
+controller/widget cases; it is not a count
 of 44 independent Windows network experiments.
 
 Covered by executed tests:
@@ -41,6 +44,11 @@ Static checks executed: `git diff --check`; XML parsing of both Visual Studio
 project files; resolution of all ten new source/header entries in each; comparison
 of all six compiled dependency file-hash pins with the actual downloaded official
 artifacts. The patch was also checked for application to its clean baseline.
+
+The standalone CMake target does not compile `ProxyIntegration.cpp`, and it does
+not define `SBIE_PROXY_TUNNELS_LAB`; a successful run therefore does not compile
+the SandMan integration or the laboratory backend. Those paths require the full
+SandMan build and a separately enabled laboratory build.
 
 ## Executed using Windows Actions
 

--- a/SandboxiePlus/SandMan/SandMan.cpp
+++ b/SandboxiePlus/SandMan/SandMan.cpp
@@ -41,6 +41,7 @@
 #include "BoxTransfer.h"
 #include "Engine/ScriptManager.h"
 #include "AddonManager.h"
+#include "ProxyTunnels/ProxyIntegration.h"
 #include "Windows/PopUpWindow.h"
 #include "CustomStyles.h"
 #include <QElapsedTimer>
@@ -538,6 +539,7 @@ CSandMan::CSandMan(QWidget *parent)
 	m_SbieScripts = new CScriptManager(this);
 
 	m_AddonManager = new CAddonManager(this);
+	m_ProxyIntegration = new CProxyIntegration(this);
 
 
 	m_pMainWidget = new QWidget(this);
@@ -636,6 +638,8 @@ CSandMan::CSandMan(QWidget *parent)
 
 CSandMan::~CSandMan()
 {
+	delete m_ProxyIntegration;
+	m_ProxyIntegration = nullptr;
 	m_pPopUpWindow->close();
 	delete m_pPopUpWindow;
 
@@ -945,6 +949,7 @@ void CSandMan::CreateMenus(bool bAdvanced)
 
 	m_pMenuOptions = m_pMenuBar->addMenu(tr("&Options"));
 		m_pMenuSettings = m_pMenuOptions->addAction(CSandMan::GetIcon("Settings"), tr("Global Settings"), this, SLOT(OnSettings()));
+		m_pMenuOptions->addAction(tr("Proxy tunnels (experimental)"), this, [this]() { m_ProxyIntegration->Show(); });
 
 		m_pMenuOptions->addSeparator();
 		m_pDisableForce = m_pMenuOptions->addAction(CSandMan::GetIcon("PauseForce"), tr("Pause Forcing Programs"), this, SLOT(OnDisableForce()));
@@ -1095,6 +1100,7 @@ void CSandMan::CreateOldMenus()
 
 	m_pMenuOptions = m_pMenuBar->addMenu(tr("&Configure"));
 		m_pMenuSettings = m_pMenuOptions->addAction(CSandMan::GetIcon("Settings"), tr("Global Settings"), this, SLOT(OnSettings()));
+		m_pMenuOptions->addAction(tr("Proxy tunnels (experimental)"), this, [this]() { m_ProxyIntegration->Show(); });
 		m_pMenuOptions->addSeparator();
 
 		QAction* m_pProgramAlert = m_pMenuOptions->addAction(CSandMan::GetIcon("Alarm"), tr("Program Alerts"), this, SLOT(OnSettingsAction()));

--- a/SandboxiePlus/SandMan/SandMan.h
+++ b/SandboxiePlus/SandMan/SandMan.h
@@ -22,6 +22,7 @@ class CSbieTemplatesEx;
 class CTraceView;
 class CScriptManager;
 class CAddonManager;
+class CProxyIntegration;
 class QLineEdit;
 
 struct ToolBarAction {
@@ -166,6 +167,7 @@ protected:
 
 	CScriptManager*		m_SbieScripts;
 	CAddonManager*		m_AddonManager;
+	CProxyIntegration*	m_ProxyIntegration;
 
 	QMap<CSbieProgress*, QPair<CSbieProgressPtr, QPointer<QWidget>>> m_pAsyncProgress;
 

--- a/SandboxiePlus/SandMan/SandMan.pri
+++ b/SandboxiePlus/SandMan/SandMan.pri
@@ -155,3 +155,16 @@ TRANSLATIONS += sandman_ar.ts \
 
 
 RESOURCES += Resources/SandMan.qrc
+
+# Native proxy profile UI and experimental tunnel backend.
+HEADERS += ./ProxyTunnels/ProxyProfile.h \
+    ./ProxyTunnels/ProxyTunnel.h \
+    ./ProxyTunnels/ProxyManager.h \
+    ./ProxyTunnels/ProxyWindow.h \
+    ./ProxyTunnels/ProxyIntegration.h
+SOURCES += ./ProxyTunnels/ProxyProfile.cpp \
+    ./ProxyTunnels/ProxyTunnel.cpp \
+    ./ProxyTunnels/ProxyManager.cpp \
+    ./ProxyTunnels/ProxyWindow.cpp \
+    ./ProxyTunnels/ProxyIntegration.cpp
+win32:LIBS += -lcrypt32

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -160,7 +160,7 @@
       <SubSystem>Windows</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;crypt32.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -182,7 +182,7 @@
       <SubSystem>Windows</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;crypt32.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -207,7 +207,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalOptions> /SUBSYSTEM:WINDOWS</AdditionalOptions>
-      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;crypt32.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -229,7 +229,7 @@
       <SubSystem>Windows</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;crypt32.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;Version.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -250,7 +250,7 @@
       <SubSystem>Windows</SubSystem>
       <OutputFile>$(OutDir)\$(ProjectName).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;crypt32.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -274,7 +274,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalOptions> /SUBSYSTEM:WINDOWS</AdditionalOptions>
-      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>QSbieAPI.lib;MiscHelpers.lib;ntdll.lib;QtSingleApp.lib;UGlobalHotkey.lib;comctl32.lib;bcrypt.lib;crypt32.lib;taskschd.lib;ws2_32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -621,4 +621,16 @@
   </ImportGroup>
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ItemGroup>
+    <ClCompile Include="ProxyTunnels\ProxyProfile.cpp" />
+    <ClCompile Include="ProxyTunnels\ProxyTunnel.cpp" />
+    <ClCompile Include="ProxyTunnels\ProxyManager.cpp" />
+    <ClCompile Include="ProxyTunnels\ProxyWindow.cpp" />
+    <ClCompile Include="ProxyTunnels\ProxyIntegration.cpp" />
+    <ClInclude Include="ProxyTunnels\ProxyProfile.h" />
+    <QtMoc Include="ProxyTunnels\ProxyTunnel.h" />
+    <QtMoc Include="ProxyTunnels\ProxyManager.h" />
+    <QtMoc Include="ProxyTunnels\ProxyWindow.h" />
+    <ClInclude Include="ProxyTunnels\ProxyIntegration.h" />
+  </ItemGroup>
 </Project>

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -569,4 +569,36 @@
       <Filter>Resource Files</Filter>
     </ResourceCompile>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="ProxyTunnels\ProxyProfile.cpp">
+      <Filter>SandMan</Filter>
+    </ClCompile>
+    <ClInclude Include="ProxyTunnels\ProxyProfile.h">
+      <Filter>SandMan</Filter>
+    </ClInclude>
+    <ClCompile Include="ProxyTunnels\ProxyTunnel.cpp">
+      <Filter>SandMan</Filter>
+    </ClCompile>
+    <QtMoc Include="ProxyTunnels\ProxyTunnel.h">
+      <Filter>SandMan</Filter>
+    </QtMoc>
+    <ClCompile Include="ProxyTunnels\ProxyManager.cpp">
+      <Filter>SandMan</Filter>
+    </ClCompile>
+    <QtMoc Include="ProxyTunnels\ProxyManager.h">
+      <Filter>SandMan</Filter>
+    </QtMoc>
+    <ClCompile Include="ProxyTunnels\ProxyWindow.cpp">
+      <Filter>SandMan</Filter>
+    </ClCompile>
+    <QtMoc Include="ProxyTunnels\ProxyWindow.h">
+      <Filter>SandMan</Filter>
+    </QtMoc>
+    <ClCompile Include="ProxyTunnels\ProxyIntegration.cpp">
+      <Filter>SandMan</Filter>
+    </ClCompile>
+    <ClInclude Include="ProxyTunnels\ProxyIntegration.h">
+      <Filter>SandMan</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/SandboxiePlus/SandMan/Tests/ProxyTunnels/CMakeLists.txt
+++ b/SandboxiePlus/SandMan/Tests/ProxyTunnels/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.16)
+project(ProxyTunnelsTests LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Network Widgets Test)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Network Widgets Test)
+add_executable(proxy-tests
+    tst_ProxyTunnels.cpp
+    ../../ProxyTunnels/ProxyProfile.cpp ../../ProxyTunnels/ProxyProfile.h
+    ../../ProxyTunnels/ProxyTunnel.cpp ../../ProxyTunnels/ProxyTunnel.h
+    ../../ProxyTunnels/ProxyManager.cpp ../../ProxyTunnels/ProxyManager.h
+    ../../ProxyTunnels/ProxyWindow.cpp ../../ProxyTunnels/ProxyWindow.h)
+target_compile_definitions(proxy-tests PRIVATE PROXY_TUNNELS_STANDALONE)
+target_link_libraries(proxy-tests PRIVATE
+    Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Network
+    Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Test)
+if(WIN32)
+    target_link_libraries(proxy-tests PRIVATE crypt32 ws2_32 iphlpapi)
+endif()
+enable_testing()
+add_test(NAME proxy-tests COMMAND proxy-tests)
+set_tests_properties(proxy-tests PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/SandboxiePlus/SandMan/Tests/ProxyTunnels/tst_ProxyTunnels.cpp
+++ b/SandboxiePlus/SandMan/Tests/ProxyTunnels/tst_ProxyTunnels.cpp
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: LicenseRef-Sandboxie-Plus
+#include <QtTest>
+#include <QTemporaryDir>
+#include <QJsonDocument>
+#include <QTreeWidget>
+#include "../../ProxyTunnels/ProxyWindow.h"
+#include <atomic>
+#include "../../ProxyTunnels/ProxyManager.h"
+
+class CFakeTunnel : public CProxyTunnel
+{
+public:
+	CFakeTunnel(const SProxyProfile& Profile, QObject* Parent, std::shared_ptr<std::atomic<bool>> Failure)
+		: CProxyTunnel(Profile, QString(), Parent), Id(Profile.Id), Failure(std::move(Failure)) {}
+protected:
+	void run() override
+	{
+		emit StateChanged(Id, Starting, "Fake starting");
+		msleep(5);
+		if (!isInterruptionRequested()) emit StateChanged(Id, Running, "Fake active, not a network check");
+		while (!isInterruptionRequested() && !Failure->load()) msleep(2);
+		if (Failure->load()) emit StateChanged(Id, Failed, "Simulated child/proxy/adapter failure");
+		else emit StateChanged(Id, Stopped, "Fake stopped");
+	}
+private:
+	QString Id;
+	std::shared_ptr<std::atomic<bool>> Failure;
+};
+
+class CProxyTests : public QObject
+{
+	Q_OBJECT
+private slots:
+	void parse_data()
+	{
+		QTest::addColumn<QString>("line");
+		QTest::addColumn<bool>("valid");
+		QTest::newRow("host-port") << "proxy.example:1080" << true;
+		QTest::newRow("ipv4-auth") << "192.0.2.10:8000:session-a:secret" << true;
+		QTest::newRow("password-colons") << "proxy.example:1080:user:a:b:c" << true;
+		QTest::newRow("ipv6-brackets") << "[2001:db8::10]:1080:user:secret" << true;
+		QTest::newRow("socks-url") << "socks5://user:p%40ss%3Aword@proxy.example:1080" << true;
+		QTest::newRow("http-url") << "http://proxy.example:8080" << true;
+		QTest::newRow("idn") << QString::fromUtf8("próxy.example:1080") << true;
+		QTest::newRow("ipv6-url") << "socks5://[2001:db8::10]:1080" << true;
+		QTest::newRow("zero-port") << "proxy.example:0" << false;
+		QTest::newRow("overflow-port") << "proxy.example:65536" << false;
+		QTest::newRow("negative-port") << "proxy.example:-1" << false;
+		QTest::newRow("missing-port") << "socks5://proxy.example" << false;
+		QTest::newRow("missing-host") << "socks5://:1080" << false;
+		QTest::newRow("unsupported-scheme") << "ftp://proxy.example:1080" << false;
+		QTest::newRow("path") << "socks5://proxy.example:1080/other" << false;
+		QTest::newRow("query") << "socks5://proxy.example:1080?password=secret" << false;
+		QTest::newRow("fragment") << "socks5://proxy.example:1080#secret" << false;
+		QTest::newRow("wildcard4") << "0.0.0.0:1080" << false;
+		QTest::newRow("wildcard6") << "[::]:1080" << false;
+		QTest::newRow("multicast") << "239.0.0.1:1080" << false;
+		QTest::newRow("broadcast") << "255.255.255.255:1080" << false;
+		QTest::newRow("malformed-numeric") << "999.0.0.1:1080" << false;
+		QTest::newRow("empty-label") << "proxy..example:1080" << false;
+		QTest::newRow("label-dash") << "-proxy.example:1080" << false;
+		QTest::newRow("whitespace-host") << "proxy example:1080" << false;
+		QTest::newRow("scope") << "[fe80::1%eth0]:1080" << false;
+		QTest::newRow("empty-username") << "proxy.example:1080::secret" << false;
+		QTest::newRow("encoded-newline") << "socks5://user:secret%0A@proxy.example:1080" << false;
+		QTest::newRow("literal-control") << QString("proxy.example:1080:user:sec\tret") << false;
+		QTest::newRow("oversize-credential") << ("proxy.example:1080:user:" + QString(256, 's')) << false;
+	}
+	void parse()
+	{
+		QFETCH(QString, line); QFETCH(bool, valid);
+		SProxyInput Input; QString Error;
+		QCOMPARE(ProxyProfiles::ParseLine(line, Input, Error), valid);
+		if (!valid) { QVERIFY(!Error.isEmpty()); QVERIFY(!Error.contains("secret")); }
+	}
+	void specialCredentials()
+	{
+		SProxyInput Input; QString Error;
+		QVERIFY(ProxyProfiles::ParseLine("socks5://u%40ser:p%40ss%3Aword@proxy.example:1080", Input, Error));
+		QCOMPARE(Input.User, QString("u@ser")); QCOMPARE(Input.Password, QString("p@ss:word"));
+		SProxyInput Roundtrip;
+		QVERIFY(ProxyProfiles::ParseLine(ProxyProfiles::ProxyUrl(Input), Roundtrip, Error));
+		QCOMPARE(Roundtrip.User, Input.User); QCOMPARE(Roundtrip.Password, Input.Password);
+	}
+	void importErrorsAndSessions()
+	{
+		QList<SProxyImportError> Errors;
+		auto Inputs = ProxyProfiles::ParseList("# comment\r\nproxy.example:1080:a:one\r\ninvalid:secret\nproxy.example:1080:b:two\nproxy.example:1081:a:one\n", Errors);
+		QCOMPARE(Inputs.size(), 3); QCOMPARE(Errors.size(), 1); QCOMPARE(Errors.first().Line, 3);
+		QVERIFY(!Errors.first().Reason.contains("secret"));
+		QCOMPARE(Inputs[0].Host, Inputs[1].Host); QVERIFY(Inputs[0].User != Inputs[1].User);
+	}
+	void uniqueIdentityAndAtomicPersistence()
+	{
+		QTemporaryDir Dir; QVERIFY(Dir.isValid()); QString Error;
+		SProxyInput Input; QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error));
+		SProxyProfile A, B;
+		QVERIFY(ProxyProfiles::Protect(Input, A, Error)); QVERIFY(ProxyProfiles::Protect(Input, B, Error));
+		QVERIFY(A.Id != B.Id); QVERIFY(A.AdapterName() != B.AdapterName());
+		QString Path = Dir.filePath("profiles.json");
+		QVERIFY(ProxyProfiles::Save(Path, {A, B}, Error));
+		QList<SProxyProfile> Loaded; QVERIFY(ProxyProfiles::Load(Path, Loaded, Error)); QCOMPARE(Loaded.size(), 2);
+		QFile Saved(Path); QVERIFY(Saved.open(QIODevice::ReadOnly)); QByteArray Original = Saved.readAll(); Saved.close();
+		QVERIFY(!ProxyProfiles::Save(Path, {A, A}, Error));
+		QVERIFY(Saved.open(QIODevice::ReadOnly)); QCOMPARE(Saved.readAll(), Original); Saved.close();
+		QVERIFY(!Original.contains("active")); QVERIFY(!Original.contains("pid")); QVERIFY(!Original.contains("password"));
+		QVERIFY(!ProxyProfiles::Save(Dir.filePath("missing/profiles.json"), {A}, Error));
+	}
+	void corruptStoreIsNotOverwritten()
+	{
+		QTemporaryDir Dir; QString Path = Dir.filePath("profiles.json"); QFile File(Path);
+		QVERIFY(File.open(QIODevice::WriteOnly)); File.write("{broken"); File.close();
+		CProxyManager Manager(Path, {}); QVERIFY(!Manager.StorageError().isEmpty());
+		SProxyInput Input; QString Error, Id; QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error));
+		QVERIFY(!Manager.SaveProfile(Input, Id, Error));
+		QVERIFY(File.open(QIODevice::ReadOnly)); QCOMPARE(File.readAll(), QByteArray("{broken"));
+	}
+	void exclusiveStoreLock()
+	{
+		QTemporaryDir Dir; QString Path = Dir.filePath("profiles.json");
+		CProxyManager First(Path, {}); CProxyManager Second(Path, {});
+		QVERIFY(First.StorageError().isEmpty()); QVERIFY(!Second.StorageError().isEmpty());
+	}
+	void savedDataValidation()
+	{
+		SProxyInput Input; SProxyProfile Profile, Out; QString Error;
+		QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error)); QVERIFY(ProxyProfiles::Protect(Input, Profile, Error));
+		auto Json = Profile.ToJson(); Json["password"] = "secret";
+		QVERIFY(!SProxyProfile::FromJson(Json, Out, Error)); QVERIFY(!Error.contains("secret"));
+		Json = Profile.ToJson(); Json["id"] = "../adapter"; QVERIFY(!SProxyProfile::FromJson(Json, Out, Error));
+		Json = Profile.ToJson(); Json["dpapi"] = "!invalid"; QVERIFY(!SProxyProfile::FromJson(Json, Out, Error));
+		Json = Profile.ToJson(); Json["port"] = 10.5; QVERIFY(!SProxyProfile::FromJson(Json, Out, Error));
+		Json = Profile.ToJson(); Json["dpapi"] = 123; QVERIFY(!SProxyProfile::FromJson(Json, Out, Error));
+	}
+	void credentialProtection()
+	{
+		SProxyInput Input; SProxyProfile Profile; QString Error;
+		QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080:user:secret", Input, Error));
+#ifdef Q_OS_WIN
+		QVERIFY2(ProxyProfiles::Protect(Input, Profile, Error), qPrintable(Error));
+		QVERIFY(!Profile.ProtectedAuth.contains("secret"));
+		SProxyInput Recovered; QVERIFY(ProxyProfiles::Reveal(Profile, Recovered, Error));
+		QCOMPARE(Recovered.Password, Input.Password); QCOMPARE(Recovered.User, Input.User);
+		Profile.ProtectedAuth[0] = char(Profile.ProtectedAuth[0] ^ 0x80);
+		QVERIFY(!ProxyProfiles::Reveal(Profile, Recovered, Error));
+#else
+		QVERIFY(!ProxyProfiles::Protect(Input, Profile, Error)); QVERIFY(Profile.Id.isEmpty());
+		QSKIP("DPAPI round trip and tamper rejection require Windows; Linux refusal was verified.");
+#endif
+	}
+	void controllerLifecycleAndSharedBoxes()
+	{
+		QTemporaryDir Dir; QString Path = Dir.filePath("profiles.json"), Error, Id;
+		QMap<QString, QString> Associations; int Created = 0; bool Allowed = true;
+		auto Failure = std::make_shared<std::atomic<bool>>(false);
+		SProxyHooks Hooks;
+		Hooks.ActivationError = [&]() { return Allowed ? QString() : QString("Policy no longer permits activation"); };
+		Hooks.Boxes = [&]() { QList<SProxyBox> Boxes; for (auto It = Associations.begin(); It != Associations.end(); ++It) Boxes.append({It.key(), It.value(), {}}); return Boxes; };
+		Hooks.Assign = [&](const QString& Box, const QString& Profile, QString&) { Associations[Box] = Profile; return true; };
+		auto Factory = [&](const SProxyProfile& Profile, const QString&, QObject* Parent) -> CProxyTunnel* {
+			++Created; return new CFakeTunnel(Profile, Parent, Failure);
+		};
+		{
+			CProxyManager Manager(Path, Hooks, nullptr, Factory);
+			SProxyInput Input; QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error));
+			QVERIFY(Manager.SaveProfile(Input, Id, Error));
+			QVERIFY(Manager.Assign("BoxA", Id, Error)); QVERIFY(Manager.Assign("BoxB", Id, Error));
+			QCOMPARE(Manager.Users(Id).size(), 2); QVERIFY(!Manager.Remove(Id, Error));
+			QVERIFY(Manager.Start(Id, Error)); QVERIFY(!Manager.Start(Id, Error)); QCOMPARE(Created, 1);
+			QTRY_COMPARE(Manager.Runtime(Id).State, int(CProxyTunnel::Running));
+			QVERIFY(!Manager.SaveProfile(Input, Id, Error));
+			Failure->store(true);
+			QTRY_VERIFY(!Manager.HasWorker(Id)); QCOMPARE(Manager.Runtime(Id).State, int(CProxyTunnel::Failed));
+			QCOMPARE(Manager.Users(Id).size(), 2); QVERIFY(Manager.Runtime(Id).Egress.isEmpty());
+			Failure->store(false); QVERIFY(Manager.Start(Id, Error)); Manager.Stop(Id);
+			QTRY_VERIFY(!Manager.HasWorker(Id)); QCOMPARE(Manager.Runtime(Id).State, int(CProxyTunnel::Stopped));
+			QVERIFY(Manager.Start(Id, Error)); QTRY_COMPARE(Manager.Runtime(Id).State, int(CProxyTunnel::Running));
+			Allowed = false; QTRY_VERIFY(!Manager.HasWorker(Id)); QCOMPARE(Manager.Users(Id).size(), 2);
+			QVERIFY(!Manager.Start(Id, Error));
+		}
+		Allowed = true;
+		CProxyManager Restarted(Path, Hooks, nullptr, Factory);
+		QCOMPARE(Restarted.Profiles().size(), 1); QCOMPARE(Restarted.Users(Id).size(), 2);
+		QCOMPARE(Restarted.Runtime(Id).State, int(CProxyTunnel::Stopped)); QVERIFY(!Restarted.HasWorker(Id));
+	}
+	void bulkStartStopAndShutdown()
+	{
+		QTemporaryDir Dir; QString Error; int Created = 0;
+		SProxyHooks Hooks; Hooks.ActivationError = []() { return QString(); };
+		auto Failure = std::make_shared<std::atomic<bool>>(false);
+		CProxyManager Manager(Dir.filePath("profiles.json"), Hooks, nullptr,
+			[&](const SProxyProfile& Profile, const QString&, QObject* Parent) -> CProxyTunnel* { ++Created; return new CFakeTunnel(Profile, Parent, Failure); });
+		SProxyInput Input; QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error));
+		QStringList Ids;
+		for (int i = 0; i < 3; ++i) { QString Id; QVERIFY(Manager.SaveProfile(Input, Id, Error)); Ids.append(Id); QVERIFY(Manager.Start(Id, Error)); }
+		QCOMPARE(Created, 3); Manager.StopAll();
+		for (const auto& Id : Ids) QTRY_VERIFY(!Manager.HasWorker(Id));
+		for (const auto& Id : Ids) QVERIFY(Manager.Start(Id, Error));
+		// Destruction must cancel and join each owned worker without detached processes.
+	}
+	void importLimitsAndPartialCommit()
+	{
+		QList<SProxyImportError> Errors;
+		const auto Inputs = ProxyProfiles::ParseList(QString("proxy.example:1080\n").repeated(1002), Errors);
+		QCOMPARE(Inputs.size(), 1000); QCOMPARE(Errors.size(), 2);
+		QCOMPARE(Errors.first().Line, 1001);
+		QTemporaryDir Dir; CProxyManager Manager(Dir.filePath("profiles.json"), {});
+		int Added = -1; QString Error;
+		QVERIFY(Manager.Import("proxy.example:1080\ninvalid:secret\nproxy.example:1081", Errors, Added, Error));
+		QCOMPARE(Added, 2); QCOMPARE(Errors.size(), 1); QCOMPARE(Manager.Profiles().size(), 2);
+		QVERIFY(!Manager.Import("invalid:secret", Errors, Added, Error));
+		QCOMPARE(Added, 0); QCOMPARE(Manager.Profiles().size(), 2);
+	}
+	void defaultBackendCannotActivate()
+	{
+		SProxyInput Input; SProxyProfile Profile; QString Error;
+		QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error));
+		QVERIFY(ProxyProfiles::Protect(Input, Profile, Error));
+		CProxyTunnel Worker(Profile, QString());
+		QSignalSpy States(&Worker, &CProxyTunnel::StateChanged);
+		QSignalSpy Checks(&Worker, &CProxyTunnel::EgressChecked);
+		Worker.start(); QVERIFY(Worker.wait(2000));
+		QCoreApplication::processEvents();
+		QVERIFY(States.size() >= 2); QCOMPARE(States.last().at(1).toInt(), int(CProxyTunnel::Failed));
+		QCOMPARE(Checks.size(), 0);
+	}
+	void nativeWindowSmoke()
+	{
+		QTemporaryDir Dir; QString Error, Id; SProxyInput Input;
+		SProxyHooks Hooks;
+		Hooks.Boxes = [&]() { return QList<SProxyBox>{{"BoxA", Id, "Saved / offline"}, {"BoxB", Id, "Saved / offline"}}; };
+		CProxyManager Manager(Dir.filePath("profiles.json"), Hooks);
+		QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error));
+		Input.Name = "Shared profile"; QVERIFY(Manager.SaveProfile(Input, Id, Error));
+		CProxyWindow Window(&Manager);
+		const auto Trees = Window.findChildren<QTreeWidget*>();
+		QCOMPARE(Trees.size(), 2); QCOMPARE(Trees[0]->topLevelItemCount(), 1); QCOMPARE(Trees[1]->topLevelItemCount(), 2);
+		QCOMPARE(Trees[0]->topLevelItem(0)->text(4), QString("BoxA, BoxB"));
+		QVERIFY(Window.windowTitle().contains("experimental"));
+	}
+	void absentIntegrationFailsClosed()
+	{
+		QTemporaryDir Dir; QString Error, Id; SProxyInput Input;
+		CProxyManager Manager(Dir.filePath("profiles.json"), {});
+		QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error)); QVERIFY(Manager.SaveProfile(Input, Id, Error));
+		QVERIFY(!Manager.Start(Id, Error)); QVERIFY(!Manager.Assign("BoxA", Id, Error)); QVERIFY(!Manager.HasWorker(Id));
+	}
+};
+QTEST_MAIN(CProxyTests)
+#include "tst_ProxyTunnels.moc"

--- a/SandboxiePlus/SandMan/Tests/ProxyTunnels/tst_ProxyTunnels.cpp
+++ b/SandboxiePlus/SandMan/Tests/ProxyTunnels/tst_ProxyTunnels.cpp
@@ -246,20 +246,22 @@ private slots:
 		QString SecondId; Input.Name = "Second profile"; QVERIFY(Manager.SaveProfile(Input, SecondId, Error));
 		CProxyWindow Window(&Manager);
 		BoxQueries = 0; Input.Name = "Shared profile updated"; QVERIFY(Manager.SaveProfile(Input, Id, Error));
-		QCOMPARE(BoxQueries, 1);
+		QCOMPARE(BoxQueries, 0);
+		Window.show(); QTest::qWait(20); QVERIFY(BoxQueries > 0);
 		const auto Trees = Window.findChildren<QTreeWidget*>();
 		QCOMPARE(Trees.size(), 2); QCOMPARE(Trees[0]->topLevelItemCount(), 2); QCOMPARE(Trees[1]->topLevelItemCount(), 2);
 		QCOMPARE(Trees[0]->topLevelItem(0)->text(4), QString("BoxA, BoxB"));
 		QVERIFY(Window.windowTitle().contains("experimental"));
 		int DisabledActions = 0;
 		for (auto Button : Window.findChildren<QPushButton*>()) {
-			if (Button->text() == "Start selected" || Button->text() == "Start all" || Button->text() == "Check exit IP") {
+			if (Button->text() == "Start selected" || Button->text() == "Start all" || Button->text() == "Check exit IP" || Button->text() == "Assign selected profile to selected sandboxes") {
 				QVERIFY(!Button->isEnabled());
 				++DisabledActions;
 			}
 		}
-		QCOMPARE(DisabledActions, 3);
-		Window.show(); QTest::qWait(20); BoxQueries = 0; Window.hide(); QTest::qWait(1100); QCOMPARE(BoxQueries, 0);
+		QCOMPARE(DisabledActions, 4);
+		Window.hide(); BoxQueries = 0; Input.Name = "Shared profile recovered"; QVERIFY(Manager.SaveProfile(Input, Id, Error)); QCOMPARE(BoxQueries, 0);
+		Window.show(); QTest::qWait(20); QVERIFY(BoxQueries > 0); QCOMPARE(Trees[0]->topLevelItem(0)->text(0), QString("Shared profile recovered"));
 	}
 	void absentIntegrationFailsClosed()
 	{

--- a/SandboxiePlus/SandMan/Tests/ProxyTunnels/tst_ProxyTunnels.cpp
+++ b/SandboxiePlus/SandMan/Tests/ProxyTunnels/tst_ProxyTunnels.cpp
@@ -2,6 +2,7 @@
 #include <QtTest>
 #include <QTemporaryDir>
 #include <QJsonDocument>
+#include <QPushButton>
 #include <QTreeWidget>
 #include "../../ProxyTunnels/ProxyWindow.h"
 #include <atomic>
@@ -198,6 +199,16 @@ private slots:
 		for (const auto& Id : Ids) QVERIFY(Manager.Start(Id, Error));
 		// Destruction must cancel and join each owned worker without detached processes.
 	}
+	void detachRemainsAvailableWhenActivationFails()
+	{
+		QTemporaryDir Dir; QString Error; bool Detached = false;
+		SProxyHooks Hooks;
+		Hooks.ActivationError = []() { return QString("Tunnel activation is unavailable"); };
+		Hooks.Assign = [&](const QString& Box, const QString& Id, QString&) { Detached = Box == "BoxA" && Id.isEmpty(); return Detached; };
+		CProxyManager Manager(Dir.filePath("profiles.json"), Hooks);
+		QVERIFY(Manager.Assign("BoxA", QString(), Error));
+		QVERIFY(Detached);
+	}
 	void importLimitsAndPartialCommit()
 	{
 		QList<SProxyImportError> Errors;
@@ -226,17 +237,29 @@ private slots:
 	}
 	void nativeWindowSmoke()
 	{
-		QTemporaryDir Dir; QString Error, Id; SProxyInput Input;
+		QTemporaryDir Dir; QString Error, Id; SProxyInput Input; int BoxQueries = 0;
 		SProxyHooks Hooks;
-		Hooks.Boxes = [&]() { return QList<SProxyBox>{{"BoxA", Id, "Saved / offline"}, {"BoxB", Id, "Saved / offline"}}; };
+		Hooks.Boxes = [&]() { ++BoxQueries; return QList<SProxyBox>{{"BoxA", Id, "Saved / offline"}, {"BoxB", Id, "Saved / offline"}}; };
 		CProxyManager Manager(Dir.filePath("profiles.json"), Hooks);
 		QVERIFY(ProxyProfiles::ParseLine("proxy.example:1080", Input, Error));
 		Input.Name = "Shared profile"; QVERIFY(Manager.SaveProfile(Input, Id, Error));
+		QString SecondId; Input.Name = "Second profile"; QVERIFY(Manager.SaveProfile(Input, SecondId, Error));
 		CProxyWindow Window(&Manager);
+		BoxQueries = 0; Input.Name = "Shared profile updated"; QVERIFY(Manager.SaveProfile(Input, Id, Error));
+		QCOMPARE(BoxQueries, 1);
 		const auto Trees = Window.findChildren<QTreeWidget*>();
-		QCOMPARE(Trees.size(), 2); QCOMPARE(Trees[0]->topLevelItemCount(), 1); QCOMPARE(Trees[1]->topLevelItemCount(), 2);
+		QCOMPARE(Trees.size(), 2); QCOMPARE(Trees[0]->topLevelItemCount(), 2); QCOMPARE(Trees[1]->topLevelItemCount(), 2);
 		QCOMPARE(Trees[0]->topLevelItem(0)->text(4), QString("BoxA, BoxB"));
 		QVERIFY(Window.windowTitle().contains("experimental"));
+		int DisabledActions = 0;
+		for (auto Button : Window.findChildren<QPushButton*>()) {
+			if (Button->text() == "Start selected" || Button->text() == "Start all" || Button->text() == "Check exit IP") {
+				QVERIFY(!Button->isEnabled());
+				++DisabledActions;
+			}
+		}
+		QCOMPARE(DisabledActions, 3);
+		Window.show(); QTest::qWait(20); BoxQueries = 0; Window.hide(); QTest::qWait(1100); QCOMPARE(BoxQueries, 0);
 	}
 	void absentIntegrationFailsClosed()
 	{

--- a/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsNetwork.cpp
@@ -117,6 +117,15 @@ void COptionsWindow::LoadNetwork()
 			ui.cmbNIC->setCurrentIndex(ui.cmbNIC->count() - 1);
 	}
 
+	// Keep a saved binding selectable when its adapter is temporarily absent.
+	// Otherwise saving unrelated options would silently replace it with "None".
+	if (!BindAdapter.isEmpty() && ui.cmbNIC->currentIndex() == 0) {
+		QVariantMap Missing;
+		Missing["Adapter"] = BindAdapter;
+		ui.cmbNIC->addItem(tr("%1 (unavailable; binding retained)").arg(BindAdapter), Missing);
+		ui.cmbNIC->setCurrentIndex(ui.cmbNIC->count() - 1);
+	}
+
 	OnAdapterChanged();
 
 	QStringList BindIPs = m_pBox->GetTextList("BindAdapterIP", false);


### PR DESCRIPTION
This adds native proxy profile management to SandMan and an experimental tunnel manager for associating sandboxes with `BindAdapter` profiles. It is deliberately a review prototype: normal builds cannot activate tunnels or create new sandbox associations because `SBIE_PROXY_TUNNELS_LAB` is not defined. A confirmed recovery detach remains available for a stopped sandbox with a local managed binding.

- Profiles use stable UUIDs, atomic storage, a store lock, and current-user DPAPI for credentials; there is no plaintext fallback.
- The panel supports profile editing, validated bulk import, per-line errors, lifecycle status, exit-IP checks, and shared profile-to-sandbox mappings.
- The controller retains `BindAdapter` as the association authority and never persists worker PIDs or adopts pre-existing processes or adapters.
- The laboratory backend tracks only handles it created, uses a kill-on-close job, verifies pinned dependencies, and uses a PID-checked private configuration pipe. It does not kill by process name or remove adapters without ownership proof.
- The network template restricts DNS, UDP, and ICMP, and SandMan now retains an unavailable adapter selection when saving unrelated network settings. The user-mode bind path records a forced binding only after the system bind succeeds.
- Recovery detaches are idempotent, preserve inherited guard templates, and remain available when activation policy is no longer valid. The panel uses one sandbox snapshot per refresh, pauses visual refresh when hidden, and disables unavailable activation commands.

The implementation is inspired by `Artjosh/tun2proxy-bindsandboxie`, without copying its Go UI, local HTTP service, or bundled executables. HWID, whitelist, and IP-reputation changes are out of scope.

Related context:

- [#4207](https://github.com/sandboxie-plus/Sandboxie/issues/4207) and [#4454](https://github.com/sandboxie-plus/Sandboxie/issues/4454) motivate fail-closed behavior and HTTP CONNECT compatibility, respectively. This proposes a separate panel and experimental tunnel backend; it does not replace the existing Internet Proxy rules or claim complete HTTP/HTTPS proxy compatibility.
- [#4896](https://github.com/sandboxie-plus/Sandboxie/issues/4896) is regression context for adapter loss and strict binding, building on the existing fix in [#5094](https://github.com/sandboxie-plus/Sandboxie/pull/5094).
- [#5109](https://github.com/sandboxie-plus/Sandboxie/issues/5109) is compatibility context for explicitly authorized local proxies and IPv4/IPv6 loopback. It does not imply unrestricted loopback access or IPv6-only proxy ingress support.
- [#4460](https://github.com/sandboxie-plus/Sandboxie/issues/4460) relates to the credential-transport warning: DPAPI protects stored credentials, not their transport to a proxy.

None of these issues is claimed as resolved by this draft.

Validation performed for this branch:

- Applied cleanly to `00ae8850d681962cf1864055c551faaf3ba77770` and passed `git diff --check`.
- Parsed both Visual Studio project files as XML and confirmed all ten new project references resolve.
- The standalone Qt test target could not be configured locally because neither Qt5 nor Qt6 development packages are installed. MSVC was detected, but no SandMan build or Windows runtime test was run. The target also excludes `ProxyIntegration.cpp` and the laboratory backend; those require separate full and laboratory builds.

The attached source-review package includes an earlier Qt 5.15.15/GCC run with fake workers reporting 44 passed, 0 failed, and 1 skipped. That result was not rerun for this branch and is not a Windows integration result.

Activation must remain disabled until the documented blockers are resolved: global Windows route influence, proof of adapter ownership, private-pipe interoperability, DNS/IPv4/IPv6/UDP coverage, failure recovery, packaging approval, and real MSVC/Qt6 plus Sandboxie regression validation. A public-IP check is not evidence of complete leak protection or proof that the host is never used as an egress path.
