### PR TITLE
sandman: keep pending edits when ini writes fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - fixed ignored INI list and boolean write errors and SandMan discarding pending options or raw INI edits after a reported save failure
+- fixed sandbox Apply/OK writing stale structured settings immediately after cancelling a partial raw INI save
 - fixed stale INI completion-popup candidate tooltips during editing and limited `Template`/`TemplateReject` tooltips to setting-name text
 - fixed SandMan File Panel "Create Shortcut" producing a shortcut without a working directory, so the sandboxed program inherited SandMan's current directory and applications that open their data files by relative path failed to find them [#5542](https://github.com/sandboxie-plus/Sandboxie/issues/5542)
 - fixed wrong return type ein sbiesvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 
 ### Fixed
+- fixed ignored INI list and boolean write errors and SandMan discarding pending options after a reported save failure
 - fixed stale INI completion-popup candidate tooltips during editing and limited `Template`/`TemplateReject` tooltips to setting-name text
 - fixed SandMan File Panel "Create Shortcut" producing a shortcut without a working directory, so the sandboxed program inherited SandMan's current directory and applications that open their data files by relative path failed to find them [#5542](https://github.com/sandboxie-plus/Sandboxie/issues/5542)
 - fixed wrong return type ein sbiesvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 
 ### Fixed
-- fixed ignored INI list and boolean write errors and SandMan discarding pending options or raw INI edits after a reported save failure
-- fixed sandbox Apply/OK writing stale structured settings immediately after cancelling a partial raw INI save
+- fixed ignored INI list and boolean write errors and SandMan discarding pending options or raw INI edits after a reported save failure, including sandbox Apply/OK writing stale structured settings right after cancelling a partial raw save
 - fixed stale INI completion-popup candidate tooltips during editing and limited `Template`/`TemplateReject` tooltips to setting-name text
 - fixed SandMan File Panel "Create Shortcut" producing a shortcut without a working directory, so the sandboxed program inherited SandMan's current directory and applications that open their data files by relative path failed to find them [#5542](https://github.com/sandboxie-plus/Sandboxie/issues/5542)
 - fixed wrong return type ein sbiesvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 
 ### Fixed
-- fixed ignored INI list and boolean write errors and SandMan discarding pending options after a reported save failure
+- fixed ignored INI list and boolean write errors and SandMan discarding pending options or raw INI edits after a reported save failure
 - fixed stale INI completion-popup candidate tooltips during editing and limited `Template`/`TemplateReject` tooltips to setting-name text
 - fixed SandMan File Panel "Create Shortcut" producing a shortcut without a working directory, so the sandboxed program inherited SandMan's current directory and applications that open their data files by relative path failed to find them [#5542](https://github.com/sandboxie-plus/Sandboxie/issues/5542)
 - fixed wrong return type ein sbiesvc

--- a/SandboxiePlus/QSbieAPI/Sandboxie/SbieIni.cpp
+++ b/SandboxiePlus/QSbieAPI/Sandboxie/SbieIni.cpp
@@ -72,8 +72,11 @@ SB_STATUS CSbieIni::SetBoolSafe(const QString& Setting, bool Value)
 			continue;
 		if (CurValue == StrValue)
 			bAdd = false;
-		else
-			DelValue(Setting, CurValue);
+		else {
+			SB_STATUS Status = DelValue(Setting, CurValue);
+			if (!Status)
+				return Status;
+		}
 	}
 	if(bAdd)
 		return AppendText(Setting, StrValue);
@@ -161,11 +164,17 @@ SB_STATUS CSbieIni::UpdateTextList(const QString &Setting, const QStringList& Li
 			NewSettings.append(Value);
 	}
 	// delete removed or changed settings
-	foreach(const QString& Value, OldSettings)
-		DelValue(Setting, Value);
+	foreach(const QString& Value, OldSettings) {
+		SB_STATUS Status = DelValue(Setting, Value);
+		if (!Status)
+			return Status;
+	}
 	// add new or changed settings
-	foreach(const QString& Value, NewSettings)
-		AppendText(Setting, Value);
+	foreach(const QString& Value, NewSettings) {
+		SB_STATUS Status = AppendText(Setting, Value);
+		if (!Status)
+			return Status;
+	}
 	return SB_OK;
 }
 

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -1322,6 +1322,11 @@ bool COptionsWindow::apply()
 	}
 	else
 	{
+		if (m_ConfigDirty) {
+			if (!m_pBox->GetAPI()->IsConnected())
+				return false;
+			LoadConfig();
+		}
 		if (m_GeneralChanged) {
 			auto pBoxEx = m_pBox.objectCast<CSandBoxPlus>();
 			if (ui.chkEncrypt->isChecked() && !QFile::exists(pBoxEx->GetBoxImagePath())) {
@@ -1461,7 +1466,7 @@ void COptionsWindow::OnTab(QWidget* pTab)
 	}
 	else 
 	{
-		if (m_ConfigDirty)
+		if (m_ConfigDirty && m_pBox->GetAPI()->IsConnected())
 			LoadConfig();
 
 		UpdateCurrentTab();

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -1316,8 +1316,10 @@ bool COptionsWindow::apply()
 	CloseCopyEdit();
     CloseNetProxyEdit();
 
-	if (!ui.btnEditIni->isEnabled())
-		SaveIniSection();
+	if (!ui.btnEditIni->isEnabled()) {
+		if (!SaveIniSection())
+			return false;
+	}
 	else
 	{
 		if (m_GeneralChanged) {
@@ -1720,7 +1722,8 @@ void COptionsWindow::OnEditorSettings()
 
 void COptionsWindow::OnSaveIni()
 {
-	SaveIniSection();
+	if (!SaveIniSection())
+		return;
 	SetIniEdit(false);
 }
 
@@ -1760,47 +1763,16 @@ void COptionsWindow::LoadIniSection()
 	m_HoldChange = false;
 }
 
-void COptionsWindow::SaveIniSection()
+bool COptionsWindow::SaveIniSection()
 {
-	m_ConfigDirty = true;
-
-	/*m_pBox->SetRefreshOnChange(false);
-
-	// Note: an incremental update would be more elegant but it would change the entry order in the ini,
-	//			hence it's better for the user to fully rebuild the section each time.
-	//
-	for (QList<QPair<QString, QString>>::const_iterator I = m_Settings.begin(); I != m_Settings.end(); ++I)
-		m_pBox->DelValue(I->first, I->second);
-
-	//QList<QPair<QString, QString>> NewSettings;
-	//QList<QPair<QString, QString>> OldSettings = m_Settings;
-
-	QStringList Section = SplitStr(ui.txtIniSection->toPlainText(), "\n");
-	foreach(const QString& Line, Section)
-	{
-		if (Line.isEmpty())
-			return;
-		StrPair Settings = Split2(Line, "=");
-		
-		//if (!OldSettings.removeOne(Settings))
-		//	NewSettings.append(Settings);
-
-		m_pBox->AppendText(Settings.first, Settings.second);
+	SB_STATUS Status = m_pBox->SbieIniSet(m_pBox->GetName(), "", m_pCodeEdit->GetCode());
+	if (!Status) {
+		theGUI->CheckResults(QList<SB_STATUS>() << Status, this);
+		return false;
 	}
 
-	//for (QList<QPair<QString, QString>>::const_iterator I = OldSettings.begin(); I != OldSettings.end(); ++I)
-	//	m_pBox->DelValue(I->first, I->second);
-	//
-	//for (QList<QPair<QString, QString>>::const_iterator I = NewSettings.begin(); I != NewSettings.end(); ++I)
-	//	m_pBox->AppendText(I->first, I->second);
-
-	m_pBox->SetRefreshOnChange(true);
-	m_pBox->CommitIniChanges();*/
-
-	//m_pBox->GetAPI()->SbieIniSet(m_pBox->GetName(), "", ui.txtIniSection->toPlainText());
-	m_pBox->SbieIniSet(m_pBox->GetName(), "", m_pCodeEdit->GetCode());
-
-	//LoadIniSection();
+	m_ConfigDirty = true;
+	return true;
 }
 
 #include "OptionsAccess.cpp"

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -1177,8 +1177,11 @@ void COptionsWindow::WriteAdvancedCheck(QCheckBox* pCheck, const QString& Name, 
 			continue;
 		if (!StrValue.isEmpty() && CurValue == StrValue)
 			StrValue.clear();
-		else
-			m_pBox->DelValue(Name, CurValue);
+		else {
+			SB_STATUS Status = m_pBox->DelValue(Name, CurValue);
+			if (!Status)
+				throw Status;
+		}
 	}
 
 	if (!StrValue.isEmpty()) {
@@ -1230,9 +1233,10 @@ QString COptionsWindow::ReadTextSafe(const QString& Name, const QString& Default
 	return Default;
 }
 
-void COptionsWindow::SaveConfig()
+bool COptionsWindow::SaveConfig()
 {
 	bool UpdatePaths = false;
+	bool Success = true;
 
 	m_pBox->SetRefreshOnChange(false);
 
@@ -1286,6 +1290,7 @@ void COptionsWindow::SaveConfig()
 	}
 	catch (SB_STATUS Status)
 	{
+		Success = false;
 		theGUI->CheckResults(QList<SB_STATUS>() << Status, theGUI);
 	}
 
@@ -1294,6 +1299,7 @@ void COptionsWindow::SaveConfig()
 
 	if (UpdatePaths)
 		TriggerPathReload();
+	return Success;
 }
 
 bool COptionsWindow::apply()
@@ -1325,7 +1331,8 @@ bool COptionsWindow::apply()
 			}
 		}
 
-		SaveConfig();
+		if (!SaveConfig())
+			return false;
 	}
 
 	LoadConfig();

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.cpp
@@ -1765,13 +1765,13 @@ void COptionsWindow::LoadIniSection()
 
 bool COptionsWindow::SaveIniSection()
 {
+	m_ConfigDirty = true; // A reported failure can still leave partially applied changes.
 	SB_STATUS Status = m_pBox->SbieIniSet(m_pBox->GetName(), "", m_pCodeEdit->GetCode());
 	if (!Status) {
 		theGUI->CheckResults(QList<SB_STATUS>() << Status, this);
 		return false;
 	}
 
-	m_ConfigDirty = true;
 	return true;
 }
 

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -572,7 +572,7 @@ protected:
 	void SaveFolders();
 
 	void LoadIniSection();
-	void SaveIniSection();
+	bool SaveIniSection();
 
 	void ApplyIniEditFont();
 	

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -424,7 +424,7 @@ protected:
 	bool RunImBox(const QStringList& Arguments);
 
 	void LoadConfig();
-	void SaveConfig();
+	bool SaveConfig();
 	void UpdateCurrentTab();
 
 	void CreateGeneral();

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -2395,6 +2395,7 @@ bool CSettingsWindow::apply()
 	}
 	else
 		SaveSettings();
+	m_SettingsDirty = false;
 	LoadSettings();
 	return true;
 }
@@ -2520,6 +2521,12 @@ void CSettingsWindow::OnTab(QWidget* pTab)
 {
 	m_pCurrentTab = pTab;
 
+	if (pTab != ui.tabEdit && m_SettingsDirty)
+	{
+		m_SettingsDirty = false;
+		LoadSettings();
+	}
+
 	if (pTab == ui.tabSupport)
 	{
 		if (CSettingsWindow::CertRefreshRequired())
@@ -2544,13 +2551,7 @@ void CSettingsWindow::OnTab(QWidget* pTab)
 		LoadIniSection();
 		//ui.txtIniSection->setReadOnly(true);
 	}
-	else if (m_SettingsDirty)
-	{
-		m_SettingsDirty = false;
-		LoadSettings();
-	}
-
-	if (pTab == ui.tabCompat && m_CompatLoaded != 1 && theAPI->IsConnected())
+	else if (pTab == ui.tabCompat && m_CompatLoaded != 1 && theAPI->IsConnected())
 	{
 		if(m_CompatLoaded == 0)
 			theGUI->CheckCompat(this, "OnCompat");

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -2393,8 +2393,10 @@ bool CSettingsWindow::apply()
 		if (!SaveIniSection())
 			return false;
 	}
-	else
+	else {
+		ReloadDirtySettings();
 		SaveSettings();
+	}
 	m_SettingsDirty = false;
 	LoadSettings();
 	return true;
@@ -2517,15 +2519,21 @@ void CSettingsWindow::OnTab()
 	OnTab(ui.tabs->currentWidget());
 }
 
+void CSettingsWindow::ReloadDirtySettings()
+{
+	// LoadSettings skips the service-backed fields while disconnected, so keep the invalidation until it can read them.
+	if (!m_SettingsDirty || !theAPI->IsConnected())
+		return;
+	m_SettingsDirty = false;
+	LoadSettings();
+}
+
 void CSettingsWindow::OnTab(QWidget* pTab)
 {
 	m_pCurrentTab = pTab;
 
-	if (pTab != ui.tabEdit && m_SettingsDirty)
-	{
-		m_SettingsDirty = false;
-		LoadSettings();
-	}
+	if (pTab != ui.tabEdit)
+		ReloadDirtySettings();
 
 	if (pTab == ui.tabSupport)
 	{

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -2395,6 +2395,8 @@ bool CSettingsWindow::apply()
 	}
 	else {
 		ReloadDirtySettings();
+		if (m_SettingsDirty)
+			return false;
 		SaveSettings();
 	}
 	m_SettingsDirty = false;

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -749,6 +749,7 @@ CSettingsWindow::CSettingsWindow(QWidget* parent)
 	connect(ui.btnAddCompat, SIGNAL(clicked(bool)), this, SLOT(OnAddCompat()));
 	connect(ui.btnDelCompat, SIGNAL(clicked(bool)), this, SLOT(OnDelCompat()));
 	m_CompatLoaded = 0;
+	m_SettingsDirty = false;
 	m_CompatChanged = false;
 	ui.chkNoCompat->setChecked(!theConf->GetBool("Options/AutoRunSoftCompat", true));
 
@@ -2543,7 +2544,13 @@ void CSettingsWindow::OnTab(QWidget* pTab)
 		LoadIniSection();
 		//ui.txtIniSection->setReadOnly(true);
 	}
-	else if (pTab == ui.tabCompat && m_CompatLoaded != 1 && theAPI->IsConnected())
+	else if (m_SettingsDirty)
+	{
+		m_SettingsDirty = false;
+		LoadSettings();
+	}
+
+	if (pTab == ui.tabCompat && m_CompatLoaded != 1 && theAPI->IsConnected())
 	{
 		if(m_CompatLoaded == 0)
 			theGUI->CheckCompat(this, "OnCompat");
@@ -2985,6 +2992,7 @@ void CSettingsWindow::OnSaveIni()
 	if (!SaveIniSection())
 		return;
 	SetIniEdit(false);
+	m_SettingsDirty = false;
 	LoadSettings();
 }
 
@@ -3025,6 +3033,7 @@ bool CSettingsWindow::SaveIniSection()
 		return false;
 	}
 
+	m_SettingsDirty = true; // A reported failure can still leave partially applied changes.
 	SB_STATUS Status = theAPI->SbieIniSet("GlobalSettings", "", m_pCodeEdit->GetCode());
 	if (!Status) {
 		theGUI->CheckResults(QList<SB_STATUS>() << Status, this);

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -2386,20 +2386,22 @@ void CSettingsWindow::SaveSettings()
 }
 
 
-void CSettingsWindow::apply()
+bool CSettingsWindow::apply()
 {
-	if (!ui.btnEditIni->isEnabled())
-		SaveIniSection();
+	if (!ui.btnEditIni->isEnabled()) {
+		if (!SaveIniSection())
+			return false;
+	}
 	else
 		SaveSettings();
 	LoadSettings();
+	return true;
 }
 
 void CSettingsWindow::ok()
 {
-	apply();
-
-	this->close();
+	if (apply())
+		this->close();
 }
 
 void CSettingsWindow::reject()
@@ -2980,7 +2982,8 @@ void CSettingsWindow::OnAutoCompletionToggled(int state)
 
 void CSettingsWindow::OnSaveIni()
 {
-	SaveIniSection();
+	if (!SaveIniSection())
+		return;
 	SetIniEdit(false);
 	LoadSettings();
 }
@@ -3015,13 +3018,19 @@ void CSettingsWindow::LoadIniSection()
 	m_HoldChange = false;
 }
 
-void CSettingsWindow::SaveIniSection()
+bool CSettingsWindow::SaveIniSection()
 {
-	if(theAPI->IsConnected())
-		//theAPI->SbieIniSet("GlobalSettings", "", ui.txtIniSection->toPlainText());
-		theAPI->SbieIniSet("GlobalSettings", "", m_pCodeEdit->GetCode());
+	if (!theAPI->IsConnected()) {
+		QMessageBox::critical(this, "Sandboxie-Plus", tr("Sandboxie is not connected."));
+		return false;
+	}
 
-	//LoadIniSection();
+	SB_STATUS Status = theAPI->SbieIniSet("GlobalSettings", "", m_pCodeEdit->GetCode());
+	if (!Status) {
+		theGUI->CheckResults(QList<SB_STATUS>() << Status, this);
+		return false;
+	}
+	return true;
 }
 
 QVariantMap GetRunEntry(const QString& sEntry)

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.h
@@ -208,6 +208,7 @@ protected:
 	bool	m_SkipSaveOnToggle; // Skip saving to config when applying reset settings
 	int 	m_CompatLoaded;
 	bool	m_SettingsDirty;
+	void	ReloadDirtySettings();
 	QString m_NewPassword;
 	bool	m_MessagesChanged;
 	bool	m_WarnProgsChanged;

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.h
@@ -207,6 +207,7 @@ protected:
 	CPendingChanges m_PendingChanges{this, &m_HoldChange, -1, true};
 	bool	m_SkipSaveOnToggle; // Skip saving to config when applying reset settings
 	int 	m_CompatLoaded;
+	bool	m_SettingsDirty;
 	QString m_NewPassword;
 	bool	m_MessagesChanged;
 	bool	m_WarnProgsChanged;

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.h
@@ -75,7 +75,7 @@ signals:
 
 public slots:
 	void ok();
-	void apply();
+	bool apply();
 
 	void showTab(const QString& Name, bool bExclusive = false, bool bExec = false);
 
@@ -193,7 +193,7 @@ protected:
 	void	LoadTemplates();
 
 	void	LoadIniSection();
-	void	SaveIniSection();
+	bool	SaveIniSection();
 	void    ApplyIniEditFont();
 
 	// Autocompletion support

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -19,3 +19,18 @@ foreach(case list-delete list-append list-retry list-noop bool-delete bool-succe
     add_test(NAME ini_write_${case} COMMAND ini_write_test ${case})
     set_tests_properties(ini_write_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endforeach()
+
+add_custom_command(
+    OUTPUT raw_ini_under_test.inc raw_ini_return.inc
+    COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/generate_raw_fixture.py" "${CMAKE_CURRENT_BINARY_DIR}"
+    DEPENDS generate_raw_fixture.py generate_fixture.py ../../SandMan/Windows/OptionsWindow.cpp ../../SandMan/Windows/SettingsWindow.cpp
+    VERBATIM
+)
+add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_return.inc)
+set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
+target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured)
+    add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
+    set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endforeach()

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_retu
 set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel global-partial-cancel)
+foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel global-partial-cancel global-support-pending global-addons-pending global-common-pending global-apply-clean global-saveini-clean)
     add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
     set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endforeach()

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_retu
 set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel global-partial-cancel global-support-pending global-addons-pending global-common-pending global-apply-clean global-saveini-clean)
+foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel global-partial-cancel global-support-pending global-addons-pending global-common-pending global-apply-clean global-saveini-clean global-partial-cancel-apply global-partial-cancel-ok global-dirty-offline-reconnect global-cancel-form-apply-control global-cancel-form-ok-control global-offline-no-tab-control)
     add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
     set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endforeach()

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(IniWriteTests LANGUAGES CXX)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+enable_testing()
+
+add_custom_command(
+    OUTPUT ini_write_under_test.inc fixture_return.inc
+    COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/generate_fixture.py" "${CMAKE_CURRENT_BINARY_DIR}"
+    DEPENDS generate_fixture.py ../../QSbieAPI/Sandboxie/SbieIni.cpp ../../SandMan/Windows/OptionsWindow.cpp
+    VERBATIM
+)
+add_executable(ini_write_test ini_write_test.cpp ini_write_under_test.inc fixture_return.inc)
+set_target_properties(ini_write_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
+target_include_directories(ini_write_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+target_link_libraries(ini_write_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+foreach(case list-delete list-append list-retry list-noop bool-delete bool-success checkbox-delete options-failure options-success options-reported-failure)
+    add_test(NAME ini_write_${case} COMMAND ini_write_test ${case})
+    set_tests_properties(ini_write_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endforeach()

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -27,6 +27,10 @@ add_custom_command(
     VERBATIM
 )
 add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_return.inc)
+foreach(case box-partial-cancel-save box-partial-cancel-offline)
+    add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
+    set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endforeach()
 set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_retu
 set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel global-partial-cancel global-support-pending global-addons-pending global-common-pending global-apply-clean global-saveini-clean global-partial-cancel-apply global-partial-cancel-ok global-dirty-offline-reconnect global-cancel-form-apply-control global-cancel-form-ok-control global-offline-no-tab-control)
+foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel global-partial-cancel global-support-pending global-addons-pending global-common-pending global-apply-clean global-saveini-clean global-partial-cancel-apply global-partial-cancel-ok global-dirty-offline-reconnect global-cancel-form-apply-control global-cancel-form-ok-control global-offline-no-tab-control global-dirty-offline-apply global-dirty-offline-ok global-clean-offline-apply-control global-dirty-reconnect-ok-control)
     add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
     set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endforeach()

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_retu
 set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel)
+foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel global-partial-cancel)
     add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
     set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endforeach()

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_retu
 set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured)
+foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial)
     add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
     set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endforeach()

--- a/SandboxiePlus/tests/ini-write/CMakeLists.txt
+++ b/SandboxiePlus/tests/ini-write/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(raw_ini_test raw_ini_test.cpp raw_ini_under_test.inc raw_ini_retu
 set_target_properties(raw_ini_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(raw_ini_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_link_libraries(raw_ini_test PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
-foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial)
+foreach(case box-save box-apply box-ok box-dirty box-empty box-cancel global-save global-apply global-ok global-offline global-empty global-cancel global-structured box-partial global-partial box-partial-cancel)
     add_test(NAME raw_ini_${case} COMMAND raw_ini_test ${case})
     set_tests_properties(raw_ini_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
 endforeach()

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -45,7 +45,7 @@ separate from these injected regression tests.
 
 ## Raw INI editor regressions
 
-A second executable, `raw_ini_test`, adds twenty-eight cases for the raw editor in
+A second executable, `raw_ini_test`, adds thirty-two cases for the raw editor in
 both the sandbox options and global settings dialogs. Save, Apply and OK must
 retain the text, cursor selection, undo history and edit controls on a reported
 write failure. They must not reload or close the dialog. Reconnecting and retrying
@@ -66,7 +66,8 @@ tab, never later over the new edit, and a successful Apply or Save must
 leave no invalidation behind. Apply/OK straight after cancelling reconcile
 the form through `ReloadDirtySettings` before `SaveSettings`, so the stale
 `ForceBoxDocs` checkbox is not written back; while disconnected the
-invalidation is kept because the real loader skips service-backed fields.
+invalidation is kept because the real loader skips service-backed fields,
+and Apply/OK refuse the structured save until it can be reconciled.
 Every case also accepts a `tabs` or `tree` argument to run one mode alone.
 Invalidating the structured view does not report success or reload over the
 active raw editor; it prevents stale fields after leaving it.

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -45,7 +45,7 @@ separate from these injected regression tests.
 
 ## Raw INI editor regressions
 
-A second executable, `raw_ini_test`, adds seventeen cases for the raw editor in
+A second executable, `raw_ini_test`, adds twenty-two cases for the raw editor in
 both the sandbox options and global settings dialogs. Save, Apply and OK must
 retain the text, cursor selection, undo history and edit controls on a reported
 write failure. They must not reload or close the dialog. Reconnecting and retrying
@@ -59,7 +59,11 @@ verify that the pending text survives a reported error and can be resubmitted.
 Separate cases cancel after a partial failure, change to a structured tab
 and verify that each dialog's tab handler reloads the current configuration;
 the global dialog tracks this with `m_SettingsDirty` because its structured
-view is otherwise only reloaded after a successful raw save.
+view is otherwise only reloaded after a successful raw save. The pending
+cases then detour through the support, add-ons or a common tab, change a
+real checkbox and move on: the reload must happen on the first structured
+tab, never later over the new edit, and a successful Apply or Save must
+leave no invalidation behind.
 Invalidating the structured view does not report success or reload over the
 active raw editor; it prevents stale fields after leaving it.
 

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -45,7 +45,7 @@ separate from these injected regression tests.
 
 ## Raw INI editor regressions
 
-A second executable, `raw_ini_test`, adds thirty-two cases for the raw editor in
+A second executable, `raw_ini_test`, adds thirty-four cases for the raw editor in
 both the sandbox options and global settings dialogs. Save, Apply and OK must
 retain the text, cursor selection, undo history and edit controls on a reported
 write failure. They must not reload or close the dialog. Reconnecting and retrying
@@ -69,6 +69,10 @@ the form through `ReloadDirtySettings` before `SaveSettings`, so the stale
 invalidation is kept because the real loader skips service-backed fields,
 and Apply/OK refuse the structured save until it can be reconciled.
 Every case also accepts a `tabs` or `tree` argument to run one mode alone.
+The sandbox `box-partial-cancel-save` and `box-partial-cancel-offline` cases
+also exercise Apply/OK without first visiting a structured tab. Pending
+invalidation is reconciled before saving and kept across offline navigation
+until the service reconnects.
 Invalidating the structured view does not report success or reload over the
 active raw editor; it prevents stale fields after leaving it.
 

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -45,7 +45,7 @@ separate from these injected regression tests.
 
 ## Raw INI editor regressions
 
-A second executable, `raw_ini_test`, adds twenty-two cases for the raw editor in
+A second executable, `raw_ini_test`, adds twenty-eight cases for the raw editor in
 both the sandbox options and global settings dialogs. Save, Apply and OK must
 retain the text, cursor selection, undo history and edit controls on a reported
 write failure. They must not reload or close the dialog. Reconnecting and retrying
@@ -63,7 +63,11 @@ view is otherwise only reloaded after a successful raw save. The pending
 cases then detour through the support, add-ons or a common tab, change a
 real checkbox and move on: the reload must happen on the first structured
 tab, never later over the new edit, and a successful Apply or Save must
-leave no invalidation behind.
+leave no invalidation behind. Apply/OK straight after cancelling reconcile
+the form through `ReloadDirtySettings` before `SaveSettings`, so the stale
+`ForceBoxDocs` checkbox is not written back; while disconnected the
+invalidation is kept because the real loader skips service-backed fields.
+Every case also accepts a `tabs` or `tree` argument to run one mode alone.
 Invalidating the structured view does not report success or reload over the
 active raw editor; it prevents stale fields after leaving it.
 

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -1,0 +1,44 @@
+# INI write error regression tests
+
+The list-update and safe-boolean helpers must return a failed mutation instead
+of continuing and reporting success. SandMan's options dialog must also stop
+Apply/OK after a reported save error rather than reloading and closing over the
+pending edits.
+
+This target extracts the production `CSbieIni::UpdateTextList`, `SetBoolSafe`,
+and the relevant `COptionsWindow` write, save, Apply and OK methods at build time.
+It uses real Qt containers and widgets with injected storage, status payloads,
+and surrounding dialog callbacks. It does not compile the entire real classes,
+connect to SbieSvc, exercise credentials, or emulate the driver's configuration
+cache. The fixture error code and all setting values are synthetic.
+
+```sh
+cmake -S SandboxiePlus/tests/ini-write -B build/ini-write -DCMAKE_BUILD_TYPE=Release
+cmake --build build/ini-write --config Release
+ctest --test-dir build/ini-write -C Release --output-on-failure
+```
+
+Python 3, a C++17 compiler, and Qt 5 or Qt 6 development packages with Widgets are
+required. CTest selects the offscreen platform. Pass `CMAKE_PREFIX_PATH` when Qt
+is not on the default search path. On Windows, the selected Qt DLL directory
+must also be on `PATH` when running tests.
+
+The ten cases cover failed deletion, failed append, partial progress and retry,
+unchanged/duplicate list values, safe-boolean failure and success, failed checkbox
+default removal, and options-dialog failure/success/retry. A separate injected
+save-stage failure tests Apply/OK independently of the list helper. Checks remain
+enabled in Release builds. The successful list path intentionally retains the
+existing multiset-diff behavior rather than introducing ordering changes.
+
+`generate_fixture.py --source-root <other-SandboxiePlus-directory> <output>`
+extracts the same methods from another revision for a before/after reproduction.
+The generated includes are build products and should not be committed.
+
+These changes are not a transaction: mutations completed before an error can
+remain applied, and the existing final commit/refresh path still runs. They do
+not add rollback, compare-and-swap, concurrent-writer protection, checked read
+enumeration, or propagation of errors hidden by other void-returning helpers
+(such as `CommitIniChanges` and `SetTextMap`). Retaining pending edits is not a
+promise that retrying every partially completed operation is safe. Actual
+service-denial and disk-write failure tests, plus the full SandMan build, remain
+separate from these injected regression tests.

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -45,15 +45,21 @@ separate from these injected regression tests.
 
 ## Raw INI editor regressions
 
-A second executable, `raw_ini_test`, adds thirteen cases for the raw editor in
+A second executable, `raw_ini_test`, adds sixteen cases for the raw editor in
 both the sandbox options and global settings dialogs. Save, Apply and OK must
 retain the text, cursor selection, undo history and edit controls on a reported
 write failure. They must not reload or close the dialog. Reconnecting and retrying
 must submit the same Unicode text, comments, duplicate keys and ordering.
 A disconnected global editor rejects the save without a write attempt. The
-sandbox's structured-view dirty flag changes only after a successful raw write.
+sandbox's structured view is invalidated before each raw write attempt, because
+a reported failure may still leave the backend partially changed.
 Explicit Cancel and successful empty-section writes keep their existing behavior.
-Each case runs with tab navigation and tree navigation.
+Each case runs with tab navigation and tree navigation. Partial-write fixtures
+verify that the pending text survives a reported error and can be resubmitted.
+A separate case cancels after a partial failure, changes to a structured tab
+and verifies that the existing tab handler reloads the current configuration.
+Invalidating the structured view does not report success or reload over the
+active raw editor; it prevents stale fields after leaving it.
 
 `generate_raw_fixture.py --source-root <other-SandboxiePlus-directory> <output>`
 extracts both dialogs' raw save methods and their callers for before/after runs.

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -45,7 +45,7 @@ separate from these injected regression tests.
 
 ## Raw INI editor regressions
 
-A second executable, `raw_ini_test`, adds sixteen cases for the raw editor in
+A second executable, `raw_ini_test`, adds seventeen cases for the raw editor in
 both the sandbox options and global settings dialogs. Save, Apply and OK must
 retain the text, cursor selection, undo history and edit controls on a reported
 write failure. They must not reload or close the dialog. Reconnecting and retrying
@@ -56,8 +56,10 @@ a reported failure may still leave the backend partially changed.
 Explicit Cancel and successful empty-section writes keep their existing behavior.
 Each case runs with tab navigation and tree navigation. Partial-write fixtures
 verify that the pending text survives a reported error and can be resubmitted.
-A separate case cancels after a partial failure, changes to a structured tab
-and verifies that the existing tab handler reloads the current configuration.
+Separate cases cancel after a partial failure, change to a structured tab
+and verify that each dialog's tab handler reloads the current configuration;
+the global dialog tracks this with `m_SettingsDirty` because its structured
+view is otherwise only reloaded after a successful raw save.
 Invalidating the structured view does not report success or reload over the
 active raw editor; it prevents stale fields after leaving it.
 

--- a/SandboxiePlus/tests/ini-write/README.md
+++ b/SandboxiePlus/tests/ini-write/README.md
@@ -42,3 +42,29 @@ enumeration, or propagation of errors hidden by other void-returning helpers
 promise that retrying every partially completed operation is safe. Actual
 service-denial and disk-write failure tests, plus the full SandMan build, remain
 separate from these injected regression tests.
+
+## Raw INI editor regressions
+
+A second executable, `raw_ini_test`, adds thirteen cases for the raw editor in
+both the sandbox options and global settings dialogs. Save, Apply and OK must
+retain the text, cursor selection, undo history and edit controls on a reported
+write failure. They must not reload or close the dialog. Reconnecting and retrying
+must submit the same Unicode text, comments, duplicate keys and ordering.
+A disconnected global editor rejects the save without a write attempt. The
+sandbox's structured-view dirty flag changes only after a successful raw write.
+Explicit Cancel and successful empty-section writes keep their existing behavior.
+Each case runs with tab navigation and tree navigation.
+
+`generate_raw_fixture.py --source-root <other-SandboxiePlus-directory> <output>`
+extracts both dialogs' raw save methods and their callers for before/after runs.
+The fixture uses real Qt text-edit, cursor and navigation widgets, but storage,
+message reporting and surrounding load callbacks are injected. It does not run
+CCodeEdit's completion/highlighting logic, the complete SandMan dialogs or SbieSvc.
+The fixtures model a reported failure, not a real disk fault or service outage.
+
+The raw helpers now report failure to every Save/Apply/OK caller. No raw section
+parser, format conversion, automatic retry, rollback or native publication API is
+added. This does not fix errors swallowed by the structured global
+`CSettingsWindow::SaveSettings` path, or guarantee that a service-reported failure
+left its cached or on-disk configuration unchanged. Window-manager close and the
+explicit Cancel operation are not recovery storage for unsaved text.

--- a/SandboxiePlus/tests/ini-write/generate_fixture.py
+++ b/SandboxiePlus/tests/ini-write/generate_fixture.py
@@ -1,0 +1,38 @@
+"""Extract the production mutation and options-save paths for fault injection."""
+import argparse
+import re
+from pathlib import Path
+
+
+def extract(text: str, signature: str) -> str:
+    matches = list(re.finditer(r'^' + signature + r'[^\n]*\n\{.*?^\}', text, re.M | re.S))
+    if len(matches) != 1:
+        raise ValueError(f'Expected one production function: {signature}')
+    return matches[0].group(0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output', type=Path)
+    parser.add_argument('--source-root', type=Path, default=Path(__file__).resolve().parents[2])
+    args = parser.parse_args()
+    ini = (args.source_root / 'QSbieAPI/Sandboxie/SbieIni.cpp').read_text(encoding='utf-8-sig')
+    options = (args.source_root / 'SandMan/Windows/OptionsWindow.cpp').read_text(encoding='utf-8-sig')
+    save = extract(options, r'(?:void|bool) COptionsWindow::SaveConfig\(\)')
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / 'fixture_return.inc').write_text(
+        '#define SAVE_CONFIG_RESULT ' + save.split()[0] + '\n', encoding='utf-8')
+    chunks = [
+        extract(ini, re.escape('SB_STATUS CSbieIni::SetBoolSafe(')),
+        extract(ini, re.escape('SB_STATUS CSbieIni::UpdateTextList(')),
+        extract(options, re.escape('void COptionsWindow::WriteAdvancedCheck(QCheckBox* pCheck, const QString& Name, const QString& OnValue')),
+        extract(options, re.escape('void COptionsWindow::WriteTextList(')),
+        save,
+        extract(options, re.escape('bool COptionsWindow::apply(')),
+        extract(options, re.escape('void COptionsWindow::ok(')),
+    ]
+    (args.output / 'ini_write_under_test.inc').write_text('\n\n'.join(chunks) + '\n', encoding='utf-8')
+
+
+if __name__ == '__main__':
+    main()

--- a/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
+++ b/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
@@ -22,6 +22,8 @@ def main() -> None:
                 declarations.append('#define ' + name.upper() + '_' + method.upper() + '_RESULT ' + function.split()[0])
     options = (args.source_root / "SandMan/Windows/OptionsWindow.cpp").read_text(encoding="utf-8-sig")
     chunks.append(extract(options, re.escape("void COptionsWindow::OnTab(QWidget*")))
+    settings = (args.source_root / "SandMan/Windows/SettingsWindow.cpp").read_text(encoding="utf-8-sig")
+    chunks.append(extract(settings, re.escape("void CSettingsWindow::OnTab(QWidget*")))
     args.output.mkdir(parents=True, exist_ok=True)
     (args.output / 'raw_ini_under_test.inc').write_text('\n\n'.join(chunks) + '\n', encoding='utf-8')
     (args.output / 'raw_ini_return.inc').write_text('\n'.join(declarations) + '\n', encoding='utf-8')

--- a/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
+++ b/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
@@ -24,6 +24,7 @@ def main() -> None:
     chunks.append(extract(options, re.escape("void COptionsWindow::OnTab(QWidget*")))
     settings = (args.source_root / "SandMan/Windows/SettingsWindow.cpp").read_text(encoding="utf-8-sig")
     chunks.append(extract(settings, re.escape("void CSettingsWindow::OnTab(QWidget*")))
+    chunks.append(extract(settings, re.escape("void CSettingsWindow::ReloadDirtySettings(")))
     args.output.mkdir(parents=True, exist_ok=True)
     (args.output / 'raw_ini_under_test.inc').write_text('\n\n'.join(chunks) + '\n', encoding='utf-8')
     (args.output / 'raw_ini_return.inc').write_text('\n'.join(declarations) + '\n', encoding='utf-8')

--- a/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
+++ b/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
@@ -1,0 +1,29 @@
+"""Extract raw INI save callers from both production dialogs for fault injection."""
+import argparse
+import re
+from pathlib import Path
+
+from generate_fixture import extract
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output', type=Path)
+    parser.add_argument('--source-root', type=Path, default=Path(__file__).resolve().parents[2])
+    args = parser.parse_args()
+    chunks = []
+    declarations = []
+    for name in ('OptionsWindow', 'SettingsWindow'):
+        text = (args.source_root / 'SandMan/Windows' / (name + '.cpp')).read_text(encoding='utf-8-sig')
+        for method in ('SaveIniSection', 'OnSaveIni', 'apply', 'ok', 'SetIniEdit', 'OnIniChanged', 'OnCancelEdit'):
+            function = extract(text, r'(?:void|bool) ' + re.escape('C' + name + '::' + method + '('))
+            chunks.append(function)
+            if method in ('SaveIniSection', 'apply'):
+                declarations.append('#define ' + name.upper() + '_' + method.upper() + '_RESULT ' + function.split()[0])
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / 'raw_ini_under_test.inc').write_text('\n\n'.join(chunks) + '\n', encoding='utf-8')
+    (args.output / 'raw_ini_return.inc').write_text('\n'.join(declarations) + '\n', encoding='utf-8')
+
+
+if __name__ == '__main__':
+    main()

--- a/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
+++ b/SandboxiePlus/tests/ini-write/generate_raw_fixture.py
@@ -20,6 +20,8 @@ def main() -> None:
             chunks.append(function)
             if method in ('SaveIniSection', 'apply'):
                 declarations.append('#define ' + name.upper() + '_' + method.upper() + '_RESULT ' + function.split()[0])
+    options = (args.source_root / "SandMan/Windows/OptionsWindow.cpp").read_text(encoding="utf-8-sig")
+    chunks.append(extract(options, re.escape("void COptionsWindow::OnTab(QWidget*")))
     args.output.mkdir(parents=True, exist_ok=True)
     (args.output / 'raw_ini_under_test.inc').write_text('\n\n'.join(chunks) + '\n', encoding='utf-8')
     (args.output / 'raw_ini_return.inc').write_text('\n'.join(declarations) + '\n', encoding='utf-8')

--- a/SandboxiePlus/tests/ini-write/ini_write_test.cpp
+++ b/SandboxiePlus/tests/ini-write/ini_write_test.cpp
@@ -29,6 +29,8 @@ public:
 	bool WithTemplates = false;
 	bool Refresh = true;
 	int Commits = 0;
+	CSbieIni* GetAPI() { return this; }
+	bool IsConnected() const { return true; }
 
 	SB_STATUS SetBoolSafe(const QString& Setting, bool Value);
 	SB_STATUS UpdateTextList(const QString& Setting, const QStringList& List, bool withTemplates);
@@ -83,6 +85,7 @@ public:
 	CSbieIni Box;
 	SBoxPointer m_pBox{&Box};
 	bool m_Template = false;
+	bool m_ConfigDirty = false;
 	QString m_Password;
 	qint64 m_ImageSize = 0;
 	QStringList Desired{"HarddiskVolume1,1234-ABCD"};

--- a/SandboxiePlus/tests/ini-write/ini_write_test.cpp
+++ b/SandboxiePlus/tests/ini-write/ini_write_test.cpp
@@ -112,7 +112,7 @@ public:
 	void close() { ++Closed; }
 	void TriggerPathReload() { ++PathReloads; }
 	void OnSetPassword() { CHECK(false); }
-	void SaveIniSection() { CHECK(false); }
+	bool SaveIniSection() { CHECK(false); return false; }
 	void LoadConfig() { ++Loads; }
 	void UpdateCurrentTab() { ++TabUpdates; }
 	void CloseINetEdit() {}

--- a/SandboxiePlus/tests/ini-write/ini_write_test.cpp
+++ b/SandboxiePlus/tests/ini-write/ini_write_test.cpp
@@ -1,0 +1,274 @@
+#include <QApplication>
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QMap>
+#include <QPushButton>
+#include <QStringList>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+
+#define CHECK(condition) do { if (!(condition)) { \
+	std::fprintf(stderr, "FAIL at line %d: %s\n", __LINE__, #condition); std::exit(1); \
+} } while (0)
+
+struct SB_STATUS {
+	int Code = 0;
+	QString Detail;
+	operator bool() const { return Code == 0; }
+};
+#define SB_OK SB_STATUS()
+
+class CSbieIni
+{
+public:
+	QMap<QString, QStringList> Values;
+	QStringList Calls;
+	int FailCall = 0;
+	bool WithTemplates = false;
+	bool Refresh = true;
+	int Commits = 0;
+
+	SB_STATUS SetBoolSafe(const QString& Setting, bool Value);
+	SB_STATUS UpdateTextList(const QString& Setting, const QStringList& List, bool withTemplates);
+	QStringList GetTextList(const QString& Setting, bool withTemplates)
+	{
+		WithTemplates = withTemplates;
+		return Values.value(Setting);
+	}
+	SB_STATUS DelValue(const QString& Setting, const QString& Value)
+	{
+		Calls.append("delete:" + Value);
+		if (Calls.size() == FailCall) return {-123, Calls.last()};
+		Values[Setting].removeAll(Value);
+		return SB_OK;
+	}
+	SB_STATUS AppendText(const QString& Setting, const QString& Value)
+	{
+		Calls.append("append:" + Value);
+		if (Calls.size() == FailCall) return {-123, Calls.last()};
+		Values[Setting].append(Value);
+		return SB_OK;
+	}
+	QString GetText(const QString&) { return "y"; }
+	QString GetName() { return "SyntheticBox"; }
+	void SetRefreshOnChange(bool Value) { Refresh = Value; }
+	void CommitIniChanges() { ++Commits; }
+	QString GetBoxImagePath() { return QString(); }
+	void ImBoxCreate(qint64, const QString&) { CHECK(false); }
+};
+using CSandBoxPlus = CSbieIni;
+
+struct SBoxPointer {
+	CSbieIni* Box;
+	CSbieIni* operator->() const { return Box; }
+	template<class T> T* objectCast() { return static_cast<T*>(Box); }
+};
+struct SGui {
+	QList<SB_STATUS> Errors;
+	void CheckResults(const QList<SB_STATUS>& Results, SGui*) { Errors.append(Results); }
+} Gui;
+static SGui* theGUI = &Gui;
+struct SMessageBox {
+	static void critical(void*, const char*, const QString&) { CHECK(false); }
+};
+#define QMessageBox SMessageBox
+
+#include "fixture_return.inc"
+
+class COptionsWindow
+{
+public:
+	CSbieIni Box;
+	SBoxPointer m_pBox{&Box};
+	bool m_Template = false;
+	QString m_Password;
+	qint64 m_ImageSize = 0;
+	QStringList Desired{"HarddiskVolume1,1234-ABCD"};
+	int Loads = 0, TabUpdates = 0, Closed = 0, PathReloads = 0;
+	bool FailStage = false;
+	QPushButton EditIni;
+	QCheckBox Encrypt;
+	QDialogButtonBox Buttons{QDialogButtonBox::Apply};
+	struct {
+		QPushButton* btnEditIni;
+		QCheckBox* chkEncrypt;
+		QDialogButtonBox* buttonBox;
+	} ui;
+	COptionsWindow()
+	{
+		ui.btnEditIni = &EditIni;
+		ui.chkEncrypt = &Encrypt;
+		ui.buttonBox = &Buttons;
+		ui.buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
+	}
+	void WriteAdvancedCheck(QCheckBox*, const QString&, const QString&, const QString&);
+	void WriteTextList(const QString&, const QStringList&);
+	SAVE_CONFIG_RESULT SaveConfig();
+	bool apply();
+	void ok();
+	QString tr(const char* text) { return QString::fromUtf8(text); }
+	void close() { ++Closed; }
+	void TriggerPathReload() { ++PathReloads; }
+	void OnSetPassword() { CHECK(false); }
+	void SaveIniSection() { CHECK(false); }
+	void LoadConfig() { ++Loads; }
+	void UpdateCurrentTab() { ++TabUpdates; }
+	void CloseINetEdit() {}
+	void CloseNetFwEdit() {}
+	void CloseAccessEdit() {}
+	void CloseOptionEdit() {}
+	void CloseCopyEdit() {}
+	void CloseNetProxyEdit() {}
+	void SaveDebug() {}
+#define STAGE(flag, method) bool flag = false; void method() { flag = false; }
+	STAGE(m_GeneralChanged, SaveGeneral)
+	STAGE(m_CopyRulesChanged, SaveCopyRules)
+	STAGE(m_GroupsChanged, SaveGroups)
+	STAGE(m_ForcedChanged, SaveForced)
+	STAGE(m_StopChanged, SaveStop)
+	STAGE(m_StartChanged, SaveStart)
+	STAGE(m_INetBlockChanged, SaveINetAccess)
+	STAGE(m_NetFwRulesChanged, SaveNetFwRules)
+	STAGE(m_DnsFilterChanged, SaveDnsFilter)
+	STAGE(m_NetProxyChanged, SaveNetProxy)
+	STAGE(m_NetworkChanged, SaveNetwork)
+	STAGE(m_AccessChanged, SaveAccessList)
+	STAGE(m_RecoveryChanged, SaveRecoveryList)
+	STAGE(m_TemplatesChanged, SaveTemplates)
+	STAGE(m_FoldersChanged, SaveFolders)
+#undef STAGE
+	bool m_AdvancedChanged = true;
+	void SaveAdvanced()
+	{
+		if (FailStage) throw SB_STATUS{-321, "stage"};
+		WriteTextList("DiskSerialNumber", Desired);
+		m_AdvancedChanged = false;
+	}
+};
+
+#include "ini_write_under_test.inc"
+
+static void ListDelete()
+{
+	CSbieIni Ini;
+	Ini.Values["Test"] = QStringList{"old-a", "old-b"};
+	Ini.FailCall = 1;
+	SB_STATUS Result = Ini.UpdateTextList("Test", {"new"}, false);
+	CHECK(!Result && Result.Code == -123 && Result.Detail == "delete:old-a");
+	CHECK(Ini.Calls == QStringList{"delete:old-a"});
+	CHECK((Ini.Values["Test"] == QStringList{"old-a", "old-b"}));
+}
+static void ListAppend()
+{
+	CSbieIni Ini;
+	Ini.FailCall = 1;
+	SB_STATUS Result = Ini.UpdateTextList("Test", {"a", "b"}, false);
+	CHECK(!Result && Result.Code == -123 && Result.Detail == "append:a");
+	CHECK(Ini.Calls == QStringList{"append:a"} && Ini.Values["Test"].isEmpty());
+}
+static void ListRetry()
+{
+	CSbieIni Ini;
+	Ini.Values["Test"] = QStringList{"old"};
+	Ini.FailCall = 3;
+	SB_STATUS Result = Ini.UpdateTextList("Test", {"a", "b", "c"}, false);
+	CHECK(!Result && Result.Detail == "append:b");
+	CHECK(Ini.Values["Test"] == QStringList{"a"});
+	CHECK((Ini.Calls == QStringList{"delete:old", "append:a", "append:b"}));
+	Ini.FailCall = 0;
+	CHECK(Ini.UpdateTextList("Test", {"a", "b", "c"}, false));
+	CHECK((Ini.Values["Test"] == QStringList{"a", "b", "c"}));
+	CHECK(Ini.Calls.size() == 5);
+}
+static void ListNoop()
+{
+	CSbieIni Ini;
+	Ini.Values["Test"] = QStringList{"a", "a", "b"};
+	CHECK(Ini.UpdateTextList("Test", {"a", "a", "b"}, true));
+	CHECK(Ini.WithTemplates && Ini.Calls.isEmpty());
+	CHECK(Ini.UpdateTextList("Test", {"b", "a", "a"}, false));
+	CHECK(!Ini.WithTemplates && Ini.Calls.isEmpty());
+}
+static void BoolDelete()
+{
+	CSbieIni Ini;
+	Ini.Values["Test"] = QStringList{"excluded.exe,n", "n"};
+	Ini.FailCall = 1;
+	SB_STATUS Result = Ini.SetBoolSafe("Test", true);
+	CHECK(!Result && Result.Detail == "delete:n");
+	CHECK(Ini.Calls == QStringList{"delete:n"});
+	CHECK((Ini.Values["Test"] == QStringList{"excluded.exe,n", "n"}));
+}
+static void BoolSuccess()
+{
+	CSbieIni Ini;
+	Ini.Values["Test"] = QStringList{"excluded.exe,n", "n"};
+	CHECK(Ini.SetBoolSafe("Test", true));
+	CHECK((Ini.Values["Test"] == QStringList{"excluded.exe,n", "y"}));
+	Ini.Calls.clear();
+	CHECK(Ini.SetBoolSafe("Test", true) && Ini.Calls.isEmpty());
+}
+static void CheckboxDelete()
+{
+	COptionsWindow Window;
+	Window.Box.Values["Test"] = QStringList{"excluded.exe,n", "n"};
+	Window.Box.FailCall = 1;
+	QCheckBox Check;
+	Check.setChecked(true);
+	bool Thrown = false;
+	try { Window.WriteAdvancedCheck(&Check, "Test", "y", ""); }
+	catch (SB_STATUS Result) { Thrown = !Result && Result.Detail == "delete:n"; }
+	CHECK(Thrown && Window.Box.Calls == QStringList{"delete:n"});
+}
+static void OptionsFailure()
+{
+	COptionsWindow Window;
+	Window.Box.FailCall = 1;
+	CHECK(!Window.apply());
+	CHECK(Window.Loads == 0 && Window.TabUpdates == 0);
+	CHECK(Window.m_AdvancedChanged && Window.Box.Refresh);
+	CHECK(Window.ui.buttonBox->button(QDialogButtonBox::Apply)->isEnabled());
+	CHECK(Gui.Errors.size() == 1 && Gui.Errors[0].Code == -123);
+	Window.Box.FailCall = 2;
+	Window.ok();
+	CHECK(Window.Closed == 0 && Window.Loads == 0);
+	Window.Box.FailCall = 0;
+	Window.ok();
+	CHECK(Window.Closed == 1 && Window.Loads == 1 && Window.TabUpdates == 1);
+	CHECK(!Window.m_AdvancedChanged && Window.Box.Refresh);
+	CHECK(Window.Box.Values["DiskSerialNumber"] == Window.Desired);
+}
+static void OptionsReportedFailure()
+{
+	COptionsWindow Window;
+	Window.FailStage = true;
+	Window.ok();
+	CHECK(Window.Closed == 0 && Window.Loads == 0 && Window.TabUpdates == 0);
+	CHECK(Window.m_AdvancedChanged && Window.Box.Refresh);
+	CHECK(Window.ui.buttonBox->button(QDialogButtonBox::Apply)->isEnabled());
+	CHECK(Gui.Errors.size() == 1 && Gui.Errors[0].Code == -321);
+}
+static void OptionsSuccess()
+{
+	COptionsWindow Window;
+	Window.ok();
+	CHECK(Window.Closed == 1 && Window.Loads == 1 && Window.TabUpdates == 1);
+	CHECK(Window.Box.Refresh && Window.Box.Commits == 1);
+	CHECK(!Window.m_AdvancedChanged && Gui.Errors.isEmpty());
+	CHECK(!Window.ui.buttonBox->button(QDialogButtonBox::Apply)->isEnabled());
+}
+int main(int argc, char** argv)
+{
+	QApplication App(argc, argv);
+	QMap<QString, std::function<void()>> Cases{
+		{"list-delete", ListDelete}, {"list-append", ListAppend}, {"list-retry", ListRetry},
+		{"list-noop", ListNoop}, {"bool-delete", BoolDelete}, {"bool-success", BoolSuccess},
+		{"checkbox-delete", CheckboxDelete}, {"options-failure", OptionsFailure}, {"options-success", OptionsSuccess}, {"options-reported-failure", OptionsReportedFailure}
+	};
+	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
+	Cases.value(QString::fromUtf8(argv[1]))();
+	std::printf("PASS: %s\n", argv[1]);
+	return 0;
+}

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -89,6 +89,7 @@ struct SEditorWindow : QDialog {
 	bool m_HoldChange = false;
 	int Loads = 0, IniLoads = 0, Closed = 0, TabUpdates = 0, StructuredSaves = 0;
 	struct {
+		QWidget* tabEdit;
 		QTabWidget* tabs;
 		QPushButton* btnEditIni;
 		QPushButton* btnSaveIni;
@@ -100,8 +101,9 @@ struct SEditorWindow : QDialog {
 	{
 		Gui.Errors.clear(); Gui.ErrorParent = nullptr; SMessageBox::Criticals = 0;
 		if (!tree) m_pTree = nullptr;
-		ui = {&Tabs, &EditIni, &SaveIni, &CancelEdit, &Encrypt, &Buttons};
+		ui = {nullptr, &Tabs, &EditIni, &SaveIni, &CancelEdit, &Encrypt, &Buttons};
 		for (int i = 0; i < 7; ++i) Tabs.addTab(new QWidget(), QString::number(i));
+		ui.tabEdit = Tabs.widget(Tabs.count() - 1);
 		Tabs.widget(5)->setEnabled(false);
 		ui.buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
 		Code.SetCode(QString::fromUtf8("# synthetic \xc3\xa9\xe6\xbc\xa2\nEnabled=y\nTest=a\nTest=b\n\n"));
@@ -123,6 +125,9 @@ class COptionsWindow : public SEditorWindow {
 public:
 	using SEditorWindow::SEditorWindow;
 	SBoxPointer m_pBox{&Storage};
+	QWidget* m_pCurrentTab = nullptr;
+	QString StructuredCode = Storage.Persisted;
+	void OnTab(QWidget*);
 	bool m_Template = false, m_GeneralChanged = false, m_ConfigDirty = false;
 	QString m_Password;
 	qint64 m_ImageSize = 0;
@@ -135,7 +140,7 @@ public:
 	void OnCancelEdit();
 	void OnSetPassword() { CHECK(false); }
 	bool SaveConfig() { ++StructuredSaves; return true; }
-	void LoadConfig() { ++Loads; m_ConfigDirty = false; }
+	void LoadConfig() { ++Loads; m_ConfigDirty = false; StructuredCode = Storage.Persisted; }
 };
 class CSettingsWindow : public SEditorWindow {
 public:
@@ -216,7 +221,7 @@ static void BoxDirty(bool tree)
 	Window.SetIniEdit(true);
 	Window.Storage.Fail = true;
 	Window.OnSaveIni();
-	CHECK(!Window.m_ConfigDirty);
+	CHECK(Window.m_ConfigDirty);
 	Window.m_ConfigDirty = true;
 	Window.OnSaveIni();
 	CHECK(Window.m_ConfigDirty && Window.Storage.Writes == 2);
@@ -298,6 +303,26 @@ template<class T> static void PartialFailureRetry(bool tree)
 	}
 }
 
+static void PartialCancelReload(bool tree)
+{
+	COptionsWindow Window(tree);
+	Window.SetIniEdit(true);
+	const QString Pending = Window.Code.GetCode();
+	const QString Before = Window.StructuredCode;
+	Window.Storage.Fail = true;
+	Window.Storage.PartialWrite = true;
+	Window.OnSaveIni();
+	CHECK(Window.Storage.Writes == 1 && Window.Storage.Persisted != Before);
+	CHECK(Window.Code.GetCode() == Pending && Window.Loads == 0 && Window.Closed == 0);
+	CHECK(Gui.Errors.size() == 1 && Gui.Errors[0].Code == -123);
+	Window.OnCancelEdit();
+	CHECK(Window.Code.GetCode() == Window.Storage.Persisted && Window.Storage.Writes == 1);
+	Window.OnTab(Window.ui.tabs->widget(0));
+	CHECK(Window.Loads == 1 && Window.StructuredCode == Window.Storage.Persisted);
+	CHECK(Window.StructuredCode != Before && !Window.m_ConfigDirty);
+	CHECK(Window.Storage.Writes == 1 && Window.Closed == 0 && Gui.Errors.size() == 1);
+}
+
 int main(int argc, char** argv)
 {
 	QApplication App(argc, argv);
@@ -311,7 +336,8 @@ int main(int argc, char** argv)
 		{"global-ok", [](bool tree) { FailureRetry<CSettingsWindow>(tree, "ok"); }},
 		{"global-offline", GlobalOffline}, {"global-empty", Empty<CSettingsWindow>},
 		{"global-cancel", Cancel<CSettingsWindow>}, {"global-structured", Structured},
-		{"box-partial", PartialFailureRetry<COptionsWindow>}, {"global-partial", PartialFailureRetry<CSettingsWindow>}
+		{"box-partial", PartialFailureRetry<COptionsWindow>}, {"global-partial", PartialFailureRetry<CSettingsWindow>},
+		{"box-partial-cancel", PartialCancelReload}
 	};
 	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
 	for (bool Tree : {false, true}) Cases.value(QString::fromUtf8(argv[1]))(Tree);

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -47,6 +47,7 @@ struct SStorage {
 		return {};
 	}
 	bool IsConnected() const { return Connected; }
+	SStorage* GetAPI() { return this; }
 	QString GetName() const { return "SyntheticBox"; }
 	QString GetText(const QString&) const { return "y"; }
 	QString GetBoxImagePath() const { return {}; }
@@ -143,6 +144,7 @@ public:
 	SBoxPointer m_pBox{&Storage};
 	QWidget* m_pCurrentTab = nullptr;
 	QString StructuredCode = Storage.Persisted;
+	int StaleStructuredSaves = 0;
 	void OnTab(QWidget*);
 	bool m_Template = false, m_GeneralChanged = false, m_ConfigDirty = false;
 	QString m_Password;
@@ -155,8 +157,12 @@ public:
 	void OnIniChanged();
 	void OnCancelEdit();
 	void OnSetPassword() { CHECK(false); }
-	bool SaveConfig() { ++StructuredSaves; return true; }
-	void LoadConfig() { ++Loads; m_ConfigDirty = false; StructuredCode = Storage.Persisted; }
+	bool SaveConfig() {
+		++StructuredSaves;
+		if (m_GeneralChanged && StructuredCode != Storage.Persisted) ++StaleStructuredSaves;
+		return true;
+	}
+	void LoadConfig() { ++Loads; m_ConfigDirty = false; m_GeneralChanged = false; StructuredCode = Storage.Persisted; }
 };
 class CSettingsWindow : public SEditorWindow {
 public:
@@ -370,6 +376,33 @@ static void PartialCancelReload(bool tree)
 	CHECK(Window.Storage.Writes == 1 && Window.Closed == 0 && Gui.Errors.size() == 1);
 }
 
+static void BoxCancelThenStructuredSave(bool tree, bool offline)
+{
+	for (const auto& Action : {"apply", "ok"}) {
+		COptionsWindow Window(tree);
+		Window.m_GeneralChanged = true;
+		Window.SetIniEdit(true);
+		Window.Storage.Fail = true;
+		Window.Storage.PartialWrite = true;
+		Window.OnSaveIni();
+		Window.OnCancelEdit();
+		Window.Storage.Fail = false;
+		Window.Storage.Connected = !offline;
+		Invoke(Window, Action);
+		CHECK(Window.StaleStructuredSaves == 0);
+		if (offline) {
+			CHECK(Window.StructuredSaves == 0 && Window.m_ConfigDirty && Window.Closed == 0);
+			Window.OnTab(Window.ui.tabs->widget(0));
+			CHECK(Window.m_ConfigDirty && Window.Loads == 0);
+			Window.Storage.Connected = true;
+			Invoke(Window, Action);
+		}
+		CHECK(Window.StaleStructuredSaves == 0 && !Window.m_ConfigDirty);
+		CHECK(Window.StructuredCode == Window.Storage.Persisted);
+		CHECK(Window.Closed == (QString(Action) == "ok" ? 1 : 0));
+	}
+}
+
 static void GlobalPartialCancelReload(bool tree)
 {
  CSettingsWindow Window(tree);
@@ -513,6 +546,8 @@ int main(int argc, char** argv)
 		{"global-cancel", Cancel<CSettingsWindow>}, {"global-structured", Structured},
 		{"box-partial", PartialFailureRetry<COptionsWindow>}, {"global-partial", PartialFailureRetry<CSettingsWindow>},
 		{"box-partial-cancel", PartialCancelReload}, {"global-partial-cancel", GlobalPartialCancelReload},
+		{"box-partial-cancel-save", [](bool tree) { BoxCancelThenStructuredSave(tree, false); }},
+		{"box-partial-cancel-offline", [](bool tree) { BoxCancelThenStructuredSave(tree, true); }},
 		{"global-support-pending", GlobalSupportPending}, {"global-addons-pending", GlobalAddonsPending},
 		{"global-common-pending", GlobalCommonPending}, {"global-apply-clean", GlobalApplyClean},
 		{"global-saveini-clean", GlobalSaveIniClean},

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -67,7 +67,7 @@ struct SGui {
 } Gui;
 [[maybe_unused]] static SGui* theGUI = &Gui;
 static SStorage* theAPI = nullptr;
-struct SConfig { int GetInt(const char*, int) { CHECK(false); return 0; } } Conf;
+struct SConfig { int GetInt(const char*, int fallback) { return fallback; } } Conf;
 static SConfig* theConf = &Conf;
 template<class... Args> static void TryRefreshCert(Args...) { CHECK(false); }
 struct SMessageBox {
@@ -159,10 +159,18 @@ public:
 	QWidget* m_pCurrentTab = nullptr;
 	int m_CompatLoaded = 0;
 	bool m_SettingsDirty = false;
-	static bool CertRefreshRequired() { CHECK(false); return false; }
+	static bool CertRefreshRequired() { return false; }
 	void GetUpdates() { CHECK(false); }
 	void OnTab(QWidget*);
-	CSettingsWindow(bool tree) : SEditorWindow(tree) { theAPI = &Storage; }
+	QPushButton Current, UpdateAddons;
+	QCheckBox AutoUpdate, Pending;
+	CSettingsWindow(bool tree) : SEditorWindow(tree)
+	{
+		theAPI = &Storage;
+		ui.tabSupport = Tabs.widget(1); ui.tabAddons = Tabs.widget(2);
+		ui.lblCurrent = &Current; ui.lblUpdateAddons = &UpdateAddons; ui.chkAutoUpdate = &AutoUpdate;
+		Current.setText("synthetic current");
+	}
 	~CSettingsWindow() { theAPI = nullptr; }
 	SETTINGSWINDOW_SAVEINISECTION_RESULT SaveIniSection();
 	SETTINGSWINDOW_APPLY_RESULT apply();
@@ -173,7 +181,7 @@ public:
 	void OnCancelEdit();
 	void SaveSettings() { ++StructuredSaves; }
 	QString StructuredCode = Storage.Persisted;
-	void LoadSettings() { ++Loads; StructuredCode = Storage.Persisted; }
+	void LoadSettings() { ++Loads; StructuredCode = Storage.Persisted; Pending.setChecked(Storage.Persisted.contains("Pending=y")); }
 };
 
 #include "raw_ini_under_test.inc"
@@ -359,6 +367,45 @@ static void GlobalPartialCancelReload(bool tree)
  CHECK(Window.StructuredCode == Window.Storage.Persisted);
 }
 
+static void GlobalPendingAfterPartialCancel(bool tree, int detour)
+{
+	CSettingsWindow Window(tree);
+	Window.SetIniEdit(true);
+	Window.Storage.Fail = true;
+	Window.Storage.PartialWrite = true;
+	Window.OnSaveIni();
+	Window.OnCancelEdit();
+	CHECK(Window.Loads == 0 && !Window.Pending.isChecked());
+	Window.OnTab(Window.ui.tabs->widget(detour));
+	CHECK(Window.Loads == 1 && !Window.m_SettingsDirty);
+	Window.Pending.setChecked(true);
+	Window.OnTab(Window.ui.tabs->widget(0));
+	CHECK(Window.Loads == 1 && Window.Pending.isChecked());
+	CHECK(Window.StructuredCode == Window.Storage.Persisted);
+	CHECK(Window.Code.GetCode() == Window.Storage.Persisted);
+}
+static void GlobalSupportPending(bool tree) { GlobalPendingAfterPartialCancel(tree, 1); }
+static void GlobalAddonsPending(bool tree) { GlobalPendingAfterPartialCancel(tree, 2); }
+static void GlobalCommonPending(bool tree) { GlobalPendingAfterPartialCancel(tree, 3); }
+static void GlobalApplyClean(bool tree)
+{
+	CSettingsWindow Window(tree);
+	Window.SetIniEdit(true);
+	Window.apply();
+	CHECK(Window.Storage.Writes == 1 && Window.Loads == 1 && !Window.m_SettingsDirty);
+	Window.OnTab(Window.ui.tabs->widget(0));
+	CHECK(Window.Loads == 1);
+}
+static void GlobalSaveIniClean(bool tree)
+{
+	CSettingsWindow Window(tree);
+	Window.SetIniEdit(true);
+	Window.OnSaveIni();
+	CHECK(Window.Storage.Writes == 1 && Window.Loads == 1 && !Window.m_SettingsDirty);
+	Window.OnTab(Window.ui.tabs->widget(0));
+	CHECK(Window.Loads == 1);
+}
+
 int main(int argc, char** argv)
 {
 	QApplication App(argc, argv);
@@ -373,7 +420,10 @@ int main(int argc, char** argv)
 		{"global-offline", GlobalOffline}, {"global-empty", Empty<CSettingsWindow>},
 		{"global-cancel", Cancel<CSettingsWindow>}, {"global-structured", Structured},
 		{"box-partial", PartialFailureRetry<COptionsWindow>}, {"global-partial", PartialFailureRetry<CSettingsWindow>},
-		{"box-partial-cancel", PartialCancelReload}, {"global-partial-cancel", GlobalPartialCancelReload}
+		{"box-partial-cancel", PartialCancelReload}, {"global-partial-cancel", GlobalPartialCancelReload},
+		{"global-support-pending", GlobalSupportPending}, {"global-addons-pending", GlobalAddonsPending},
+		{"global-common-pending", GlobalCommonPending}, {"global-apply-clean", GlobalApplyClean},
+		{"global-saveini-clean", GlobalSaveIniClean}
 	};
 	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
 	for (bool Tree : {false, true}) Cases.value(QString::fromUtf8(argv[1]))(Tree);

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -55,6 +55,9 @@ struct SBoxPointer {
 	template<class T> T* objectCast() { return static_cast<T*>(Box); }
 };
 struct SGui {
+	struct Addons { void UpdateAddonsWhenNotCached() { CHECK(false); } } addons;
+	Addons* GetAddonManager() { return &addons; }
+	void CheckCompat(QWidget*, const char*) { CHECK(false); }
 	QList<SB_STATUS> Errors;
 	QWidget* ErrorParent = nullptr;
 	void CheckResults(const QList<SB_STATUS>& results, QWidget* parent)
@@ -64,6 +67,9 @@ struct SGui {
 } Gui;
 [[maybe_unused]] static SGui* theGUI = &Gui;
 static SStorage* theAPI = nullptr;
+struct SConfig { int GetInt(const char*, int) { CHECK(false); return 0; } } Conf;
+static SConfig* theConf = &Conf;
+template<class... Args> static void TryRefreshCert(Args...) { CHECK(false); }
 struct SMessageBox {
 	static int Criticals;
 	static void critical(QWidget*, const char*, const QString&) { ++Criticals; }
@@ -96,6 +102,12 @@ struct SEditorWindow : QDialog {
 		QPushButton* btnCancelEdit;
 		QCheckBox* chkEncrypt;
 		QDialogButtonBox* buttonBox;
+		QWidget* tabSupport = nullptr;
+		QWidget* tabAddons = nullptr;
+		QWidget* tabCompat = nullptr;
+		QPushButton* lblCurrent = nullptr;
+		QPushButton* lblUpdateAddons = nullptr;
+		QCheckBox* chkAutoUpdate = nullptr;
 	} ui;
 	SEditorWindow(bool tree)
 	{
@@ -144,6 +156,12 @@ public:
 };
 class CSettingsWindow : public SEditorWindow {
 public:
+	QWidget* m_pCurrentTab = nullptr;
+	int m_CompatLoaded = 0;
+	bool m_SettingsDirty = false;
+	static bool CertRefreshRequired() { CHECK(false); return false; }
+	void GetUpdates() { CHECK(false); }
+	void OnTab(QWidget*);
 	CSettingsWindow(bool tree) : SEditorWindow(tree) { theAPI = &Storage; }
 	~CSettingsWindow() { theAPI = nullptr; }
 	SETTINGSWINDOW_SAVEINISECTION_RESULT SaveIniSection();
@@ -154,7 +172,8 @@ public:
 	void OnIniChanged();
 	void OnCancelEdit();
 	void SaveSettings() { ++StructuredSaves; }
-	void LoadSettings() { ++Loads; }
+	QString StructuredCode = Storage.Persisted;
+	void LoadSettings() { ++Loads; StructuredCode = Storage.Persisted; }
 };
 
 #include "raw_ini_under_test.inc"
@@ -323,6 +342,23 @@ static void PartialCancelReload(bool tree)
 	CHECK(Window.Storage.Writes == 1 && Window.Closed == 0 && Gui.Errors.size() == 1);
 }
 
+static void GlobalPartialCancelReload(bool tree)
+{
+ CSettingsWindow Window(tree);
+ Window.SetIniEdit(true);
+ const QString Before = Window.StructuredCode;
+ Window.Storage.Fail = true;
+ Window.Storage.PartialWrite = true;
+ Window.OnSaveIni();
+ CHECK(Window.Storage.Persisted != Before);
+ CHECK(Window.Loads == 0);
+ Window.OnCancelEdit();
+ CHECK(Window.Code.GetCode() == Window.Storage.Persisted);
+ CHECK(Window.ui.btnEditIni->isEnabled());
+ Window.OnTab(Window.ui.tabs->widget(0));
+ CHECK(Window.StructuredCode == Window.Storage.Persisted);
+}
+
 int main(int argc, char** argv)
 {
 	QApplication App(argc, argv);
@@ -337,7 +373,7 @@ int main(int argc, char** argv)
 		{"global-offline", GlobalOffline}, {"global-empty", Empty<CSettingsWindow>},
 		{"global-cancel", Cancel<CSettingsWindow>}, {"global-structured", Structured},
 		{"box-partial", PartialFailureRetry<COptionsWindow>}, {"global-partial", PartialFailureRetry<CSettingsWindow>},
-		{"box-partial-cancel", PartialCancelReload}
+		{"box-partial-cancel", PartialCancelReload}, {"global-partial-cancel", GlobalPartialCancelReload}
 	};
 	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
 	for (bool Tree : {false, true}) Cases.value(QString::fromUtf8(argv[1]))(Tree);

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -479,6 +479,25 @@ static void GlobalOfflineReconcile(bool tree, bool visitOffline)
 	CHECK(!window.m_SettingsDirty);
 }
 
+static void GlobalOfflineStructuredSave(bool tree, const QString& action, bool dirty, bool reconnect)
+{
+	CSettingsWindow window(tree);
+	if (dirty) PreparePartialBooleanCancel(window);
+	window.Storage.Connected = false;
+	if (reconnect) window.Storage.Connected = true;
+	Invoke(window, action);
+	std::printf("TRACE: offline %s nav=%s dirty=%d reconnect=%d saves=%d staleSaves=%d dirtyNow=%d closed=%d\n",
+		qPrintable(action), tree ? "tree" : "tabs", dirty, reconnect, window.StructuredSaves,
+		window.StaleStructuredSaves, window.m_SettingsDirty, window.Closed);
+	CHECK(window.StaleStructuredSaves == 0);
+	if (dirty && !reconnect) {
+		CHECK(window.StructuredSaves == 0 && window.m_SettingsDirty && window.Closed == 0);
+	} else {
+		CHECK(window.StructuredSaves == 1 && !window.m_SettingsDirty);
+		if (action == "ok") CHECK(window.Closed == 1);
+	}
+}
+
 int main(int argc, char** argv)
 {
 	QApplication App(argc, argv);
@@ -502,7 +521,11 @@ int main(int argc, char** argv)
 		{"global-dirty-offline-reconnect", [](bool tree) { GlobalOfflineReconcile(tree, true); }},
 		{"global-cancel-form-apply-control", [](bool tree) { GlobalCancelThenStructuredSave(tree, "apply", true); }},
 		{"global-cancel-form-ok-control", [](bool tree) { GlobalCancelThenStructuredSave(tree, "ok", true); }},
-		{"global-offline-no-tab-control", [](bool tree) { GlobalOfflineReconcile(tree, false); }}
+		{"global-offline-no-tab-control", [](bool tree) { GlobalOfflineReconcile(tree, false); }},
+		{"global-dirty-offline-apply", [](bool tree) { GlobalOfflineStructuredSave(tree, "apply", true, false); }},
+		{"global-dirty-offline-ok", [](bool tree) { GlobalOfflineStructuredSave(tree, "ok", true, false); }},
+		{"global-clean-offline-apply-control", [](bool tree) { GlobalOfflineStructuredSave(tree, "apply", false, false); }},
+		{"global-dirty-reconnect-ok-control", [](bool tree) { GlobalOfflineStructuredSave(tree, "ok", true, true); }}
 	};
 	if ((argc != 2 && argc != 3) || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
 	const QString mode = argc == 3 ? QString::fromUtf8(argv[2]) : "both";

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -27,6 +27,7 @@ struct SB_STATUS {
 struct SStorage {
 	bool Connected = true;
 	bool Fail = false;
+	bool PartialWrite = false;
 	QString Persisted = "# synthetic baseline\nEnabled=y\n";
 	QString Section, Setting, Submitted;
 	int Writes = 0;
@@ -34,7 +35,10 @@ struct SStorage {
 	{
 		++Writes;
 		Section = section; Setting = setting; Submitted = value;
-		if (Fail) return {-123, "synthetic_write_failure"};
+		if (Fail) {
+			if (PartialWrite) Persisted = "# synthetic partial write\nEnabled=y\n";
+			return {-123, "synthetic_write_failure"};
+		}
 		Persisted = value;
 		return {};
 	}
@@ -269,6 +273,31 @@ static void Structured(bool tree)
 	CHECK(Window.Storage.Writes == 0 && Gui.Errors.isEmpty());
 }
 
+template<class T> static void PartialFailureRetry(bool tree)
+{
+	for (const auto& Action : {"save", "apply", "ok"}) {
+		T Window(tree);
+		Window.SetIniEdit(true);
+		const QString Pending = Window.Code.GetCode();
+		const QString Before = Window.Storage.Persisted;
+		Window.Storage.Fail = true;
+		Window.Storage.PartialWrite = true;
+		Invoke(Window, Action);
+		CHECK(Window.Storage.Writes == 1 && Window.Storage.Persisted != Before);
+		CHECK(Window.Storage.Persisted != Pending && Window.Code.GetCode() == Pending);
+		CHECK(Window.Loads == 0 && Window.IniLoads == 0 && Window.Closed == 0);
+		CHECK(Window.StructuredSaves == 0 && Gui.Errors.size() == 1);
+		CHECK(Gui.Errors[0].Code == -123 && Gui.ErrorParent == &Window);
+		CheckEditing(Window);
+		Window.Storage.Fail = false;
+		Window.Storage.PartialWrite = false;
+		Invoke(Window, Action);
+		CHECK(Window.Storage.Writes == 2 && Window.Storage.Persisted == Pending);
+		CHECK(Window.Code.GetCode() == Pending && Gui.Errors.size() == 1);
+		CHECK(Window.StructuredSaves == 0 && Window.Closed == (QString(Action) == "ok" ? 1 : 0));
+	}
+}
+
 int main(int argc, char** argv)
 {
 	QApplication App(argc, argv);
@@ -281,7 +310,8 @@ int main(int argc, char** argv)
 		{"global-apply", [](bool tree) { FailureRetry<CSettingsWindow>(tree, "apply"); }},
 		{"global-ok", [](bool tree) { FailureRetry<CSettingsWindow>(tree, "ok"); }},
 		{"global-offline", GlobalOffline}, {"global-empty", Empty<CSettingsWindow>},
-		{"global-cancel", Cancel<CSettingsWindow>}, {"global-structured", Structured}
+		{"global-cancel", Cancel<CSettingsWindow>}, {"global-structured", Structured},
+		{"box-partial", PartialFailureRetry<COptionsWindow>}, {"global-partial", PartialFailureRetry<CSettingsWindow>}
 	};
 	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
 	for (bool Tree : {false, true}) Cases.value(QString::fromUtf8(argv[1]))(Tree);

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -28,6 +28,7 @@ struct SStorage {
 	bool Connected = true;
 	bool Fail = false;
 	bool PartialWrite = false;
+	bool PartialBooleanWrite = false;
 	QString Persisted = "# synthetic baseline\nEnabled=y\n";
 	QString Section, Setting, Submitted;
 	int Writes = 0;
@@ -36,7 +37,10 @@ struct SStorage {
 		++Writes;
 		Section = section; Setting = setting; Submitted = value;
 		if (Fail) {
-			if (PartialWrite) Persisted = "# synthetic partial write\nEnabled=y\n";
+			if (PartialWrite) {
+				Persisted = "# synthetic partial write\nEnabled=y\n";
+				if (PartialBooleanWrite) Persisted += "ForceBoxDocs=y\n";
+			}
 			return {-123, "synthetic_write_failure"};
 		}
 		Persisted = value;
@@ -162,8 +166,10 @@ public:
 	static bool CertRefreshRequired() { return false; }
 	void GetUpdates() { CHECK(false); }
 	void OnTab(QWidget*);
+	void ReloadDirtySettings();
 	QPushButton Current, UpdateAddons;
-	QCheckBox AutoUpdate, Pending;
+	QCheckBox AutoUpdate, Pending, ForceBoxDocs;
+	int StaleStructuredSaves = 0;
 	CSettingsWindow(bool tree) : SEditorWindow(tree)
 	{
 		theAPI = &Storage;
@@ -179,9 +185,23 @@ public:
 	void SetIniEdit(bool);
 	void OnIniChanged();
 	void OnCancelEdit();
-	void SaveSettings() { ++StructuredSaves; }
+	void SaveSettings()
+	{
+		++StructuredSaves;
+		if (ForceBoxDocs.isChecked() != Storage.Persisted.contains("ForceBoxDocs=y"))
+			++StaleStructuredSaves;
+	}
 	QString StructuredCode = Storage.Persisted;
-	void LoadSettings() { ++Loads; StructuredCode = Storage.Persisted; Pending.setChecked(Storage.Persisted.contains("Pending=y")); }
+	void LoadSettings()
+	{
+		++Loads;
+		// Service-owned fields are not read while disconnected in the real loader.
+		if (Storage.IsConnected()) {
+			StructuredCode = Storage.Persisted;
+			ForceBoxDocs.setChecked(Storage.Persisted.contains("ForceBoxDocs=y"));
+		}
+		Pending.setChecked(Storage.Persisted.contains("Pending=y"));
+	}
 };
 
 #include "raw_ini_under_test.inc"
@@ -406,6 +426,59 @@ static void GlobalSaveIniClean(bool tree)
 	CHECK(Window.Loads == 1);
 }
 
+
+static void PreparePartialBooleanCancel(CSettingsWindow& window)
+{
+	window.ui.tabs->setCurrentWidget(window.ui.tabEdit);
+	window.SetIniEdit(true);
+	window.OnIniChanged();
+	window.Storage.Fail = true;
+	window.Storage.PartialWrite = true;
+	window.Storage.PartialBooleanWrite = true;
+	window.OnSaveIni();
+	CHECK(window.Storage.Persisted.contains("ForceBoxDocs=y"));
+	CHECK(!window.ForceBoxDocs.isChecked() && window.m_SettingsDirty);
+	CHECK(window.Loads == 0 && window.Storage.Writes == 1);
+	window.OnCancelEdit();
+	CHECK(window.ui.btnEditIni->isEnabled());
+	CHECK(window.ui.tabs->currentWidget() == window.ui.tabEdit);
+	CHECK(window.ui.buttonBox->button(QDialogButtonBox::Apply)->isEnabled());
+	CHECK(window.Code.GetCode() == window.Storage.Persisted);
+	window.Storage.Fail = false;
+	window.Storage.PartialWrite = false;
+}
+
+static void GlobalCancelThenStructuredSave(bool tree, const QString& action, bool visitForm)
+{
+	CSettingsWindow window(tree);
+	PreparePartialBooleanCancel(window);
+	if (visitForm) window.OnTab(window.ui.tabs->widget(0));
+	Invoke(window, action);
+	std::printf("TRACE: %s nav=%s formVisited=%d saves=%d staleSaves=%d loads=%d dirty=%d closed=%d\n",
+		qPrintable(action), tree ? "tree" : "tabs", visitForm, window.StructuredSaves,
+		window.StaleStructuredSaves, window.Loads, window.m_SettingsDirty, window.Closed);
+	CHECK(window.StaleStructuredSaves == 0);
+}
+
+static void GlobalOfflineReconcile(bool tree, bool visitOffline)
+{
+	CSettingsWindow window(tree);
+	PreparePartialBooleanCancel(window);
+	window.Storage.Connected = false;
+	if (visitOffline) window.OnTab(window.ui.tabs->widget(0));
+	const bool dirtyWhileOffline = window.m_SettingsDirty;
+	CHECK(!window.ForceBoxDocs.isChecked());
+	window.Storage.Connected = true;
+	window.OnTab(window.ui.tabs->widget(3));
+	std::printf("TRACE: reconnect nav=%s offlineVisit=%d dirtyOffline=%d dirtyNow=%d field=%d stored=%d loads=%d\n",
+		tree ? "tree" : "tabs", visitOffline, dirtyWhileOffline, window.m_SettingsDirty,
+		window.ForceBoxDocs.isChecked(), window.Storage.Persisted.contains("ForceBoxDocs=y"), window.Loads);
+	CHECK(dirtyWhileOffline);
+	CHECK(window.ForceBoxDocs.isChecked());
+	CHECK(window.StructuredCode == window.Storage.Persisted);
+	CHECK(!window.m_SettingsDirty);
+}
+
 int main(int argc, char** argv)
 {
 	QApplication App(argc, argv);
@@ -423,10 +496,21 @@ int main(int argc, char** argv)
 		{"box-partial-cancel", PartialCancelReload}, {"global-partial-cancel", GlobalPartialCancelReload},
 		{"global-support-pending", GlobalSupportPending}, {"global-addons-pending", GlobalAddonsPending},
 		{"global-common-pending", GlobalCommonPending}, {"global-apply-clean", GlobalApplyClean},
-		{"global-saveini-clean", GlobalSaveIniClean}
+		{"global-saveini-clean", GlobalSaveIniClean},
+		{"global-partial-cancel-apply", [](bool tree) { GlobalCancelThenStructuredSave(tree, "apply", false); }},
+		{"global-partial-cancel-ok", [](bool tree) { GlobalCancelThenStructuredSave(tree, "ok", false); }},
+		{"global-dirty-offline-reconnect", [](bool tree) { GlobalOfflineReconcile(tree, true); }},
+		{"global-cancel-form-apply-control", [](bool tree) { GlobalCancelThenStructuredSave(tree, "apply", true); }},
+		{"global-cancel-form-ok-control", [](bool tree) { GlobalCancelThenStructuredSave(tree, "ok", true); }},
+		{"global-offline-no-tab-control", [](bool tree) { GlobalOfflineReconcile(tree, false); }}
 	};
-	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
-	for (bool Tree : {false, true}) Cases.value(QString::fromUtf8(argv[1]))(Tree);
-	std::printf("PASS: %s (tabs and tree)\n", argv[1]);
+	if ((argc != 2 && argc != 3) || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
+	const QString mode = argc == 3 ? QString::fromUtf8(argv[2]) : "both";
+	if (mode != "tabs" && mode != "tree" && mode != "both") return 2;
+	for (bool Tree : {false, true}) {
+		if (mode == "both" || (Tree ? mode == "tree" : mode == "tabs"))
+			Cases.value(QString::fromUtf8(argv[1]))(Tree);
+	}
+	std::printf("PASS: %s (%s)\n", argv[1], qPrintable(mode));
 	return 0;
 }

--- a/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
+++ b/SandboxiePlus/tests/ini-write/raw_ini_test.cpp
@@ -1,0 +1,290 @@
+#include <QApplication>
+#include <QCheckBox>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QMap>
+#include <QPushButton>
+#include <QStringList>
+#include <QTabWidget>
+#include <QTextEdit>
+#include <QTextCursor>
+#include <QTreeWidget>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+
+#define CHECK(condition) do { if (!(condition)) { \
+	std::fprintf(stderr, "FAIL at line %d: %s\n", __LINE__, #condition); std::exit(1); \
+} } while (0)
+
+struct SB_STATUS {
+	int Code = 0;
+	QString Detail;
+	operator bool() const { return Code == 0; }
+};
+
+struct SStorage {
+	bool Connected = true;
+	bool Fail = false;
+	QString Persisted = "# synthetic baseline\nEnabled=y\n";
+	QString Section, Setting, Submitted;
+	int Writes = 0;
+	SB_STATUS SbieIniSet(const QString& section, const QString& setting, const QString& value)
+	{
+		++Writes;
+		Section = section; Setting = setting; Submitted = value;
+		if (Fail) return {-123, "synthetic_write_failure"};
+		Persisted = value;
+		return {};
+	}
+	bool IsConnected() const { return Connected; }
+	QString GetName() const { return "SyntheticBox"; }
+	QString GetText(const QString&) const { return "y"; }
+	QString GetBoxImagePath() const { return {}; }
+	void ImBoxCreate(qint64, const QString&) { CHECK(false); }
+};
+using CSandBoxPlus = SStorage;
+struct SBoxPointer {
+	SStorage* Box;
+	SStorage* operator->() const { return Box; }
+	template<class T> T* objectCast() { return static_cast<T*>(Box); }
+};
+struct SGui {
+	QList<SB_STATUS> Errors;
+	QWidget* ErrorParent = nullptr;
+	void CheckResults(const QList<SB_STATUS>& results, QWidget* parent)
+	{
+		Errors.append(results); ErrorParent = parent;
+	}
+} Gui;
+[[maybe_unused]] static SGui* theGUI = &Gui;
+static SStorage* theAPI = nullptr;
+struct SMessageBox {
+	static int Criticals;
+	static void critical(QWidget*, const char*, const QString&) { ++Criticals; }
+};
+int SMessageBox::Criticals = 0;
+#define QMessageBox SMessageBox
+
+struct SCodeEdit {
+	QTextEdit Editor;
+	QString GetCode() const { return Editor.toPlainText(); }
+	void SetCode(const QString& value) { Editor.setPlainText(value); }
+};
+struct SEditorWindow : QDialog {
+	SStorage Storage;
+	SCodeEdit Code;
+	SCodeEdit* m_pCodeEdit = &Code;
+	QTreeWidget Navigation;
+	QTreeWidget* m_pTree = &Navigation;
+	QTabWidget Tabs;
+	QPushButton EditIni, SaveIni, CancelEdit;
+	QCheckBox Encrypt;
+	QDialogButtonBox Buttons{QDialogButtonBox::Apply};
+	bool m_HoldChange = false;
+	int Loads = 0, IniLoads = 0, Closed = 0, TabUpdates = 0, StructuredSaves = 0;
+	struct {
+		QTabWidget* tabs;
+		QPushButton* btnEditIni;
+		QPushButton* btnSaveIni;
+		QPushButton* btnCancelEdit;
+		QCheckBox* chkEncrypt;
+		QDialogButtonBox* buttonBox;
+	} ui;
+	SEditorWindow(bool tree)
+	{
+		Gui.Errors.clear(); Gui.ErrorParent = nullptr; SMessageBox::Criticals = 0;
+		if (!tree) m_pTree = nullptr;
+		ui = {&Tabs, &EditIni, &SaveIni, &CancelEdit, &Encrypt, &Buttons};
+		for (int i = 0; i < 7; ++i) Tabs.addTab(new QWidget(), QString::number(i));
+		Tabs.widget(5)->setEnabled(false);
+		ui.buttonBox->button(QDialogButtonBox::Apply)->setEnabled(true);
+		Code.SetCode(QString::fromUtf8("# synthetic \xc3\xa9\xe6\xbc\xa2\nEnabled=y\nTest=a\nTest=b\n\n"));
+	}
+	bool close() { ++Closed; return QDialog::close(); }
+	void LoadIniSection() { ++IniLoads; Code.SetCode(Storage.Persisted); }
+	void UpdateCurrentTab() { ++TabUpdates; }
+	void CloseINetEdit() {}
+	void CloseNetFwEdit() {}
+	void CloseAccessEdit() {}
+	void CloseOptionEdit() {}
+	void CloseCopyEdit() {}
+	void CloseNetProxyEdit() {}
+};
+
+#include "raw_ini_return.inc"
+
+class COptionsWindow : public SEditorWindow {
+public:
+	using SEditorWindow::SEditorWindow;
+	SBoxPointer m_pBox{&Storage};
+	bool m_Template = false, m_GeneralChanged = false, m_ConfigDirty = false;
+	QString m_Password;
+	qint64 m_ImageSize = 0;
+	OPTIONSWINDOW_SAVEINISECTION_RESULT SaveIniSection();
+	OPTIONSWINDOW_APPLY_RESULT apply();
+	void OnSaveIni();
+	void ok();
+	void SetIniEdit(bool);
+	void OnIniChanged();
+	void OnCancelEdit();
+	void OnSetPassword() { CHECK(false); }
+	bool SaveConfig() { ++StructuredSaves; return true; }
+	void LoadConfig() { ++Loads; m_ConfigDirty = false; }
+};
+class CSettingsWindow : public SEditorWindow {
+public:
+	CSettingsWindow(bool tree) : SEditorWindow(tree) { theAPI = &Storage; }
+	~CSettingsWindow() { theAPI = nullptr; }
+	SETTINGSWINDOW_SAVEINISECTION_RESULT SaveIniSection();
+	SETTINGSWINDOW_APPLY_RESULT apply();
+	void OnSaveIni();
+	void ok();
+	void SetIniEdit(bool);
+	void OnIniChanged();
+	void OnCancelEdit();
+	void SaveSettings() { ++StructuredSaves; }
+	void LoadSettings() { ++Loads; }
+};
+
+#include "raw_ini_under_test.inc"
+
+static void CheckEditing(const SEditorWindow& window)
+{
+	CHECK(!window.ui.btnEditIni->isEnabled());
+	CHECK(window.ui.btnSaveIni->isEnabled() && window.ui.btnCancelEdit->isEnabled());
+	CHECK(window.ui.buttonBox->button(QDialogButtonBox::Apply)->isEnabled());
+	if (window.m_pTree) CHECK(!window.m_pTree->isEnabled());
+	else CHECK(!window.ui.tabs->isTabEnabled(4));
+}
+template<class T> static void Invoke(T& window, const QString& action)
+{
+	if (action == "save") window.OnSaveIni();
+	else if (action == "apply") window.apply();
+	else if (action == "ok") window.ok();
+	else CHECK(false);
+}
+template<class T> static void FailureRetry(bool tree, const QString& action)
+{
+	T Window(tree);
+	Window.SetIniEdit(true);
+	Window.Code.Editor.moveCursor(QTextCursor::End);
+	Window.Code.Editor.insertPlainText("# pending edit\n");
+	QTextCursor Cursor = Window.Code.Editor.textCursor();
+	Cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor, 5);
+	Window.Code.Editor.setTextCursor(Cursor);
+	CHECK(Window.Code.Editor.document()->isUndoAvailable());
+	const QString Pending = Window.Code.GetCode();
+	const QString Persisted = Window.Storage.Persisted;
+	Window.Storage.Fail = true;
+	Invoke(Window, action);
+	CHECK(Window.Storage.Writes == 1 && Window.Storage.Submitted == Pending);
+	CHECK(Window.Storage.Persisted == Persisted && Window.Code.GetCode() == Pending);
+	CHECK(Window.Loads == 0 && Window.IniLoads == 0 && Window.Closed == 0 && Window.TabUpdates == 0);
+	CHECK(Window.StructuredSaves == 0 && SMessageBox::Criticals == 0);
+	CHECK(Gui.Errors.size() == 1 && Gui.Errors[0].Code == -123);
+	CHECK(Gui.Errors[0].Detail == "synthetic_write_failure" && Gui.ErrorParent == &Window);
+	CheckEditing(Window);
+	CHECK(Window.Code.Editor.textCursor().position() == Cursor.position());
+	CHECK(Window.Code.Editor.textCursor().anchor() == Cursor.anchor());
+	CHECK(Window.Code.Editor.document()->isUndoAvailable());
+	Window.Storage.Fail = false;
+	Invoke(Window, action);
+	CHECK(Window.Storage.Writes == 2 && Window.Storage.Persisted == Pending);
+	CHECK(Window.Code.GetCode() == Pending && Gui.Errors.size() == 1);
+	CHECK(Window.StructuredSaves == 0);
+	CHECK(Window.Closed == (action == "ok" ? 1 : 0));
+	CHECK(Window.Storage.Setting.isEmpty());
+	if (action == "save") {
+		CHECK(Window.ui.btnEditIni->isEnabled());
+		CHECK(!Window.ui.btnSaveIni->isEnabled() && !Window.ui.btnCancelEdit->isEnabled());
+		if (Window.m_pTree) CHECK(Window.m_pTree->isEnabled());
+		else {
+			CHECK(Window.ui.tabs->isTabEnabled(4));
+			CHECK(!Window.ui.tabs->isTabEnabled(5));
+		}
+	}
+}
+static void BoxDirty(bool tree)
+{
+	COptionsWindow Window(tree);
+	Window.SetIniEdit(true);
+	Window.Storage.Fail = true;
+	Window.OnSaveIni();
+	CHECK(!Window.m_ConfigDirty);
+	Window.m_ConfigDirty = true;
+	Window.OnSaveIni();
+	CHECK(Window.m_ConfigDirty && Window.Storage.Writes == 2);
+	Window.m_ConfigDirty = false;
+	Window.Storage.Fail = false;
+	Window.OnSaveIni();
+	CHECK(Window.m_ConfigDirty && Window.Storage.Section == "SyntheticBox");
+}
+static void GlobalOffline(bool tree)
+{
+	for (const auto& Action : {"save", "apply", "ok"}) {
+		CSettingsWindow Window(tree);
+		Window.SetIniEdit(true);
+		const QString Pending = Window.Code.GetCode();
+		Window.Storage.Connected = false;
+		Invoke(Window, Action);
+		CHECK(Window.Storage.Writes == 0 && Window.Loads == 0 && Window.Closed == 0);
+		CHECK(Window.StructuredSaves == 0 && Window.Code.GetCode() == Pending);
+		CHECK(SMessageBox::Criticals == 1 && Gui.Errors.isEmpty());
+		CheckEditing(Window);
+		Window.Storage.Connected = true;
+		Invoke(Window, Action);
+		CHECK(Window.Storage.Writes == 1 && Window.Storage.Persisted == Pending);
+		CHECK(Window.Storage.Section == "GlobalSettings" && Window.Loads == 1);
+	}
+}
+template<class T> static void Empty(bool tree)
+{
+	T Window(tree);
+	Window.SetIniEdit(true);
+	Window.Code.SetCode("");
+	Window.OnSaveIni();
+	CHECK(Window.Storage.Writes == 1 && Window.Storage.Submitted.isEmpty());
+	CHECK(Window.Storage.Persisted.isEmpty() && Gui.Errors.isEmpty());
+	CHECK(Window.ui.btnEditIni->isEnabled());
+}
+template<class T> static void Cancel(bool tree)
+{
+	T Window(tree);
+	Window.SetIniEdit(true);
+	Window.Storage.Fail = true;
+	Window.OnSaveIni();
+	Window.OnCancelEdit();
+	CHECK(Window.IniLoads == 1 && Window.Storage.Writes == 1);
+	CHECK(Window.Code.GetCode() == Window.Storage.Persisted);
+	CHECK(Window.ui.btnEditIni->isEnabled() && Window.Closed == 0);
+}
+static void Structured(bool tree)
+{
+	CSettingsWindow Window(tree);
+	Window.SetIniEdit(false);
+	Window.ok();
+	CHECK(Window.StructuredSaves == 1 && Window.Loads == 1 && Window.Closed == 1);
+	CHECK(Window.Storage.Writes == 0 && Gui.Errors.isEmpty());
+}
+
+int main(int argc, char** argv)
+{
+	QApplication App(argc, argv);
+	QMap<QString, std::function<void(bool)>> Cases{
+		{"box-save", [](bool tree) { FailureRetry<COptionsWindow>(tree, "save"); }},
+		{"box-apply", [](bool tree) { FailureRetry<COptionsWindow>(tree, "apply"); }},
+		{"box-ok", [](bool tree) { FailureRetry<COptionsWindow>(tree, "ok"); }},
+		{"box-dirty", BoxDirty}, {"box-empty", Empty<COptionsWindow>}, {"box-cancel", Cancel<COptionsWindow>},
+		{"global-save", [](bool tree) { FailureRetry<CSettingsWindow>(tree, "save"); }},
+		{"global-apply", [](bool tree) { FailureRetry<CSettingsWindow>(tree, "apply"); }},
+		{"global-ok", [](bool tree) { FailureRetry<CSettingsWindow>(tree, "ok"); }},
+		{"global-offline", GlobalOffline}, {"global-empty", Empty<CSettingsWindow>},
+		{"global-cancel", Cancel<CSettingsWindow>}, {"global-structured", Structured}
+	};
+	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
+	for (bool Tree : {false, true}) Cases.value(QString::fromUtf8(argv[1]))(Tree);
+	std::printf("PASS: %s (tabs and tree)\n", argv[1]);
+	return 0;
+}


### PR DESCRIPTION
`CSbieIni::UpdateTextList` ignored the status of both `DelValue` and `AppendText`, and `SetBoolSafe` ignored the `DelValue` status (it already returned the `AppendText` one), so a failed write still came back as success and sandman then reloaded/closed the dialog over whatever the user had typed

what changes

- `UpdateTextList` stops at the first failed `DelValue`/`AppendText` and returns that status, `SetBoolSafe` now propagates the failed `DelValue` too
- `COptionsWindow::SaveConfig` / `SaveIniSection` and `CSettingsWindow::apply` / `SaveIniSection` now return `bool`, and the save/apply/ok handlers bail out on failure instead of reloading and closing
- raw ini editor on a failed `SbieIniSet` keeps the text, selection, undo history and controls, reports through `theGUI->CheckResults`, and the sandbox structured view is invalidated before each raw write (`m_ConfigDirty`) because a reported failure may still have changed part of the section
- same thing for the global editor in `CSettingsWindow`: a new `m_SettingsDirty` is set before each raw write, and `OnTab` reconciles it first for every tab except the raw editor, so cancelling after a partial failure and going anywhere in the form (including support and add-ons, whose loader also resets the update/add-on controls) reloads `LoadSettings()` once before any new edit, never later over it. `apply()` clears the flag on its own success path too, `OnSaveIni` was the only one doing it before (58440bb + 52a7331, both found in review, the sandbox window already had this)
- the dirty reconcile now lives in `ReloadDirtySettings()`, which `apply()` also calls before `SaveSettings()`, so apply/ok straight after cancelling a failed raw write no longer push the pre-write form (e.g. `ForceBoxDocs`) back over what the partial write already changed. it only consumes the flag while connected, because `LoadSettings()` skips the service-backed fields when disconnected, so a reconnect followed by any tab switch still refreshes them (029261f, third review round)
- and when that reconcile cannot run because sandboxie is disconnected, `apply()`/`ok()` refuse the structured save and return false instead of saving the pre-write form, clearing the flag and closing (2287c17); a clean offline save without a pending invalidation is unchanged
- global raw editor refuses to save when not connected instead of silently doing nothing
- dead commented-out code in `COptionsWindow::SaveIniSection` removed

tests

- new `SandboxiePlus/tests/ini-write` ctest target, 42 cases: 10 in `ini_write_test` (list delete/append/retry/noop, safe bool, checkbox default, options dialog failure/success/retry) and 32 in `raw_ini_test` (sandbox + global raw editor, tab and tree navigation, partial write then retry, cancel after partial failure for both dialogs, pending edit after a support/add-ons/common tab detour, clean flag after a successful apply/save, apply/ok right after cancelling, dirty flag across disconnect/reconnect, dirty apply/ok while offline, plus their passing controls). `raw_ini_test <case> tabs|tree` runs one navigation mode alone
- the fixtures extract the real methods at build time via `generate_fixture.py` / `generate_raw_fixture.py` and inject storage and status payloads, so they run offscreen without SbieSvc, see the README in that folder for the build commands

validation, split by revision

- e68aa11 (26 cases, before the global fix): earlier run on my fork, not an upstream check, https://github.com/Kizuno18/sbxie/actions/runs/34140173059 (`gh run view 34140173059 --repo Kizuno18/sbxie --log`), artifacts `cancel-save-qt5`, `cancel-save-qt6`, `cancel-save-windows`, `ini-round4-published`. that workflow applied the patch on top of ebaeaa8 and then published e68aa11, so i checked the link by blob hash and not just by head: the 5 patched files in the platform manifests and all 12 files in the publication manifest match the e68aa11 tree. results are 26/26 on qt5, qt6 and windows, and the windows job also built `QSbieAPI.dll` and `SandMan.exe` x64 with msvc and passed the exist checks
- e68aa11 + the new `global-partial-cancel` case: fails locally, `FAIL at line 392: Window.StructuredCode == Window.Storage.Persisted`, 26 other cases pass
- 58440bb: `global-partial-cancel` fixed, but review found the `m_SettingsDirty` reload sitting behind the support/add-ons branches and `apply()` never clearing it. `global-support-pending`, `global-addons-pending` and `global-apply-clean` fail on that revision (`FAIL at line 380: Window.Loads == 1 && !Window.m_SettingsDirty`), the two controls `global-common-pending` and `global-saveini-clean` pass
- 52a7331: 32/32 locally and on my fork run https://github.com/Kizuno18/sbxie/actions/runs/34156033522 (qt5, qt6, windows msvc incl. the real `QSbieAPI.dll`/`SandMan.exe` x64 build). review then found two more paths: `global-partial-cancel-apply` and `global-partial-cancel-ok` fail with `staleSaves=1` (the ok variant also `closed=1`), and `global-dirty-offline-reconnect` fails with `dirtyOffline=0 field=0 stored=1`; the three controls pass. all six were run in tabs and tree mode separately
- 029261f: 38/38 locally and on my fork run https://github.com/Kizuno18/sbxie/actions/runs/34157521188 (qt5, qt6, windows msvc incl. the real `QSbieAPI.dll`/`SandMan.exe` x64 build). review then found that `apply()` still saved and cleared the flag when `ReloadDirtySettings()` had kept it while offline: `global-dirty-offline-apply` and `global-dirty-offline-ok` fail with `staleSaves=1` (ok also `closed=1`), the two controls pass
- 2287c17 (current head): 42/42 locally (g++ 16.2, qt 6.11 offscreen) and 42/42 on my fork, not an upstream check, https://github.com/Kizuno18/sbxie/actions/runs/34158971704 (`gh run view 34158971704 --repo Kizuno18/sbxie --log`), artifacts `round7-qt5`, `round7-qt6`, `round7-windows`. the run checks out this branch head directly, `round7-manifest.txt` records commit 2287c17 and the `SettingsWindow.cpp`/`raw_ini_test.cpp` blobs match this branch; the windows job runs all 42 cases with msvc + the repo qt6 and then builds `QSbieAPI.dll` and `SandMan.exe` x64 for real, sha256 in the manifest
- the e68aa11, 52a7331 and 029261f logs do not cover 2287c17, only the round 7 run does

limits, being upfront

- not a transaction: no rollback, no compare-and-swap, no protection against concurrent writers, mutations done before the error stay applied and the normal commit/refresh path still runs
- not validated against a real disk fault or a real SbieSvc denial, only injected failures
- the dirty reload after a failed raw write drops structured edits made before entering the raw editor, same as the existing successful raw save path already did; edits made after leaving it are kept now
- while disconnected the invalidation stays pending: apply/ok are refused until sandboxie is back, and form edits made offline are reloaded over on the first tab switch or apply after reconnecting; the alternative was writing stale service fields back
- the fixtures extract the real `OnTab`/`ReloadDirtySettings`/`apply`/`OnSaveIni`/`SaveIniSection` handlers, but `LoadSettings()` and storage stay simulated and the pending field is a plain qt checkbox, not the full dialog or SbieSvc; the stale-save cases observe the old form reaching the save callback, they do not perform a real SbieSvc write
- errors hidden by other void helpers (`CommitIniChanges`, `SetTextMap`, structured `CSettingsWindow::SaveSettings`) are untouched
- persistent identity profiles, volumes and proxies are not part of this pr


Follow-up: the sandbox options dialog now reconciles its dirty form before Apply/OK immediately after cancelling a partial raw write, matching the global-dialog handling. Offline navigation retains the invalidation; structured saves wait until the service reconnects. Two new cases cover Apply/OK in tabs and tree mode, with and without disconnect/reconnect. Both fail on 2287c17 by observing stale form data at the save callback (verified). Linux/GCC 16.2.1/Qt 6.11.2: `cmake -S SandboxiePlus/tests/ini-write -B build/ini-write -DCMAKE_BUILD_TYPE=Release`, `cmake --build build/ini-write -j4`, and `ctest --test-dir build/ini-write --output-on-failure` exit 0, 44/44 cases, and the fork run https://github.com/Kizuno18/sbxie/actions/runs/34241340527 on `d130a237` (current head `65b26e5c` is the same tree plus a CHANGELOG-only commit) is green on qt5, qt6 and windows msvc + the real `SandMan.exe`/`QSbieAPI.dll` x64 build. These remain extracted-method fixtures with synthetic storage; the Windows job builds the manager but no SbieSvc runtime validation was performed for this follow-up; earlier evidence above applies only to its stated revisions.

