### PR TITLE
sandman: persistent identity profiles for volume serials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.18.4 / 5.73.4] - 2026-09-06
 
 ### Added
-- added per-sandbox identity profiles to SandMan (Advanced > Privacy): persistent, versioned volume serial profiles that are bound to a sandbox and written as `DiskSerialNumber`/`HideDiskSerialNumber`; covers the existing `GetVolumeInformationByHandleW` hook only
+- added per-sandbox identity profiles to SandMan (Advanced > Privacy): persistent, versioned volume serial profiles that are bound to a sandbox and written as `DiskSerialNumber`/`HideDiskSerialNumber`; covers the existing `GetVolumeInformationByHandleW` hook only. Saves take a per-profile lock and check the stored revision, so a stale editor cannot overwrite newer serials or recreate a removed profile
 - added low-noise `SbieTrace` logging for `Shell_NotifyIconW` calls, including the message, icon identity (`NIF_GUID`/GUID or `HWND`/`uID`), and effective direct/proxy route
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 
 ### Fixed
-- fixed stale identity profile edits overwriting newer serials and saves racing profile removal
 - fixed stale INI completion-popup candidate tooltips during editing and limited `Template`/`TemplateReject` tooltips to setting-name text
 - fixed SandMan File Panel "Create Shortcut" producing a shortcut without a working directory, so the sandboxed program inherited SandMan's current directory and applications that open their data files by relative path failed to find them [#5542](https://github.com/sandboxie-plus/Sandboxie/issues/5542)
 - fixed wrong return type ein sbiesvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.18.4 / 5.73.4] - 2026-09-06
 
 ### Added
+- added per-sandbox identity profiles to SandMan (Advanced > Privacy): persistent, versioned volume serial profiles that are bound to a sandbox and written as `DiskSerialNumber`/`HideDiskSerialNumber`; covers the existing `GetVolumeInformationByHandleW` hook only
 - added low-noise `SbieTrace` logging for `Shell_NotifyIconW` calls, including the message, icon identity (`NIF_GUID`/GUID or `HWND`/`uID`), and effective direct/proxy route
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 
 ### Fixed
+- fixed stale identity profile edits overwriting newer serials and saves racing profile removal
 - fixed stale INI completion-popup candidate tooltips during editing and limited `Template`/`TemplateReject` tooltips to setting-name text
 - fixed SandMan File Panel "Create Shortcut" producing a shortcut without a working directory, so the sandboxed program inherited SandMan's current directory and applications that open their data files by relative path failed to find them [#5542](https://github.com/sandboxie-plus/Sandboxie/issues/5542)
 - fixed wrong return type ein sbiesvc

--- a/Sandboxie/install/SbieSettings.ini
+++ b/Sandboxie/install/SbieSettings.ini
@@ -2590,6 +2590,32 @@ Syntax=[sn]=[bN]
 Description=When enabled, the box border overlay windows are excluded from\nscreen capture (using [code]WDA_EXCLUDEFROMCAPTURE[/code]). When not set,\nthe value of [code]CoverBoxedWindows[/code] is used as the default. Can be set globally or per-box.
 
 
+[IdentityProfile]
+AddedVersion=1.18.4
+RemovedVersion=
+ReAddedVersion=
+RenamedVersion=
+SupersededBy=
+Category=ay
+Context=
+Requirements=
+Syntax=[sn]=profile_id
+Description=Id of the SandMan identity profile bound to this sandbox.\nSandMan writes the profile's volume serials as DiskSerialNumber entries and sets HideDiskSerialNumber; the profile itself is stored by SandMan, not in this file.
+
+
+[IdentityProfileRevision]
+AddedVersion=1.18.4
+RemovedVersion=
+ReAddedVersion=
+RenamedVersion=
+SupersededBy=
+Category=ay
+Context=
+Requirements=<IdentityProfile>
+Syntax=[sn]=[nN]
+Description=Revision of the bound identity profile that was last applied to this sandbox.
+
+
 [HideDiskSerialNumber]
 AddedVersion=1.14.7
 RemovedVersion=

--- a/Sandboxie/install/SbieSettings.ini
+++ b/Sandboxie/install/SbieSettings.ini
@@ -2591,7 +2591,7 @@ Description=When enabled, the box border overlay windows are excluded from\nscre
 
 
 [IdentityProfile]
-AddedVersion=1.18.4
+AddedVersion=1.18.5
 RemovedVersion=
 ReAddedVersion=
 RenamedVersion=
@@ -2604,7 +2604,7 @@ Description=Id of the SandMan identity profile bound to this sandbox.\nSandMan w
 
 
 [IdentityProfileRevision]
-AddedVersion=1.18.4
+AddedVersion=1.18.5
 RemovedVersion=
 ReAddedVersion=
 RenamedVersion=

--- a/SandboxiePlus/SandMan/Docs/IdentityCoverage.md
+++ b/SandboxiePlus/SandMan/Docs/IdentityCoverage.md
@@ -1,0 +1,52 @@
+# Identity and privacy coverage inventory
+
+"Existing" names a code path in the repository; it is not a claim that every
+related API is covered or runtime-tested. "Not in this slice" means the identity
+profile feature does not implement the category; it does not assert that no
+compatibility code exists elsewhere. No category counts as complete from a
+declaration, a checkbox or a passing unit test alone.
+
+The current slice is the persistent volume serial profile described in
+[IdentityProfiles.md](IdentityProfiles.md). It changes SandMan only; SbieDll,
+SbieSvc and the driver are unchanged.
+
+| # / category | Existing evidence and limits | This slice | Platforms and dependencies | Acceptance tests still needed |
+| --- | --- | --- | --- | --- |
+| 1. Generation, persistence and authority | `QSbieAPI/Sandboxie/SbieIni.cpp` writes box sections through SbieSvc; `sbieiniserver.cpp::RefreshConf` is backup/overwrite/reload, not a transaction | **New:** versioned JSON profile in the SandMan data dir, `QSaveFile` atomic save with read-back, explicit regenerate, clone and import with new ids; binding recorded as `IdentityProfile` + `IdentityProfileRevision` | SandMan Qt/C++, existing INI authorization | Service-side atomic publication, concurrent launcher lock, startup rejection of an invalid reference |
+| 2. Machine and derived identifiers | `core/dll/custom.c::Custom_ProductID` (`RandomRegUID`) writes shared boxed registry values | Not in this slice | Windows registry, SbieDll/SbieSvc | Typed base/derived ids; A/W/native and registry-view agreement |
+| 3. Computer name, user and directories | File/registry virtualization, `File_CreateBaseFolders` | Not in this slice | Windows name APIs, environment, virtual filesystem | Host name must stay resolvable; Unicode, children, buffer negotiation |
+| 4. CPU identity/topology | `dllmain.c` reads `CpuAffinityMask` (resource policy, not identity) | Not in this slice, real CPU preserved | Architecture-specific CPU APIs | Logical/physical counts, groups, masks, native agreement |
+| 5. Direct CPUID and hypervisor information | No instruction-level mechanism in the reviewed DLL paths | Not in this slice, real information preserved | x86/x64 vs ARM64/ARM64EC semantics | Feasibility analysis before any synthetic mode |
+| 6. BIOS/firmware/system/board/chassis | `sysinfo.c` `HideFirmwareInfo`, `Template_BlockAccessWMI` | Not in this slice | SMBIOS/ACPI layouts, WMI, certificate policy | Independent SMBIOS/ACPI/registry/WMI mapping |
+| 7. Registry interfaces | `key*.c` virtualization; `Custom_ProductID` shared values | Reused, no new registry writes | ANSI/Unicode wrappers, WOW64 views | Type/error/size/enumeration semantics, covered vs excluded processes |
+| 8. Disks, volumes and capacity | `kernel.c::Kernel_GetVolumeInformationByHandleW` reads `DiskSerialNumber` when `HideDiskSerialNumber=y`; the cache-key fix on `fix/volume-serial-cache-20260906` is a separate change | **New, partial:** profile values become the `DiskSerialNumber` entries of the box; by-handle query only, volume serial not physical serial, capacity untouched | Existing hook, `HarddiskVolumeN` names | Runtime query in two boxes and on the host, `GetVolumeInformationW/A`, native and WMI paths compared independently |
+| 9. Memory | Service job limits only | Not in this slice, real information preserved | Windows memory APIs | Totals and bounds across APIs |
+| 10. MAC and adapters | `custom.c::Nsi_Init` (`HideNetworkAdapterMAC`/`NetworkAdapterMAC`), `net.c` policies | Not in this slice | NSI, adapter enumeration | Stable adapter authority, hot-plug, loopback |
+| 11. Uptime, boot and clocks | `kernel.c` `UseChangeSpeed` timer adjustments | Not in this slice | Monotonic/wall clock semantics | Boot-session boundaries, resume/restart |
+| 12. OS and language | `userenv.c` `OverrideOsBuild`, `kernel.c` `CustomLCID` | Not in this slice | Build/ABI and locale formats | System/app locale distinction |
+| 13. GPU and graphics APIs | No generic GPU identity layer | Not in this slice, real information preserved | OpenGL, DXGI, D3D, Vulkan | Per-API getters and real rendering |
+| 14. Window/presentation/audio preferences | Application behavior, not hardware identity | Not applicable | Application contracts | Not a sandbox identity surface |
+| 15. Environment, credentials and startup | Configuration and process-launch infrastructure | **Profile authority ignores the environment:** only public synthetic fields are stored; no seed or secret material | SbieSvc authorization, process environment | Children, diagnostics, malformed input |
+| 16. Process/module/resource visibility | `sysinfo.c` `HideOtherBoxes`, `HideSbieProcesses`, `HideHostProcess` | Reused as is | Native enumeration, existing boundaries | Other-box/host views |
+| 17. Linux identity files and environment preparation | Linux `/proc`, sysfs, DMI, cgroups are Linux-specific | Not applicable; each requirement maps to a reviewed Windows interface | Windows APIs/registry/firmware | Native equivalents, not Linux behavior |
+| 18. Files and handles | `File_GetName` and handle virtualization underpin the volume query | Reused; no synthetic filesystem | Name resolution, duplicated handles | Aliases, oversized names, handle reuse |
+| 19. Initialization, children and reapplication | `Kernel_Init`, `dllmain.c` loader infrastructure | **Reuse:** no injector or hook library; new editor registered in `SandMan.vcxproj`; tests compile the shipped sources rather than a rewritten model | Architecture-specific SbieDll loading | Early queries, children, repeated initialization |
+| 20. Capabilities and diagnostics | SandMan error reporting for configuration operations | **New, partial:** binding state (unbound/manual/applied/stale/diverged/missing), coverage text, validation errors; no runtime active/real indicator, no fail-closed launch | Qt UI, service errors | Missing/tampered profiles, partial initialization, diagnostics on failure |
+| 21. Wine/compatibility environments | No Wine-specific identity implementation | Not applicable | Wine vs native Windows discovery | Separate native and compatibility results |
+| 22. Application-specific behavior | Internal getters, telemetry filtering, binary patches are not generic sandbox identity interfaces | Explicitly excluded | Specific application contracts | Only owned/documented test applications |
+
+## Follow-up sequence
+
+1. Runtime evidence for category 8: run a read-only probe inside two bound
+   sandboxes and on the host, compare the by-handle, `GetVolumeInformationW/A`,
+   native and WMI paths independently, repeat after restarts.
+2. Service-side atomic configuration publication and a launch/configuration
+   lock, so a binding cannot race an external launcher.
+3. Typed machine/firmware identity that integrates the existing registry and
+   firmware options instead of duplicating them.
+4. Per-process capability reporting and an explicitly opt-in fail-closed
+   launch policy whose failure keeps SandMan and diagnostics usable.
+
+Each stage needs separate source review, compilation and runtime evidence for
+the relevant Win32, x64, ARM64 and ARM64EC targets. No anonymity claim follows
+from a passing unit test or a successful build.

--- a/SandboxiePlus/SandMan/Docs/IdentityProfiles.md
+++ b/SandboxiePlus/SandMan/Docs/IdentityProfiles.md
@@ -1,0 +1,83 @@
+# Identity profiles (version 1: volume serials)
+
+This is the first functional slice of per-sandbox identity profiles. A profile
+is a small, versioned record owned by SandMan that holds synthetic **volume
+serial numbers** for native volumes. Binding a profile to a sandbox writes those
+values into the sandbox section as the existing `DiskSerialNumber` entries and
+sets `HideDiskSerialNumber=y`, so the existing `GetVolumeInformationByHandleW`
+hook in SbieDll serves them. Nothing else is covered by this version.
+
+Three things are deliberately kept apart:
+
+| Layer | Where it lives | What it proves |
+| --- | --- | --- |
+| Saved profile | `<SandMan data dir>/IdentityProfiles/<id>.json` | The values exist and validate. Nothing is configured yet. |
+| Applied configuration | `IdentityProfile`, `IdentityProfileRevision`, `HideDiskSerialNumber`, `DiskSerialNumber` in the box section of `Sandboxie.ini` | SandMan wrote the values and read them back. Running processes are not affected. |
+| Verified protection | Not provided by this version | Only a runtime query inside the box proves what an application sees. |
+
+## Using a profile
+
+Sandbox Options > Advanced > Privacy has a profile selector next to
+**Hide Disk Serial Number** and an **Identity Profiles...** button.
+
+- **New / Edit** open the editor: a name and a table of `HarddiskVolumeN` device
+  names with `XXXX-XXXX` serials. `\Device\HarddiskVolume1` is accepted and
+  stored as `HarddiskVolume1`. Drive letters, `PhysicalDriveN` and wildcards are
+  rejected. New rows get a random serial; the editor never reads the host.
+- **Regenerate Serials** (editor) replaces every serial in the draft. It is an
+  explicit action; nothing changes until Save.
+- **Regenerate** (list) does the same to the stored profile in one step, after a
+  confirmation that lists the sandboxes using it.
+- **Clone** creates a new profile id with the same serials.
+- **Import / Export** exchange one profile as JSON. Import always creates a new
+  profile id and keeps the serials; it never overwrites an existing record.
+- **Delete** refuses while any sandbox still references the profile.
+
+Selecting a profile in the combo box and pressing Apply/OK binds it. SandMan
+refuses to apply or remove a binding while the sandbox has running processes,
+and refuses to bind a sandbox that already has manual `DiskSerialNumber`
+entries; remove those first. While a profile is bound the **Hide Disk Serial
+Number** checkbox is managed by the profile.
+
+Selecting **No identity profile** removes `IdentityProfile`,
+`IdentityProfileRevision` and the profile's `DiskSerialNumber` entries and leaves
+`HideDiskSerialNumber` as it is, so the pre-existing checkbox keeps its meaning.
+
+## Stability and lifecycle
+
+- Values are stable across SandMan restarts and sandbox restarts because the
+  profile file and the box section both persist them. Two sandboxes bound to
+  the same profile present the same serials; two profiles distinguish two
+  sandboxes; two volumes inside one profile keep distinct serials.
+- Every save increments the profile `revision`; the box records the revision it
+  applied. After **Regenerate** the box shows *stale* until it is re-applied
+  while stopped. The stored configuration never changes silently.
+- Raw INI edits that change the box entries show as *diverged*; re-applying the
+  profile restores its values. A deleted profile shows as *missing* and the box
+  keeps its configured values until it is unbound.
+- Saves use `QSaveFile`, so a failed write leaves the previous file intact and
+  a read-back mismatch is reported instead of a success.
+- Templates are untouched: the binding only reads and writes the box section,
+  and `Template=` references stay as they are. If a template also contributes
+  `DiskSerialNumber` values they are listed separately in the binding state.
+- No environment variable, seed or external process is an authority for a
+  profile. The host configuration outside the box section is not written.
+
+## What is not covered
+
+- Only the by-handle volume query is substituted. `GetVolumeInformationW/A`,
+  `NtQueryVolumeInformationFile`, WMI and physical storage device serials are
+  separate surfaces and are not claimed.
+- This is the **volume** serial (the value `vol` prints), not the physical
+  disk serial number.
+- `HarddiskVolumeN` names can be reassigned by Windows when storage changes;
+  the profile binds names, not physical volumes.
+- Already running processes keep their current values; a re-apply needs a
+  stopped sandbox. There is no runtime indicator of what a process actually
+  observes and no fail-closed launch policy.
+- `SbieIniServer` configuration writes are not a crash-atomic transaction; the
+  profile file is atomic, the INI update is verified by read-back only.
+
+See [IdentityCoverage.md](IdentityCoverage.md) for the full category matrix and
+the tests README under `SandboxiePlus/tests/identity-profile` for what the
+simulated tests, the build and the runtime checks each prove.

--- a/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
+++ b/SandboxiePlus/SandMan/Forms/OptionsWindow.ui
@@ -5292,6 +5292,23 @@ This is done to prevent rogue processes inside the sandbox from creating a renam
                </property>
               </spacer>
              </item>
+             <item row="3" column="4">
+              <widget class="QComboBox" name="cmbIdentityProfile">
+               <property name="toolTip">
+                <string>Bind a persistent identity profile to this sandbox; its volume serials are written as DiskSerialNumber entries</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="4">
+              <widget class="QToolButton" name="btnIdentityProfiles">
+               <property name="toolTip">
+                <string>Create, edit, clone, regenerate, import or export identity profiles</string>
+               </property>
+               <property name="text">
+                <string>Identity Profiles...</string>
+               </property>
+              </widget>
+             </item>
              <item row="1" column="4">
               <widget class="QToolButton" name="btnDumpFW">
                <property name="toolTip">
@@ -6593,6 +6610,8 @@ Please note that this values are currently user specific and saved globally for 
   <tabstop>btnDumpFW</tabstop>
   <tabstop>cmbLangID</tabstop>
   <tabstop>chkHideSerial</tabstop>
+  <tabstop>cmbIdentityProfile</tabstop>
+  <tabstop>btnIdentityProfiles</tabstop>
   <tabstop>chkHideMac</tabstop>
   <tabstop>chkHideUID</tabstop>
   <tabstop>lstUsers</tabstop>

--- a/SandboxiePlus/SandMan/Helpers/IdentityProfile.cpp
+++ b/SandboxiePlus/SandMan/Helpers/IdentityProfile.cpp
@@ -1,0 +1,475 @@
+#include "IdentityProfile.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QRandomGenerator>
+#include <QRegularExpression>
+#include <QSaveFile>
+#include <QSet>
+#include <QUuid>
+
+//---------------------------------------------------------------------------
+// CIdentityProfile
+//---------------------------------------------------------------------------
+
+QString CIdentityProfile::NewId()
+{
+	return QUuid::createUuid().toString(QUuid::WithoutBraces).toLower();
+}
+
+bool CIdentityProfile::IsValidId(const QString& Id)
+{
+	static const QRegularExpression Pattern("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+	return Pattern.match(Id).hasMatch();
+}
+
+QString CIdentityProfile::NormalizeDevice(const QString& Device, QString* pError)
+{
+	QString Value = Device.trimmed();
+	if (Value.startsWith("\\Device\\", Qt::CaseInsensitive))
+		Value = Value.mid(8);
+	static const QRegularExpression Pattern("^HarddiskVolume([1-9][0-9]{0,3})$", QRegularExpression::CaseInsensitiveOption);
+	QRegularExpressionMatch Match = Pattern.match(Value);
+	if (!Match.hasMatch()) {
+		if (pError) *pError = QString("invalid volume device '%1' (expected HarddiskVolumeN)").arg(Device.trimmed());
+		return QString();
+	}
+	return "HarddiskVolume" + Match.captured(1);
+}
+
+QString CIdentityProfile::NormalizeSerial(const QString& Serial, QString* pError)
+{
+	QString Hex = Serial.trimmed().remove('-').toUpper();
+	static const QRegularExpression Pattern("^[0-9A-F]{8}$");
+	if (!Pattern.match(Hex).hasMatch()) {
+		if (pError) *pError = QString("invalid volume serial '%1' (expected XXXX-XXXX hex)").arg(Serial.trimmed());
+		return QString();
+	}
+	return Hex.left(4) + "-" + Hex.mid(4);
+}
+
+QString CIdentityProfile::RandomSerial()
+{
+	quint32 Value = QRandomGenerator::system()->generate();
+	return QString("%1").arg(Value, 8, 16, QChar('0')).toUpper().insert(4, '-');
+}
+
+QStringList CIdentityProfile::Validate() const
+{
+	QStringList Errors;
+	if (Version != CurrentVersion)
+		Errors.append(QString("unsupported profile version %1").arg(Version));
+	if (!IsValidId(Id))
+		Errors.append("missing or malformed profile id");
+	if (Name.trimmed().isEmpty())
+		Errors.append("profile name is empty");
+	if (Revision < 0)
+		Errors.append("negative revision");
+	if (Volumes.isEmpty())
+		Errors.append("profile has no volumes");
+	QSet<QString> Seen;
+	foreach(const SIdentityVolume& Volume, Volumes) {
+		QString Error;
+		QString Device = NormalizeDevice(Volume.Device, &Error);
+		if (Device.isEmpty()) { Errors.append(Error); continue; }
+		if (Device != Volume.Device)
+			Errors.append(QString("volume device '%1' is not normalized").arg(Volume.Device));
+		if (Seen.contains(Device.toLower()))
+			Errors.append(QString("duplicate volume device '%1'").arg(Device));
+		Seen.insert(Device.toLower());
+		QString Serial = NormalizeSerial(Volume.Serial, &Error);
+		if (Serial.isEmpty()) Errors.append(Error);
+		else if (Serial != Volume.Serial)
+			Errors.append(QString("volume serial '%1' is not normalized").arg(Volume.Serial));
+	}
+	return Errors;
+}
+
+QJsonObject CIdentityProfile::ToJson() const
+{
+	QJsonArray Array;
+	foreach(const SIdentityVolume& Volume, Volumes) {
+		QJsonObject Entry;
+		Entry["device"] = Volume.Device;
+		Entry["serial"] = Volume.Serial;
+		Array.append(Entry);
+	}
+	QJsonObject Json;
+	Json["format"] = "sandboxie-identity-profile";
+	Json["version"] = Version;
+	Json["id"] = Id;
+	Json["name"] = Name;
+	Json["revision"] = Revision;
+	Json["created"] = Created;
+	Json["updated"] = Updated;
+	Json["volumes"] = Array;
+	return Json;
+}
+
+bool CIdentityProfile::FromJson(const QJsonObject& Json, CIdentityProfile& Profile, QStringList& Errors)
+{
+	Errors.clear();
+	if (Json.value("format").toString() != "sandboxie-identity-profile")
+		Errors.append("not an identity profile document");
+	if (!Json.value("version").isDouble())
+		Errors.append("missing profile version");
+	if (!Json.value("volumes").isArray())
+		Errors.append("missing volume list");
+	if (!Errors.isEmpty())
+		return false;
+
+	CIdentityProfile Result;
+	Result.Version = Json.value("version").toInt(-1);
+	Result.Id = Json.value("id").toString();
+	Result.Name = Json.value("name").toString();
+	Result.Revision = Json.value("revision").toInt(-1);
+	Result.Created = Json.value("created").toString();
+	Result.Updated = Json.value("updated").toString();
+	foreach(const QJsonValue& Value, Json.value("volumes").toArray()) {
+		if (!Value.isObject()) { Errors.append("volume entry is not an object"); continue; }
+		QJsonObject Entry = Value.toObject();
+		SIdentityVolume Volume;
+		Volume.Device = Entry.value("device").toString();
+		Volume.Serial = Entry.value("serial").toString();
+		Result.Volumes.append(Volume);
+	}
+	Errors.append(Result.Validate());
+	if (!Errors.isEmpty())
+		return false;
+	Profile = Result;
+	return true;
+}
+
+QStringList CIdentityProfile::DiskSerialNumberValues() const
+{
+	QStringList Values;
+	foreach(const SIdentityVolume& Volume, Volumes)
+		Values.append(Volume.Device + "," + Volume.Serial);
+	return Values;
+}
+
+void CIdentityProfile::Regenerate()
+{
+	for (int i = 0; i < Volumes.size(); i++)
+		Volumes[i].Serial = RandomSerial();
+}
+
+CIdentityProfile CIdentityProfile::Clone(const QString& NewName) const
+{
+	CIdentityProfile Copy = *this;
+	Copy.Id = NewId();
+	Copy.Name = NewName;
+	Copy.Revision = 0;
+	Copy.Created.clear();
+	Copy.Updated.clear();
+	return Copy;
+}
+
+//---------------------------------------------------------------------------
+// CIdentityProfileStore
+//---------------------------------------------------------------------------
+
+CIdentityProfileStore::CIdentityProfileStore(const QString& Dir)
+	: m_Dir(QDir::cleanPath(Dir))
+{
+}
+
+QString CIdentityProfileStore::PathFor(const QString& Id) const
+{
+	return m_Dir + "/" + Id + ".json";
+}
+
+QList<CIdentityProfile> CIdentityProfileStore::List(QStringList* pProblems) const
+{
+	QList<CIdentityProfile> Profiles;
+	QDir Dir(m_Dir);
+	foreach(const QString& Entry, Dir.entryList(QStringList() << "*.json", QDir::Files, QDir::Name)) {
+		QString Id = Entry.left(Entry.size() - 5);
+		if (!CIdentityProfile::IsValidId(Id)) {
+			if (pProblems) pProblems->append(QString("%1: file name is not a profile id").arg(Entry));
+			continue;
+		}
+		CIdentityProfile Profile;
+		QString Error;
+		if (!Load(Id, Profile, &Error)) {
+			if (pProblems) pProblems->append(QString("%1: %2").arg(Entry, Error));
+			continue;
+		}
+		Profiles.append(Profile);
+	}
+	return Profiles;
+}
+
+bool CIdentityProfileStore::Load(const QString& Id, CIdentityProfile& Profile, QString* pError) const
+{
+	if (!CIdentityProfile::IsValidId(Id)) {
+		if (pError) *pError = "malformed profile id";
+		return false;
+	}
+	CIdentityProfile Loaded;
+	if (!ReadFile(PathFor(Id), Loaded, pError))
+		return false;
+	if (Loaded.Id != Id) {
+		if (pError) *pError = "profile id does not match its file name";
+		return false;
+	}
+	Profile = Loaded;
+	return true;
+}
+
+bool CIdentityProfileStore::Save(CIdentityProfile& Profile, QString* pError)
+{
+	QStringList Errors = Profile.Validate();
+	if (!Errors.isEmpty()) {
+		if (pError) *pError = Errors.join("; ");
+		return false;
+	}
+	if (!QDir().mkpath(m_Dir)) {
+		if (pError) *pError = QString("cannot create %1").arg(m_Dir);
+		return false;
+	}
+	CIdentityProfile Next = Profile;
+	QString Now = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
+	if (Next.Created.isEmpty()) Next.Created = Now;
+	Next.Updated = Now;
+	Next.Revision = Profile.Revision + 1;
+	if (!WriteFile(PathFor(Next.Id), Next, pError))
+		return false;
+	CIdentityProfile Check;
+	if (!ReadFile(PathFor(Next.Id), Check, pError))
+		return false;
+	if (Check.ToJson() != Next.ToJson()) {
+		if (pError) *pError = "profile read back differs from what was written";
+		return false;
+	}
+	Profile = Next;
+	return true;
+}
+
+bool CIdentityProfileStore::Remove(const QString& Id, QString* pError)
+{
+	if (!CIdentityProfile::IsValidId(Id)) {
+		if (pError) *pError = "malformed profile id";
+		return false;
+	}
+	QFile File(PathFor(Id));
+	if (!File.exists()) {
+		if (pError) *pError = "profile does not exist";
+		return false;
+	}
+	if (!File.remove()) {
+		if (pError) *pError = File.errorString();
+		return false;
+	}
+	return true;
+}
+
+bool CIdentityProfileStore::Export(const CIdentityProfile& Profile, const QString& Path, QString* pError) const
+{
+	QStringList Errors = Profile.Validate();
+	if (!Errors.isEmpty()) {
+		if (pError) *pError = Errors.join("; ");
+		return false;
+	}
+	return WriteFile(Path, Profile, pError);
+}
+
+bool CIdentityProfileStore::Import(const QString& Path, CIdentityProfile& Profile, QString* pError) const
+{
+	CIdentityProfile Loaded;
+	if (!ReadFile(Path, Loaded, pError))
+		return false;
+	// An import is a new record: the serials are preserved, the identity of the record is not.
+	Loaded.Id = CIdentityProfile::NewId();
+	Loaded.Revision = 0;
+	Loaded.Created.clear();
+	Loaded.Updated.clear();
+	Profile = Loaded;
+	return true;
+}
+
+bool CIdentityProfileStore::ReadFile(const QString& Path, CIdentityProfile& Profile, QString* pError)
+{
+	QFile File(Path);
+	if (!File.open(QIODevice::ReadOnly)) {
+		if (pError) *pError = File.errorString();
+		return false;
+	}
+	QJsonParseError ParseError;
+	QJsonDocument Document = QJsonDocument::fromJson(File.readAll(), &ParseError);
+	if (ParseError.error != QJsonParseError::NoError || !Document.isObject()) {
+		if (pError) *pError = ParseError.error != QJsonParseError::NoError ? ParseError.errorString() : QString("document is not an object");
+		return false;
+	}
+	QStringList Errors;
+	if (!CIdentityProfile::FromJson(Document.object(), Profile, Errors)) {
+		if (pError) *pError = Errors.join("; ");
+		return false;
+	}
+	return true;
+}
+
+bool CIdentityProfileStore::WriteFile(const QString& Path, const CIdentityProfile& Profile, QString* pError)
+{
+	QSaveFile File(Path);
+	if (!File.open(QIODevice::WriteOnly)) {
+		if (pError) *pError = File.errorString();
+		return false;
+	}
+	QByteArray Data = QJsonDocument(Profile.ToJson()).toJson(QJsonDocument::Indented);
+	if (File.write(Data) != Data.size() || !File.commit()) {
+		if (pError) *pError = File.errorString();
+		return false;
+	}
+	return true;
+}
+
+//---------------------------------------------------------------------------
+// CIdentityProfileBinding
+//---------------------------------------------------------------------------
+
+const char* CIdentityProfileBinding::ProfileSetting = "IdentityProfile";
+const char* CIdentityProfileBinding::RevisionSetting = "IdentityProfileRevision";
+const char* CIdentityProfileBinding::HideSetting = "HideDiskSerialNumber";
+const char* CIdentityProfileBinding::SerialSetting = "DiskSerialNumber";
+
+QString SIdentityBindingState::Describe() const
+{
+	switch (State)
+	{
+	case eUnbound:	return "no identity profile";
+	case eManual:	return QString("manual DiskSerialNumber entries (%1)").arg(BoxSerials.size());
+	case eApplied:	return QString("profile revision %1 applied").arg(AppliedRevision);
+	case eStale:	return QString("profile revision %1 applied, profile is at revision %2").arg(AppliedRevision).arg(ProfileRevision);
+	case eMissing:	return QString("bound profile %1 is missing").arg(ProfileId);
+	case eDiverged:	return QString("box DiskSerialNumber entries differ from profile revision %1").arg(AppliedRevision);
+	}
+	return QString();
+}
+
+static QStringList SortedCopy(QStringList List)
+{
+	List.sort(Qt::CaseInsensitive);
+	return List;
+}
+
+SIdentityBindingState CIdentityProfileBinding::Read(const CIdentityIniTarget& Target, const CIdentityProfileStore& Store)
+{
+	SIdentityBindingState State;
+	State.ProfileId = Target.GetText(ProfileSetting).trimmed();
+	State.HideSerial = Target.GetText(HideSetting).trimmed().compare("y", Qt::CaseInsensitive) == 0;
+	State.BoxSerials = Target.GetTextList(SerialSetting, false);
+	QStringList All = Target.GetTextList(SerialSetting, true);
+	foreach(const QString& Value, State.BoxSerials)
+		All.removeOne(Value);
+	State.TemplateSerials = All;
+
+	if (State.ProfileId.isEmpty()) {
+		State.State = State.BoxSerials.isEmpty() ? SIdentityBindingState::eUnbound : SIdentityBindingState::eManual;
+		return State;
+	}
+
+	bool Ok = false;
+	State.AppliedRevision = Target.GetText(RevisionSetting).trimmed().toInt(&Ok);
+	if (!Ok) State.AppliedRevision = -1;
+
+	CIdentityProfile Profile;
+	if (!Store.Load(State.ProfileId, Profile)) {
+		State.State = SIdentityBindingState::eMissing;
+		return State;
+	}
+	State.ProfileRevision = Profile.Revision;
+	if (State.AppliedRevision != Profile.Revision)
+		State.State = SIdentityBindingState::eStale;
+	else if (SortedCopy(State.BoxSerials) != SortedCopy(Profile.DiskSerialNumberValues()) || !State.HideSerial)
+		State.State = SIdentityBindingState::eDiverged;
+	else
+		State.State = SIdentityBindingState::eApplied;
+	return State;
+}
+
+bool CIdentityProfileBinding::Apply(CIdentityIniTarget& Target, const CIdentityProfile& Profile, QString* pError)
+{
+	QStringList Errors = Profile.Validate();
+	if (!Errors.isEmpty()) {
+		if (pError) *pError = Errors.join("; ");
+		return false;
+	}
+	if (Target.GetActiveProcessCount() > 0) {
+		if (pError) *pError = "stop all processes in this sandbox before applying an identity profile; running processes keep their current values";
+		return false;
+	}
+	QString Bound = Target.GetText(ProfileSetting).trimmed();
+	QStringList Existing = Target.GetTextList(SerialSetting, false);
+	if (Bound.isEmpty() && !Existing.isEmpty()) {
+		if (pError) *pError = "this sandbox has manual DiskSerialNumber entries; remove them before binding an identity profile";
+		return false;
+	}
+
+	QStringList Wanted = Profile.DiskSerialNumberValues();
+	QStringList ToAdd = Wanted;
+	foreach(const QString& Value, Existing) {
+		if (!ToAdd.removeOne(Value)) {
+			if (!Target.DelValue(SerialSetting, Value)) {
+				if (pError) *pError = QString("failed to remove DiskSerialNumber=%1").arg(Value);
+				return false;
+			}
+		}
+	}
+	foreach(const QString& Value, ToAdd) {
+		if (!Target.AppendText(SerialSetting, Value)) {
+			if (pError) *pError = QString("failed to add DiskSerialNumber=%1").arg(Value);
+			return false;
+		}
+	}
+	if (!Target.SetText(HideSetting, "y")) {
+		if (pError) *pError = "failed to set HideDiskSerialNumber";
+		return false;
+	}
+	if (!Target.SetText(ProfileSetting, Profile.Id) || !Target.SetText(RevisionSetting, QString::number(Profile.Revision))) {
+		if (pError) *pError = "failed to record the profile binding";
+		return false;
+	}
+
+	if (SortedCopy(Target.GetTextList(SerialSetting, false)) != SortedCopy(Wanted)
+	 || Target.GetText(ProfileSetting).trimmed() != Profile.Id
+	 || Target.GetText(RevisionSetting).trimmed().toInt() != Profile.Revision
+	 || Target.GetText(HideSetting).trimmed().compare("y", Qt::CaseInsensitive) != 0) {
+		if (pError) *pError = "configuration read back does not match the profile";
+		return false;
+	}
+	return true;
+}
+
+bool CIdentityProfileBinding::Unbind(CIdentityIniTarget& Target, QString* pError)
+{
+	if (Target.GetActiveProcessCount() > 0) {
+		if (pError) *pError = "stop all processes in this sandbox before removing its identity profile";
+		return false;
+	}
+	if (Target.GetText(ProfileSetting).trimmed().isEmpty()) {
+		if (pError) *pError = "this sandbox has no identity profile";
+		return false;
+	}
+	foreach(const QString& Value, Target.GetTextList(SerialSetting, false)) {
+		if (!Target.DelValue(SerialSetting, Value)) {
+			if (pError) *pError = QString("failed to remove DiskSerialNumber=%1").arg(Value);
+			return false;
+		}
+	}
+	if (!Target.DelValue(RevisionSetting) || !Target.DelValue(ProfileSetting)) {
+		if (pError) *pError = "failed to remove the profile binding";
+		return false;
+	}
+	return true;
+}
+
+QString CIdentityProfileBinding::CoverageText()
+{
+	return "Configured coverage: volume serial numbers returned by the GetVolumeInformationByHandleW hook (HideDiskSerialNumber + DiskSerialNumber). "
+		"This is the volume serial, not the physical disk serial. GetVolumeInformationW/A, native NtQueryVolumeInformationFile, WMI and storage device queries are not covered by this profile version. "
+		"A saved profile is not an applied configuration, and an applied configuration is not verified protection.";
+}

--- a/SandboxiePlus/SandMan/Helpers/IdentityProfile.cpp
+++ b/SandboxiePlus/SandMan/Helpers/IdentityProfile.cpp
@@ -433,6 +433,10 @@ bool CIdentityProfileBinding::Apply(CIdentityIniTarget& Target, const CIdentityP
 		if (pError) *pError = "failed to record the profile binding";
 		return false;
 	}
+	if (!Target.Flush()) {
+		if (pError) *pError = "failed to commit the configuration";
+		return false;
+	}
 
 	if (SortedCopy(Target.GetTextList(SerialSetting, false)) != SortedCopy(Wanted)
 	 || Target.GetText(ProfileSetting).trimmed() != Profile.Id
@@ -462,6 +466,14 @@ bool CIdentityProfileBinding::Unbind(CIdentityIniTarget& Target, QString* pError
 	}
 	if (!Target.DelValue(RevisionSetting) || !Target.DelValue(ProfileSetting)) {
 		if (pError) *pError = "failed to remove the profile binding";
+		return false;
+	}
+	if (!Target.Flush()) {
+		if (pError) *pError = "failed to commit the configuration";
+		return false;
+	}
+	if (!Target.GetText(ProfileSetting).trimmed().isEmpty() || !Target.GetTextList(SerialSetting, false).isEmpty()) {
+		if (pError) *pError = "configuration read back still contains the profile binding";
 		return false;
 	}
 	return true;

--- a/SandboxiePlus/SandMan/Helpers/IdentityProfile.cpp
+++ b/SandboxiePlus/SandMan/Helpers/IdentityProfile.cpp
@@ -5,6 +5,7 @@
 #include <QFile>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QLockFile>
 #include <QRandomGenerator>
 #include <QRegularExpression>
 #include <QSaveFile>
@@ -231,6 +232,25 @@ bool CIdentityProfileStore::Save(CIdentityProfile& Profile, QString* pError)
 		if (pError) *pError = QString("cannot create %1").arg(m_Dir);
 		return false;
 	}
+	QLockFile Lock(PathFor(Profile.Id) + ".lock");
+	Lock.setStaleLockTime(0);
+	if (!Lock.tryLock(0)) {
+		if (pError) *pError = "cannot lock the identity profile for saving";
+		return false;
+	}
+	if (QFile::exists(PathFor(Profile.Id))) {
+		CIdentityProfile Current;
+		if (!Load(Profile.Id, Current, pError))
+			return false;
+		if (Current.Revision != Profile.Revision) {
+			if (pError) *pError = "the identity profile changed; reopen it before saving";
+			return false;
+		}
+	}
+	else if (Profile.Revision != 0) {
+		if (pError) *pError = "the identity profile was removed; reopen the profile list";
+		return false;
+	}
 	CIdentityProfile Next = Profile;
 	QString Now = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
 	if (Next.Created.isEmpty()) Next.Created = Now;
@@ -253,6 +273,12 @@ bool CIdentityProfileStore::Remove(const QString& Id, QString* pError)
 {
 	if (!CIdentityProfile::IsValidId(Id)) {
 		if (pError) *pError = "malformed profile id";
+		return false;
+	}
+	QLockFile Lock(PathFor(Id) + ".lock");
+	Lock.setStaleLockTime(0);
+	if (!Lock.tryLock(0)) {
+		if (pError) *pError = "cannot lock the identity profile for removal";
 		return false;
 	}
 	QFile File(PathFor(Id));

--- a/SandboxiePlus/SandMan/Helpers/IdentityProfile.h
+++ b/SandboxiePlus/SandMan/Helpers/IdentityProfile.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <QJsonObject>
+#include <QList>
+#include <QString>
+#include <QStringList>
+
+struct SIdentityVolume
+{
+	QString Device;	// native device component, e.g. HarddiskVolume1
+	QString Serial;	// volume serial in XXXX-XXXX form
+
+	bool operator==(const SIdentityVolume& other) const { return Device == other.Device && Serial == other.Serial; }
+};
+
+class CIdentityProfile
+{
+public:
+	enum { CurrentVersion = 1 };
+
+	int Version = CurrentVersion;
+	QString Id;
+	QString Name;
+	int Revision = 0;
+	QString Created;
+	QString Updated;
+	QList<SIdentityVolume> Volumes;
+
+	static QString NewId();
+	static bool IsValidId(const QString& Id);
+	static QString NormalizeDevice(const QString& Device, QString* pError = nullptr);
+	static QString NormalizeSerial(const QString& Serial, QString* pError = nullptr);
+	static QString RandomSerial();
+
+	QStringList Validate() const;
+	bool IsValid() const { return Validate().isEmpty(); }
+
+	QJsonObject ToJson() const;
+	static bool FromJson(const QJsonObject& Json, CIdentityProfile& Profile, QStringList& Errors);
+
+	QStringList DiskSerialNumberValues() const;
+
+	void Regenerate();
+	CIdentityProfile Clone(const QString& NewName) const;
+};
+
+class CIdentityProfileStore
+{
+public:
+	explicit CIdentityProfileStore(const QString& Dir);
+
+	QString GetDir() const { return m_Dir; }
+	QString PathFor(const QString& Id) const;
+
+	QList<CIdentityProfile> List(QStringList* pProblems = nullptr) const;
+	bool Load(const QString& Id, CIdentityProfile& Profile, QString* pError = nullptr) const;
+	bool Save(CIdentityProfile& Profile, QString* pError = nullptr);
+	bool Remove(const QString& Id, QString* pError = nullptr);
+
+	bool Export(const CIdentityProfile& Profile, const QString& Path, QString* pError = nullptr) const;
+	bool Import(const QString& Path, CIdentityProfile& Profile, QString* pError = nullptr) const;
+
+private:
+	static bool ReadFile(const QString& Path, CIdentityProfile& Profile, QString* pError);
+	static bool WriteFile(const QString& Path, const CIdentityProfile& Profile, QString* pError);
+
+	QString m_Dir;
+};
+
+// Minimal view of a box section; SandMan adapts CSbieIni, tests inject storage.
+class CIdentityIniTarget
+{
+public:
+	virtual ~CIdentityIniTarget() {}
+	virtual QString GetText(const QString& Setting) const = 0;
+	virtual QStringList GetTextList(const QString& Setting, bool withTemplates) const = 0;
+	virtual bool SetText(const QString& Setting, const QString& Value) = 0;
+	virtual bool AppendText(const QString& Setting, const QString& Value) = 0;
+	virtual bool DelValue(const QString& Setting, const QString& Value = QString()) = 0;
+	virtual int GetActiveProcessCount() const = 0;
+};
+
+struct SIdentityBindingState
+{
+	enum EState { eUnbound, eManual, eApplied, eStale, eMissing, eDiverged };
+
+	EState State = eUnbound;
+	QString ProfileId;
+	int AppliedRevision = -1;
+	int ProfileRevision = -1;
+	bool HideSerial = false;
+	QStringList BoxSerials;			// DiskSerialNumber values in the box section itself
+	QStringList TemplateSerials;	// DiskSerialNumber values contributed by templates or globals
+
+	QString Describe() const;
+};
+
+class CIdentityProfileBinding
+{
+public:
+	static const char* ProfileSetting;
+	static const char* RevisionSetting;
+	static const char* HideSetting;
+	static const char* SerialSetting;
+
+	static SIdentityBindingState Read(const CIdentityIniTarget& Target, const CIdentityProfileStore& Store);
+	static bool Apply(CIdentityIniTarget& Target, const CIdentityProfile& Profile, QString* pError = nullptr);
+	static bool Unbind(CIdentityIniTarget& Target, QString* pError = nullptr);
+
+	static QString CoverageText();
+};

--- a/SandboxiePlus/SandMan/Helpers/IdentityProfile.h
+++ b/SandboxiePlus/SandMan/Helpers/IdentityProfile.h
@@ -105,6 +105,11 @@ public:
 	static const char* HideSetting;
 	static const char* SerialSetting;
 
+	static bool WillApplyProfile(const QString& Selected, const QString& Bound, SIdentityBindingState::EState State)
+	{
+		return !Selected.isEmpty()
+			&& (Selected != Bound || State == SIdentityBindingState::eStale || State == SIdentityBindingState::eDiverged);
+	}
 	static SIdentityBindingState Read(const CIdentityIniTarget& Target, const CIdentityProfileStore& Store);
 	static bool Apply(CIdentityIniTarget& Target, const CIdentityProfile& Profile, QString* pError = nullptr);
 	static bool Unbind(CIdentityIniTarget& Target, QString* pError = nullptr);

--- a/SandboxiePlus/SandMan/Helpers/IdentityProfile.h
+++ b/SandboxiePlus/SandMan/Helpers/IdentityProfile.h
@@ -78,6 +78,8 @@ public:
 	virtual bool AppendText(const QString& Setting, const QString& Value) = 0;
 	virtual bool DelValue(const QString& Setting, const QString& Value = QString()) = 0;
 	virtual int GetActiveProcessCount() const = 0;
+	// Publish pending writes so that the reads below observe them; a no-op for synchronous targets.
+	virtual bool Flush() { return true; }
 };
 
 struct SIdentityBindingState

--- a/SandboxiePlus/SandMan/SandMan.pri
+++ b/SandboxiePlus/SandMan/SandMan.pri
@@ -22,6 +22,7 @@ HEADERS += ./stdafx.h \
     ./Helpers/FullScreen.h \
     ./Helpers/WinAdmin.h \
     ./Helpers/WinHelper.h \
+    ./Helpers/IdentityProfile.h \
     ./Helpers/StorageInfo.h \
     ./Helpers/ReadDirectoryChanges.h \
     ./Helpers/ReadDirectoryChangesPrivate.h \
@@ -46,6 +47,7 @@ HEADERS += ./stdafx.h \
     ./Windows/BoxImageWindow.h \
     ./Windows/CompressDialog.h \
     ./Windows/ExtractDialog.h \
+    ./Windows/IdentityProfilesDialog.h \
     ./Windows/RenameSandboxDialog.h \
     ./Engine/BoxEngine.h \
     ./Engine/ScriptManager.h \
@@ -81,6 +83,7 @@ SOURCES += ./main.cpp \
     ./Helpers/FullScreen.cpp \
     ./Helpers/WinAdmin.cpp \
     ./Helpers/WinHelper.cpp \
+    ./Helpers/IdentityProfile.cpp \
     ./Helpers/StorageInfo.cpp \
     ./Helpers/ReadDirectoryChanges.cpp \
     ./Helpers/ReadDirectoryChangesPrivate.cpp \
@@ -105,6 +108,7 @@ SOURCES += ./main.cpp \
     ./Windows/BoxImageWindow.cpp \
     ./Windows/CompressDialog.cpp \
     ./Windows/ExtractDialog.cpp \
+    ./Windows/IdentityProfilesDialog.cpp \
     ./Windows/RenameSandboxDialog.cpp \
     ./Engine/BoxEngine.cpp \
     ./Engine/ScriptManager.cpp \

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -300,6 +300,7 @@
     <ClCompile Include="Helpers\IniHighlighter.cpp" />
     <ClCompile Include="Helpers\ReadDirectoryChanges.cpp" />
     <ClCompile Include="Helpers\ReadDirectoryChangesPrivate.cpp" />
+    <ClCompile Include="Helpers\IdentityProfile.cpp" />
     <ClCompile Include="Helpers\StorageInfo.cpp" />
     <ClCompile Include="Helpers\TabOrder.cpp" />
     <ClCompile Include="Helpers\WinAdmin.cpp" />
@@ -383,6 +384,7 @@
     </ClCompile>
     <ClCompile Include="Windows\CompressDialog.cpp" />
     <ClCompile Include="Windows\ExtractDialog.cpp" />
+    <ClCompile Include="Windows\IdentityProfilesDialog.cpp" />
     <ClCompile Include="Windows\RenameSandboxDialog.cpp" />
     <ClCompile Include="Windows\OptionsAccess.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -510,6 +512,7 @@
     <QtMoc Include="Windows\ExtractDialog.h" />
     <QtMoc Include="Windows\TestProxyDialog.h" />
     <QtMoc Include="Windows\CompressDialog.h" />
+    <QtMoc Include="Windows\IdentityProfilesDialog.h" />
     <QtMoc Include="Windows\RenameSandboxDialog.h" />
     <QtMoc Include="Wizards\BoxAssistant.h" />
     <QtMoc Include="Windows\BoxImageWindow.h" />
@@ -551,6 +554,7 @@
     <QtMoc Include="Helpers\IniHighlighter.h" />
     <ClInclude Include="Helpers\ReadDirectoryChanges.h" />
     <ClInclude Include="Helpers\ReadDirectoryChangesPrivate.h" />
+    <ClInclude Include="Helpers\IdentityProfile.h" />
     <ClInclude Include="Helpers\StorageInfo.h" />
     <ClInclude Include="Windows\PendingChanges.h" />
     <ClInclude Include="Helpers\TabOrder.h" />

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClCompile Include="Wizards\NewBoxWizard.cpp">
       <Filter>Wizards</Filter>
     </ClCompile>
+    <ClCompile Include="Helpers\IdentityProfile.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
     <ClCompile Include="Helpers\StorageInfo.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
@@ -232,6 +235,9 @@
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Windows\ExtractDialog.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\IdentityProfilesDialog.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Windows\RenameSandboxDialog.cpp">
@@ -295,6 +301,9 @@
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="Helpers\MiniDumpFilter.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="Helpers\IdentityProfile.h">
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="Helpers\StorageInfo.h">
@@ -427,6 +436,9 @@
       <Filter>Windows</Filter>
     </QtMoc>
     <QtMoc Include="Windows\ExtractDialog.h">
+      <Filter>Windows</Filter>
+    </QtMoc>
+    <QtMoc Include="Windows\IdentityProfilesDialog.h">
       <Filter>Windows</Filter>
     </QtMoc>
     <QtMoc Include="Windows\RenameSandboxDialog.h">

--- a/SandboxiePlus/SandMan/Windows/IdentityProfilesDialog.cpp
+++ b/SandboxiePlus/SandMan/Windows/IdentityProfilesDialog.cpp
@@ -1,0 +1,402 @@
+#include "IdentityProfilesDialog.h"
+
+#include <QtWidgets/QDialogButtonBox>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QFormLayout>
+#include <QtWidgets/QHBoxLayout>
+#include <QtWidgets/QHeaderView>
+#include <QtWidgets/QInputDialog>
+#include <QtWidgets/QMessageBox>
+#include <QtWidgets/QVBoxLayout>
+
+//---------------------------------------------------------------------------
+// CIdentityProfileEditDialog
+//---------------------------------------------------------------------------
+
+CIdentityProfileEditDialog::CIdentityProfileEditDialog(CIdentityProfileStore& Store, const CIdentityProfile& Profile, QWidget* parent)
+	: QDialog(parent), m_Store(Store), m_Profile(Profile)
+{
+	setWindowTitle(tr("Identity Profile"));
+	resize(520, 360);
+
+	QVBoxLayout* pLayout = new QVBoxLayout(this);
+
+	QFormLayout* pForm = new QFormLayout();
+	m_pName = new QLineEdit(m_Profile.Name);
+	pForm->addRow(tr("Name:"), m_pName);
+	pForm->addRow(tr("Id:"), new QLabel(m_Profile.Id));
+	pForm->addRow(tr("Revision:"), new QLabel(QString::number(m_Profile.Revision)));
+	pLayout->addLayout(pForm);
+
+	m_pVolumes = new QTableWidget(0, 2);
+	m_pVolumes->setHorizontalHeaderLabels(QStringList() << tr("Volume device") << tr("Volume serial"));
+	m_pVolumes->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+	m_pVolumes->setSelectionBehavior(QAbstractItemView::SelectRows);
+	foreach(const SIdentityVolume& Volume, m_Profile.Volumes)
+		AddVolume(Volume.Device, Volume.Serial);
+	pLayout->addWidget(m_pVolumes);
+
+	QHBoxLayout* pButtons = new QHBoxLayout();
+	QPushButton* pAdd = new QPushButton(tr("Add Volume"));
+	QPushButton* pRemove = new QPushButton(tr("Remove Volume"));
+	QPushButton* pRegenerate = new QPushButton(tr("Regenerate Serials"));
+	pRegenerate->setToolTip(tr("Replaces every serial in this draft with a new random value. Nothing changes until you save, and bound sandboxes must be re-applied while stopped."));
+	pButtons->addWidget(pAdd);
+	pButtons->addWidget(pRemove);
+	pButtons->addStretch();
+	pButtons->addWidget(pRegenerate);
+	pLayout->addLayout(pButtons);
+
+	m_pInfo = new QLabel(CIdentityProfileBinding::CoverageText());
+	m_pInfo->setWordWrap(true);
+	pLayout->addWidget(m_pInfo);
+
+	QDialogButtonBox* pBox = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel);
+	pLayout->addWidget(pBox);
+
+	connect(pAdd, SIGNAL(clicked(bool)), this, SLOT(OnAdd()));
+	connect(pRemove, SIGNAL(clicked(bool)), this, SLOT(OnRemove()));
+	connect(pRegenerate, SIGNAL(clicked(bool)), this, SLOT(OnRegenerate()));
+	connect(pBox, SIGNAL(accepted()), this, SLOT(OnSave()));
+	connect(pBox, SIGNAL(rejected()), this, SLOT(reject()));
+}
+
+void CIdentityProfileEditDialog::AddVolume(const QString& Device, const QString& Serial)
+{
+	int Row = m_pVolumes->rowCount();
+	m_pVolumes->insertRow(Row);
+	m_pVolumes->setItem(Row, 0, new QTableWidgetItem(Device));
+	m_pVolumes->setItem(Row, 1, new QTableWidgetItem(Serial));
+}
+
+void CIdentityProfileEditDialog::RemoveSelectedVolume()
+{
+	int Row = m_pVolumes->currentRow();
+	if (Row >= 0)
+		m_pVolumes->removeRow(Row);
+}
+
+void CIdentityProfileEditDialog::RegenerateSerials()
+{
+	for (int Row = 0; Row < m_pVolumes->rowCount(); Row++)
+		m_pVolumes->item(Row, 1)->setText(CIdentityProfile::RandomSerial());
+}
+
+QStringList CIdentityProfileEditDialog::GetVolumesText() const
+{
+	QStringList Values;
+	for (int Row = 0; Row < m_pVolumes->rowCount(); Row++)
+		Values.append(m_pVolumes->item(Row, 0)->text() + "," + m_pVolumes->item(Row, 1)->text());
+	return Values;
+}
+
+bool CIdentityProfileEditDialog::CollectProfile(CIdentityProfile& Profile, QString* pError)
+{
+	Profile = m_Profile;
+	Profile.Name = m_pName->text().trimmed();
+	Profile.Volumes.clear();
+	for (int Row = 0; Row < m_pVolumes->rowCount(); Row++) {
+		QString Error;
+		SIdentityVolume Volume;
+		Volume.Device = CIdentityProfile::NormalizeDevice(m_pVolumes->item(Row, 0)->text(), &Error);
+		if (Volume.Device.isEmpty()) { if (pError) *pError = Error; return false; }
+		Volume.Serial = CIdentityProfile::NormalizeSerial(m_pVolumes->item(Row, 1)->text(), &Error);
+		if (Volume.Serial.isEmpty()) { if (pError) *pError = Error; return false; }
+		Profile.Volumes.append(Volume);
+	}
+	QStringList Errors = Profile.Validate();
+	if (!Errors.isEmpty()) {
+		if (pError) *pError = Errors.join("; ");
+		return false;
+	}
+	return true;
+}
+
+bool CIdentityProfileEditDialog::Save()
+{
+	CIdentityProfile Profile;
+	if (!CollectProfile(Profile, &m_LastError))
+		return false;
+	if (!m_Store.Save(Profile, &m_LastError))
+		return false;
+	m_Profile = Profile;
+	m_LastError.clear();
+	return true;
+}
+
+void CIdentityProfileEditDialog::OnAdd()
+{
+	AddVolume("HarddiskVolume" + QString::number(m_pVolumes->rowCount() + 1), CIdentityProfile::RandomSerial());
+}
+
+void CIdentityProfileEditDialog::OnRemove()
+{
+	RemoveSelectedVolume();
+}
+
+void CIdentityProfileEditDialog::OnRegenerate()
+{
+	RegenerateSerials();
+}
+
+void CIdentityProfileEditDialog::OnSave()
+{
+	if (!Save()) {
+		QMessageBox::warning(this, "Sandboxie-Plus", tr("The identity profile was not saved: %1").arg(m_LastError));
+		return;
+	}
+	accept();
+}
+
+//---------------------------------------------------------------------------
+// CIdentityProfilesDialog
+//---------------------------------------------------------------------------
+
+CIdentityProfilesDialog::CIdentityProfilesDialog(CIdentityProfileStore& Store, UsersFunc Users, QWidget* parent)
+	: QDialog(parent), m_Store(Store), m_Users(Users)
+{
+	setWindowTitle(tr("Identity Profiles"));
+	resize(640, 400);
+
+	QVBoxLayout* pLayout = new QVBoxLayout(this);
+
+	m_pList = new QTreeWidget();
+	m_pList->setHeaderLabels(QStringList() << tr("Name") << tr("Revision") << tr("Volumes") << tr("Used by") << tr("Id"));
+	m_pList->setRootIsDecorated(false);
+	pLayout->addWidget(m_pList);
+
+	QHBoxLayout* pButtons = new QHBoxLayout();
+	QPushButton* pNew = new QPushButton(tr("New"));
+	m_pEdit = new QPushButton(tr("Edit"));
+	m_pClone = new QPushButton(tr("Clone"));
+	m_pRegenerate = new QPushButton(tr("Regenerate"));
+	QPushButton* pImport = new QPushButton(tr("Import"));
+	m_pExport = new QPushButton(tr("Export"));
+	m_pDelete = new QPushButton(tr("Delete"));
+	foreach(QPushButton* pButton, QList<QPushButton*>() << pNew << m_pEdit << m_pClone << m_pRegenerate << pImport << m_pExport << m_pDelete)
+		pButtons->addWidget(pButton);
+	pButtons->addStretch();
+	pLayout->addLayout(pButtons);
+
+	m_pInfo = new QLabel(CIdentityProfileBinding::CoverageText());
+	m_pInfo->setWordWrap(true);
+	pLayout->addWidget(m_pInfo);
+
+	QDialogButtonBox* pBox = new QDialogButtonBox(QDialogButtonBox::Close);
+	pLayout->addWidget(pBox);
+
+	connect(pNew, SIGNAL(clicked(bool)), this, SLOT(OnNew()));
+	connect(m_pEdit, SIGNAL(clicked(bool)), this, SLOT(OnEdit()));
+	connect(m_pClone, SIGNAL(clicked(bool)), this, SLOT(OnClone()));
+	connect(m_pRegenerate, SIGNAL(clicked(bool)), this, SLOT(OnRegenerate()));
+	connect(pImport, SIGNAL(clicked(bool)), this, SLOT(OnImport()));
+	connect(m_pExport, SIGNAL(clicked(bool)), this, SLOT(OnExport()));
+	connect(m_pDelete, SIGNAL(clicked(bool)), this, SLOT(OnDelete()));
+	connect(m_pList, SIGNAL(itemSelectionChanged()), this, SLOT(OnSelectionChanged()));
+	connect(m_pList, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(OnEdit()));
+	connect(pBox, SIGNAL(rejected()), this, SLOT(reject()));
+
+	Reload();
+}
+
+void CIdentityProfilesDialog::Reload()
+{
+	QString Selected = GetSelectedId();
+	m_pList->clear();
+	QStringList Problems;
+	foreach(const CIdentityProfile& Profile, m_Store.List(&Problems)) {
+		QTreeWidgetItem* pItem = new QTreeWidgetItem();
+		pItem->setText(0, Profile.Name);
+		pItem->setText(1, QString::number(Profile.Revision));
+		pItem->setText(2, QString::number(Profile.Volumes.size()));
+		pItem->setText(3, m_Users ? m_Users(Profile.Id).join(", ") : QString());
+		pItem->setText(4, Profile.Id);
+		m_pList->addTopLevelItem(pItem);
+	}
+	for (int i = 0; i < m_pList->columnCount(); i++)
+		m_pList->resizeColumnToContents(i);
+	if (!Problems.isEmpty())
+		Report(tr("Some profile files were skipped:\n%1").arg(Problems.join("\n")));
+	SelectId(Selected);
+	OnSelectionChanged();
+}
+
+QString CIdentityProfilesDialog::GetSelectedId() const
+{
+	QTreeWidgetItem* pItem = m_pList->currentItem();
+	return pItem ? pItem->text(4) : QString();
+}
+
+void CIdentityProfilesDialog::SelectId(const QString& Id)
+{
+	for (int i = 0; i < m_pList->topLevelItemCount(); i++) {
+		if (m_pList->topLevelItem(i)->text(4) == Id) {
+			m_pList->setCurrentItem(m_pList->topLevelItem(i));
+			return;
+		}
+	}
+}
+
+void CIdentityProfilesDialog::OnSelectionChanged()
+{
+	bool Has = !GetSelectedId().isEmpty();
+	m_pEdit->setEnabled(Has);
+	m_pClone->setEnabled(Has);
+	m_pRegenerate->setEnabled(Has);
+	m_pExport->setEnabled(Has);
+	m_pDelete->setEnabled(Has);
+}
+
+void CIdentityProfilesDialog::Report(const QString& Text)
+{
+	m_LastError = Text;
+	if (isVisible())
+		QMessageBox::warning(this, "Sandboxie-Plus", Text);
+}
+
+void CIdentityProfilesDialog::OnNew()
+{
+	CIdentityProfile Profile;
+	Profile.Id = CIdentityProfile::NewId();
+	Profile.Name = tr("New Profile");
+	SIdentityVolume Volume;
+	Volume.Device = "HarddiskVolume1";
+	Volume.Serial = CIdentityProfile::RandomSerial();
+	Profile.Volumes.append(Volume);
+	CIdentityProfileEditDialog Dialog(m_Store, Profile, this);
+	if (Dialog.exec() == QDialog::Accepted) {
+		Reload();
+		SelectId(Dialog.GetProfile().Id);
+	}
+}
+
+void CIdentityProfilesDialog::OnEdit()
+{
+	CIdentityProfile Profile;
+	QString Error;
+	if (!m_Store.Load(GetSelectedId(), Profile, &Error)) {
+		Report(Error);
+		return;
+	}
+	CIdentityProfileEditDialog Dialog(m_Store, Profile, this);
+	if (Dialog.exec() == QDialog::Accepted)
+		Reload();
+}
+
+bool CIdentityProfilesDialog::CloneSelected(const QString& NewName)
+{
+	CIdentityProfile Profile;
+	if (!m_Store.Load(GetSelectedId(), Profile, &m_LastError))
+		return false;
+	CIdentityProfile Copy = Profile.Clone(NewName);
+	if (!m_Store.Save(Copy, &m_LastError))
+		return false;
+	Reload();
+	SelectId(Copy.Id);
+	return true;
+}
+
+void CIdentityProfilesDialog::OnClone()
+{
+	CIdentityProfile Profile;
+	if (!m_Store.Load(GetSelectedId(), Profile, &m_LastError)) {
+		Report(m_LastError);
+		return;
+	}
+	bool Ok = false;
+	QString Name = QInputDialog::getText(this, "Sandboxie-Plus", tr("Name of the copy (same serials, new profile id):"), QLineEdit::Normal, Profile.Name + " (copy)", &Ok);
+	if (!Ok || Name.trimmed().isEmpty())
+		return;
+	if (!CloneSelected(Name.trimmed()))
+		Report(m_LastError);
+}
+
+bool CIdentityProfilesDialog::RegenerateSelected()
+{
+	CIdentityProfile Profile;
+	if (!m_Store.Load(GetSelectedId(), Profile, &m_LastError))
+		return false;
+	Profile.Regenerate();
+	if (!m_Store.Save(Profile, &m_LastError))
+		return false;
+	Reload();
+	return true;
+}
+
+void CIdentityProfilesDialog::OnRegenerate()
+{
+	QStringList Users = m_Users ? m_Users(GetSelectedId()) : QStringList();
+	QString Text = tr("Replace every serial of this profile with new random values?");
+	if (!Users.isEmpty())
+		Text += "\n\n" + tr("Sandboxes using it (%1) keep their current configuration until the profile is re-applied while they are stopped.").arg(Users.join(", "));
+	if (QMessageBox::question(this, "Sandboxie-Plus", Text, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
+		return;
+	if (!RegenerateSelected())
+		Report(m_LastError);
+}
+
+bool CIdentityProfilesDialog::DeleteSelected(bool Force)
+{
+	QString Id = GetSelectedId();
+	QStringList Users = m_Users ? m_Users(Id) : QStringList();
+	if (!Users.isEmpty() && !Force) {
+		m_LastError = tr("The profile is still used by: %1").arg(Users.join(", "));
+		return false;
+	}
+	if (!m_Store.Remove(Id, &m_LastError))
+		return false;
+	Reload();
+	return true;
+}
+
+void CIdentityProfilesDialog::OnDelete()
+{
+	QStringList Users = m_Users ? m_Users(GetSelectedId()) : QStringList();
+	if (!Users.isEmpty()) {
+		Report(tr("The profile is still used by: %1\nRemove it from those sandboxes first.").arg(Users.join(", ")));
+		return;
+	}
+	if (QMessageBox::question(this, "Sandboxie-Plus", tr("Delete the selected identity profile?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes)
+		return;
+	if (!DeleteSelected(false))
+		Report(m_LastError);
+}
+
+bool CIdentityProfilesDialog::ImportFile(const QString& Path, QString* pNewId)
+{
+	CIdentityProfile Profile;
+	if (!m_Store.Import(Path, Profile, &m_LastError))
+		return false;
+	if (!m_Store.Save(Profile, &m_LastError))
+		return false;
+	if (pNewId) *pNewId = Profile.Id;
+	Reload();
+	SelectId(Profile.Id);
+	return true;
+}
+
+void CIdentityProfilesDialog::OnImport()
+{
+	QString Path = QFileDialog::getOpenFileName(this, tr("Import identity profile"), QString(), tr("Identity profile (*.json)"));
+	if (Path.isEmpty())
+		return;
+	if (!ImportFile(Path))
+		Report(m_LastError);
+}
+
+bool CIdentityProfilesDialog::ExportSelected(const QString& Path)
+{
+	CIdentityProfile Profile;
+	if (!m_Store.Load(GetSelectedId(), Profile, &m_LastError))
+		return false;
+	return m_Store.Export(Profile, Path, &m_LastError);
+}
+
+void CIdentityProfilesDialog::OnExport()
+{
+	QString Path = QFileDialog::getSaveFileName(this, tr("Export identity profile"), GetSelectedId() + ".json", tr("Identity profile (*.json)"));
+	if (Path.isEmpty())
+		return;
+	if (!ExportSelected(Path))
+		Report(m_LastError);
+}

--- a/SandboxiePlus/SandMan/Windows/IdentityProfilesDialog.h
+++ b/SandboxiePlus/SandMan/Windows/IdentityProfilesDialog.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <QtWidgets/QDialog>
+#include <QtWidgets/QLineEdit>
+#include <QtWidgets/QTableWidget>
+#include <QtWidgets/QTreeWidget>
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QLabel>
+#include <functional>
+
+#include "../Helpers/IdentityProfile.h"
+
+class CIdentityProfileEditDialog : public QDialog
+{
+	Q_OBJECT
+public:
+	CIdentityProfileEditDialog(CIdentityProfileStore& Store, const CIdentityProfile& Profile, QWidget* parent = Q_NULLPTR);
+
+	const CIdentityProfile& GetProfile() const { return m_Profile; }
+
+	// Programmatic access used by the dialog smoke tests.
+	void SetName(const QString& Name) { m_pName->setText(Name); }
+	void AddVolume(const QString& Device, const QString& Serial);
+	void RemoveSelectedVolume();
+	void RegenerateSerials();
+	bool Save();
+	QString GetLastError() const { return m_LastError; }
+	QStringList GetVolumesText() const;
+
+private slots:
+	void OnAdd();
+	void OnRemove();
+	void OnRegenerate();
+	void OnSave();
+
+private:
+	bool CollectProfile(CIdentityProfile& Profile, QString* pError);
+
+	CIdentityProfileStore& m_Store;
+	CIdentityProfile m_Profile;
+	QString m_LastError;
+
+	QLineEdit* m_pName;
+	QTableWidget* m_pVolumes;
+	QLabel* m_pInfo;
+};
+
+class CIdentityProfilesDialog : public QDialog
+{
+	Q_OBJECT
+public:
+	typedef std::function<QStringList(const QString& ProfileId)> UsersFunc;
+
+	CIdentityProfilesDialog(CIdentityProfileStore& Store, UsersFunc Users, QWidget* parent = Q_NULLPTR);
+
+	void Reload();
+	QString GetSelectedId() const;
+	void SelectId(const QString& Id);
+	int GetProfileCount() const { return m_pList->topLevelItemCount(); }
+	QString GetLastError() const { return m_LastError; }
+
+	// Non-interactive variants used by the smoke tests.
+	bool CloneSelected(const QString& NewName);
+	bool RegenerateSelected();
+	bool DeleteSelected(bool Force);
+	bool ImportFile(const QString& Path, QString* pNewId = nullptr);
+	bool ExportSelected(const QString& Path);
+
+private slots:
+	void OnNew();
+	void OnEdit();
+	void OnClone();
+	void OnRegenerate();
+	void OnImport();
+	void OnExport();
+	void OnDelete();
+	void OnSelectionChanged();
+
+private:
+	void Report(const QString& Text);
+
+	CIdentityProfileStore& m_Store;
+	UsersFunc m_Users;
+	QString m_LastError;
+
+	QTreeWidget* m_pList;
+	QLabel* m_pInfo;
+	QPushButton* m_pEdit;
+	QPushButton* m_pClone;
+	QPushButton* m_pRegenerate;
+	QPushButton* m_pExport;
+	QPushButton* m_pDelete;
+};

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -676,7 +676,11 @@ void COptionsWindow::SaveAdvanced()
 
 	WriteAdvancedCheck(ui.chkHideFirmware, "HideFirmwareInfo", "y", "");
 	WriteAdvancedCheck(ui.chkHideUID, "RandomRegUID", "y", "");
-	WriteAdvancedCheck(ui.chkHideSerial, "HideDiskSerialNumber", "y", "");
+	QString SelectedProfile = ui.cmbIdentityProfile->currentData().toString();
+	QString BoundProfile = ui.cmbIdentityProfile->property("boundId").toString();
+	SIdentityBindingState::EState BindingState = (SIdentityBindingState::EState)ui.cmbIdentityProfile->property("boundState").toInt();
+	if (m_Template || !CIdentityProfileBinding::WillApplyProfile(SelectedProfile, BoundProfile, BindingState))
+		WriteAdvancedCheck(ui.chkHideSerial, "HideDiskSerialNumber", "y", "");
 	SaveIdentityProfile();
 	WriteAdvancedCheck(ui.chkHideMac, "HideNetworkAdapterMAC", "y", "");
 

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -23,6 +23,8 @@ namespace
 		bool AppendText(const QString& Setting, const QString& Value) { return Track(m_pBox->AppendText(Setting, Value)); }
 		bool DelValue(const QString& Setting, const QString& Value) { return Track(m_pBox->DelValue(Setting, Value)); }
 		int GetActiveProcessCount() const { auto pBoxPlus = m_pBox.objectCast<CSandBoxPlus>(); return pBoxPlus ? pBoxPlus->GetActiveProcessCount() : 0; }
+		// SaveConfig() batches writes (SetRefreshOnChange(false)); the service only publishes them on commit, so read-back needs one.
+		bool Flush() { m_pBox->CommitIniChanges(); return true; }
 		SB_STATUS GetLastStatus() const { return m_LastStatus; }
 	private:
 		bool Track(const SB_STATUS& Status) { if (!Status) m_LastStatus = Status; return !!Status; }

--- a/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
+++ b/SandboxiePlus/SandMan/Windows/OptionsAdvanced.cpp
@@ -8,6 +8,30 @@
 #include "../MiscHelpers/Common/SettingsWidgets.h"
 #include "../AddonManager.h"
 #include "Helpers/WinAdmin.h"
+#include "Helpers/IdentityProfile.h"
+#include "IdentityProfilesDialog.h"
+
+namespace
+{
+	class CIdentityIniAdapter : public CIdentityIniTarget
+	{
+	public:
+		CIdentityIniAdapter(const QSharedPointer<CSbieIni>& pBox) : m_pBox(pBox) {}
+		QString GetText(const QString& Setting) const { return m_pBox->GetText(Setting); }
+		QStringList GetTextList(const QString& Setting, bool withTemplates) const { return m_pBox->GetTextList(Setting, withTemplates); }
+		bool SetText(const QString& Setting, const QString& Value) { return Track(m_pBox->SetText(Setting, Value)); }
+		bool AppendText(const QString& Setting, const QString& Value) { return Track(m_pBox->AppendText(Setting, Value)); }
+		bool DelValue(const QString& Setting, const QString& Value) { return Track(m_pBox->DelValue(Setting, Value)); }
+		int GetActiveProcessCount() const { auto pBoxPlus = m_pBox.objectCast<CSandBoxPlus>(); return pBoxPlus ? pBoxPlus->GetActiveProcessCount() : 0; }
+		SB_STATUS GetLastStatus() const { return m_LastStatus; }
+	private:
+		bool Track(const SB_STATUS& Status) { if (!Status) m_LastStatus = Status; return !!Status; }
+		QSharedPointer<CSbieIni> m_pBox;
+		SB_STATUS m_LastStatus;
+	};
+
+	QString IdentityProfileDir() { return theConf->GetConfigDir() + "/IdentityProfiles"; }
+}
 
 void COptionsWindow::CreateAdvanced()
 {
@@ -126,6 +150,8 @@ void COptionsWindow::CreateAdvanced()
 	connect(ui.chkHideMac, SIGNAL(clicked(bool)), this, SLOT(OnAdvancedChanged()));
 	connect(ui.cmbLangID, SIGNAL(currentIndexChanged(int)), this, SLOT(OnAdvancedChanged()));
 	connect(ui.btnDumpFW, SIGNAL(clicked(bool)), this, SLOT(OnDumpFW()));
+	connect(ui.cmbIdentityProfile, SIGNAL(currentIndexChanged(int)), this, SLOT(OnAdvancedChanged()));
+	connect(ui.btnIdentityProfiles, SIGNAL(clicked(bool)), this, SLOT(OnIdentityProfiles()));
 
 	connect(ui.chkHideOtherBoxes, SIGNAL(clicked(bool)), this, SLOT(OnAdvancedChanged()));
 	connect(ui.chkHideNonSystemProcesses, SIGNAL(clicked(bool)), this, SLOT(OnAdvancedChanged()));
@@ -344,6 +370,7 @@ void COptionsWindow::LoadAdvanced()
 	ui.chkHideFirmware->setChecked(m_pBox->GetBool("HideFirmwareInfo", false));
 	ui.chkHideUID->setChecked(m_pBox->GetBool("RandomRegUID",false));
 	ui.chkHideSerial->setChecked(m_pBox->GetBool("HideDiskSerialNumber", false));
+	LoadIdentityProfile();
 	ui.chkHideMac->setChecked(m_pBox->GetBool("HideNetworkAdapterMAC", false));
 
 	ui.cmbLangID->setCurrentIndex(ui.cmbLangID->findData(m_pBox->GetNum("CustomLCID", 0)));
@@ -648,6 +675,7 @@ void COptionsWindow::SaveAdvanced()
 	WriteAdvancedCheck(ui.chkHideFirmware, "HideFirmwareInfo", "y", "");
 	WriteAdvancedCheck(ui.chkHideUID, "RandomRegUID", "y", "");
 	WriteAdvancedCheck(ui.chkHideSerial, "HideDiskSerialNumber", "y", "");
+	SaveIdentityProfile();
 	WriteAdvancedCheck(ui.chkHideMac, "HideNetworkAdapterMAC", "y", "");
 
 	int CustomLCID = ui.cmbLangID->currentData().toInt();
@@ -1791,4 +1819,94 @@ void COptionsWindow::InitLangID()
 	ui.cmbLangID->addItem("Yi (ii-CN)", 1144);
 	ui.cmbLangID->addItem("Yoruba (yo-NG)", 1130);
 	ui.cmbLangID->addItem("Zulu (zu-ZA)", 1077);
+}
+
+//---------------------------------------------------------------------------
+// Identity profiles
+//---------------------------------------------------------------------------
+
+void COptionsWindow::LoadIdentityProfile()
+{
+	CIdentityProfileStore Store(IdentityProfileDir());
+	CIdentityIniAdapter Target(m_pBox);
+	SIdentityBindingState State = CIdentityProfileBinding::Read(Target, Store);
+
+	ui.cmbIdentityProfile->blockSignals(true);
+	ui.cmbIdentityProfile->clear();
+	ui.cmbIdentityProfile->addItem(tr("No identity profile"), QString());
+	bool Found = State.ProfileId.isEmpty();
+	foreach(const CIdentityProfile& Profile, Store.List()) {
+		ui.cmbIdentityProfile->addItem(tr("%1 (revision %2)").arg(Profile.Name).arg(Profile.Revision), Profile.Id);
+		if (Profile.Id == State.ProfileId) {
+			ui.cmbIdentityProfile->setCurrentIndex(ui.cmbIdentityProfile->count() - 1);
+			Found = true;
+		}
+	}
+	if (!Found) {
+		ui.cmbIdentityProfile->addItem(tr("Missing profile %1").arg(State.ProfileId), State.ProfileId);
+		ui.cmbIdentityProfile->setCurrentIndex(ui.cmbIdentityProfile->count() - 1);
+	}
+	ui.cmbIdentityProfile->setEnabled(!m_Template);
+	ui.cmbIdentityProfile->setToolTip(State.Describe() + "\n\n" + CIdentityProfileBinding::CoverageText());
+	ui.cmbIdentityProfile->blockSignals(false);
+	ui.cmbIdentityProfile->setProperty("boundId", State.ProfileId);
+	ui.cmbIdentityProfile->setProperty("boundState", (int)State.State);
+
+	bool Managed = !State.ProfileId.isEmpty() && State.State != SIdentityBindingState::eMissing;
+	ui.chkHideSerial->setEnabled(!Managed);
+	ui.chkHideSerial->setToolTip(Managed ? tr("Managed by the selected identity profile") : QString());
+}
+
+void COptionsWindow::SaveIdentityProfile()
+{
+	if (m_Template)
+		return;
+	QString Selected = ui.cmbIdentityProfile->currentData().toString();
+	QString Bound = ui.cmbIdentityProfile->property("boundId").toString();
+	int BoundState = ui.cmbIdentityProfile->property("boundState").toInt();
+	bool Stale = BoundState == SIdentityBindingState::eStale || BoundState == SIdentityBindingState::eDiverged;
+	if (Selected == Bound && !Stale)
+		return;
+
+	CIdentityProfileStore Store(IdentityProfileDir());
+	CIdentityIniAdapter Target(m_pBox);
+	QString Error;
+	bool Ok;
+	if (Selected.isEmpty())
+		Ok = CIdentityProfileBinding::Unbind(Target, &Error);
+	else {
+		CIdentityProfile Profile;
+		Ok = Store.Load(Selected, Profile, &Error) && CIdentityProfileBinding::Apply(Target, Profile, &Error);
+	}
+	if (!Ok) {
+		if (Target.GetLastStatus().IsError())
+			throw Target.GetLastStatus();
+		throw SB_ERR(SB_Message, QVariantList() << tr("Identity profile not applied: %1").arg(Error));
+	}
+	LoadIdentityProfile();
+}
+
+QStringList COptionsWindow::GetIdentityProfileUsers(const QString& ProfileId)
+{
+	QStringList Users;
+	foreach(const CSandBoxPtr& pBox, theAPI->GetAllBoxes()) {
+		if (pBox->GetText(CIdentityProfileBinding::ProfileSetting).trimmed() == ProfileId)
+			Users.append(pBox->GetName());
+	}
+	return Users;
+}
+
+void COptionsWindow::OnIdentityProfiles()
+{
+	CIdentityProfileStore Store(IdentityProfileDir());
+	CIdentityProfilesDialog Dialog(Store, [this](const QString& Id) { return GetIdentityProfileUsers(Id); }, this);
+	Dialog.SelectId(ui.cmbIdentityProfile->currentData().toString());
+	Dialog.exec();
+	QString Selected = ui.cmbIdentityProfile->currentData().toString();
+	LoadIdentityProfile();
+	int Index = ui.cmbIdentityProfile->findData(Selected);
+	if (Index >= 0 && Index != ui.cmbIdentityProfile->currentIndex()) {
+		ui.cmbIdentityProfile->setCurrentIndex(Index);
+	}
+	OnAdvancedChanged();
 }

--- a/SandboxiePlus/SandMan/Windows/OptionsWindow.h
+++ b/SandboxiePlus/SandMan/Windows/OptionsWindow.h
@@ -227,6 +227,7 @@ private slots:
 	void OnDelAuto();
 
 	void OnDumpFW();
+	void OnIdentityProfiles();
 
 	void OnAddProcess();
 	void OnDelProcess();
@@ -538,6 +539,9 @@ protected:
 	void CreateAdvanced();
 	void LoadAdvanced();
 	void SaveAdvanced();
+	void LoadIdentityProfile();
+	void SaveIdentityProfile();
+	QStringList GetIdentityProfileUsers(const QString& ProfileId);
 	void UpdateBoxIsolation();
 	void ShowTriggersTmpl(bool bUpdate = false);
 	void AddTriggerItem(const QString& Value, ETriggerAction Type, bool disabled = false, const QString& Template = QString());

--- a/SandboxiePlus/tests/identity-profile/CMakeLists.txt
+++ b/SandboxiePlus/tests/identity-profile/CMakeLists.txt
@@ -26,6 +26,7 @@ foreach(case
     bind-apply bind-two-boxes bind-refuses-running bind-refuses-manual
     bind-stale-after-regenerate bind-diverged bind-missing bind-unbind
     bind-keeps-templates bind-write-failure host-untouched bind-deferred-commit
+    bind-deferred-checkbox-save bind-missing-checkbox-save
     dialog-new-edit dialog-clone-regenerate dialog-import-export dialog-delete-guard)
     add_test(NAME identity_${case} COMMAND identity_profile_test ${case})
     set_tests_properties(identity_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/SandboxiePlus/tests/identity-profile/CMakeLists.txt
+++ b/SandboxiePlus/tests/identity-profile/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach(case
     regenerate-explicit clone-new-id import-new-id export-atomic
     bind-apply bind-two-boxes bind-refuses-running bind-refuses-manual
     bind-stale-after-regenerate bind-diverged bind-missing bind-unbind
-    bind-keeps-templates bind-write-failure host-untouched
+    bind-keeps-templates bind-write-failure host-untouched bind-deferred-commit
     dialog-new-edit dialog-clone-regenerate dialog-import-export dialog-delete-guard)
     add_test(NAME identity_${case} COMMAND identity_profile_test ${case})
     set_tests_properties(identity_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/SandboxiePlus/tests/identity-profile/CMakeLists.txt
+++ b/SandboxiePlus/tests/identity-profile/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.16)
+project(identity_profile_tests CXX)
+
+set(CMAKE_AUTOMOC ON)
+enable_testing()
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
+
+set(SANDMAN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../SandMan")
+
+add_executable(identity_profile_test
+    identity_profile_test.cpp
+    "${SANDMAN_DIR}/Helpers/IdentityProfile.cpp"
+    "${SANDMAN_DIR}/Helpers/IdentityProfile.h"
+    "${SANDMAN_DIR}/Windows/IdentityProfilesDialog.cpp"
+    "${SANDMAN_DIR}/Windows/IdentityProfilesDialog.h")
+set_target_properties(identity_profile_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
+target_include_directories(identity_profile_test PRIVATE "${SANDMAN_DIR}")
+target_link_libraries(identity_profile_test PRIVATE Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)
+
+foreach(case
+    normalize-device normalize-serial validate-invalid json-corrupt
+    store-roundtrip store-atomic-failure store-list-skips-bad store-remove
+    regenerate-explicit clone-new-id import-new-id export-atomic
+    bind-apply bind-two-boxes bind-refuses-running bind-refuses-manual
+    bind-stale-after-regenerate bind-diverged bind-missing bind-unbind
+    bind-keeps-templates bind-write-failure host-untouched
+    dialog-new-edit dialog-clone-regenerate dialog-import-export dialog-delete-guard)
+    add_test(NAME identity_${case} COMMAND identity_profile_test ${case})
+    set_tests_properties(identity_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endforeach()

--- a/SandboxiePlus/tests/identity-profile/CMakeLists.txt
+++ b/SandboxiePlus/tests/identity-profile/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(identity_profile_test PRIVATE Qt${QT_VERSION_MAJOR}::Core 
 foreach(case
     normalize-device normalize-serial validate-invalid json-corrupt
     store-roundtrip store-atomic-failure store-list-skips-bad store-remove
+    store-stale-writer store-locked-writer
     regenerate-explicit clone-new-id import-new-id export-atomic
     bind-apply bind-two-boxes bind-refuses-running bind-refuses-manual
     bind-stale-after-regenerate bind-diverged bind-missing bind-unbind

--- a/SandboxiePlus/tests/identity-profile/README.md
+++ b/SandboxiePlus/tests/identity-profile/README.md
@@ -22,7 +22,7 @@ the offscreen platform. On Windows the selected Qt DLL directory must be on
 | --- | --- | --- |
 | Simulated tests (this target) | 28 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
 | Build | `SandMan.exe` and `QSbieAPI.dll` built with MSVC from the same commit | The Advanced page integration, `.ui` widgets and project registration compile and link |
-| Runtime | Not part of this change | What a process inside a bound sandbox actually observes from `GetVolumeInformationByHandleW`, and that the host is unchanged, needs a probe run on Windows with Sandboxie installed |
+| Runtime | Manual, see [RUNTIME.md](RUNTIME.md) and `volume_probe.ps1` | What a process inside a bound sandbox actually observes from `GetVolumeInformationByHandleW`, and that the host is unchanged; run on Windows with Sandboxie installed |
 
 The cases: `normalize-device`, `normalize-serial`, `validate-invalid`,
 `json-corrupt`; `store-roundtrip` (second store instance stands in for a new

--- a/SandboxiePlus/tests/identity-profile/README.md
+++ b/SandboxiePlus/tests/identity-profile/README.md
@@ -20,14 +20,16 @@ the offscreen platform. On Windows the selected Qt DLL directory must be on
 
 | Evidence | What it is | What it proves |
 | --- | --- | --- |
-| Simulated tests (this target) | 28 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
+| Simulated tests (this target) | 30 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
 | Build | `SandMan.exe` and `QSbieAPI.dll` built with MSVC from the same commit | The Advanced page integration, `.ui` widgets and project registration compile and link |
 | Runtime | Manual, see [RUNTIME.md](RUNTIME.md) and `volume_probe.ps1` | What a process inside a bound sandbox actually observes from `GetVolumeInformationByHandleW`, and that the host is unchanged; run on Windows with Sandboxie installed |
 
 The cases: `normalize-device`, `normalize-serial`, `validate-invalid`,
 `json-corrupt`; `store-roundtrip` (second store instance stands in for a new
 process), `store-atomic-failure` (commit blocked, previous file intact, no
-temporaries left), `store-list-skips-bad`, `store-remove`;
+temporaries left), `store-list-skips-bad`, `store-remove`, `store-stale-writer`
+(a stale editor cannot overwrite a newer revision or recreate a deleted profile),
+`store-locked-writer` (save and remove refuse a competing profile lock);
 `regenerate-explicit` (edit+save never changes serials, only `Regenerate`
 does), `clone-new-id`, `import-new-id`, `export-atomic`; `bind-apply`,
 `bind-two-boxes` (two profiles, three boxes, regeneration only reaches

--- a/SandboxiePlus/tests/identity-profile/README.md
+++ b/SandboxiePlus/tests/identity-profile/README.md
@@ -1,0 +1,41 @@
+# Identity profile tests
+
+This target compiles the shipped `SandMan/Helpers/IdentityProfile.cpp` and
+`SandMan/Windows/IdentityProfilesDialog.cpp` unchanged, together with a test
+driver. Storage is a `QTemporaryDir`; the box section is a synthetic in-memory
+target implementing `CIdentityIniTarget`. It does not load SbieDll, talk to
+SbieSvc, read `Sandboxie.ini` or query any real volume.
+
+```sh
+cmake -S SandboxiePlus/tests/identity-profile -B build/identity-profile -DCMAKE_BUILD_TYPE=Release
+cmake --build build/identity-profile --config Release
+ctest --test-dir build/identity-profile -C Release --output-on-failure
+```
+
+Python is not needed. Qt 5 or Qt 6 with Widgets is required; CTest selects
+the offscreen platform. On Windows the selected Qt DLL directory must be on
+`PATH` when running the tests.
+
+## Three kinds of evidence
+
+| Evidence | What it is | What it proves |
+| --- | --- | --- |
+| Simulated tests (this target) | 27 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
+| Build | `SandMan.exe` and `QSbieAPI.dll` built with MSVC from the same commit | The Advanced page integration, `.ui` widgets and project registration compile and link |
+| Runtime | Not part of this change | What a process inside a bound sandbox actually observes from `GetVolumeInformationByHandleW`, and that the host is unchanged, needs a probe run on Windows with Sandboxie installed |
+
+The cases: `normalize-device`, `normalize-serial`, `validate-invalid`,
+`json-corrupt`; `store-roundtrip` (second store instance stands in for a new
+process), `store-atomic-failure` (commit blocked, previous file intact, no
+temporaries left), `store-list-skips-bad`, `store-remove`;
+`regenerate-explicit` (edit+save never changes serials, only `Regenerate`
+does), `clone-new-id`, `import-new-id`, `export-atomic`; `bind-apply`,
+`bind-two-boxes` (two profiles, three boxes, regeneration only reaches
+re-applied boxes), `bind-refuses-running`, `bind-refuses-manual`,
+`bind-stale-after-regenerate`, `bind-diverged`, `bind-missing`, `bind-unbind`,
+`bind-keeps-templates`, `bind-write-failure`, `host-untouched` (only the
+profile directory and the box target change); `dialog-new-edit`,
+`dialog-clone-regenerate`, `dialog-import-export`, `dialog-delete-guard`.
+
+A passing run here is not runtime validation of the hook, of SbieSvc
+configuration writes, or of Windows file semantics.

--- a/SandboxiePlus/tests/identity-profile/README.md
+++ b/SandboxiePlus/tests/identity-profile/README.md
@@ -20,7 +20,7 @@ the offscreen platform. On Windows the selected Qt DLL directory must be on
 
 | Evidence | What it is | What it proves |
 | --- | --- | --- |
-| Simulated tests (this target) | 30 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
+| Simulated tests (this target) | 32 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
 | Build | `SandMan.exe` and `QSbieAPI.dll` built with MSVC from the same commit | The Advanced page integration, `.ui` widgets and project registration compile and link |
 | Runtime | Manual, see [RUNTIME.md](RUNTIME.md) and `volume_probe.ps1` | What a process inside a bound sandbox actually observes from `GetVolumeInformationByHandleW`, and that the host is unchanged; run on Windows with Sandboxie installed |
 
@@ -38,7 +38,11 @@ re-applied boxes), `bind-refuses-running`, `bind-refuses-manual`,
 `bind-keeps-templates`, `bind-write-failure`, `host-untouched` (only the
 profile directory and the box target change), `bind-deferred-commit` (writes
 stay invisible until `Flush()`, as with SbieSvc while SandMan batches a save;
-a commit that drops them is reported); `dialog-new-edit`,
+a commit that drops them is reported), `bind-deferred-checkbox-save` (selecting
+a profile in the same save as unchecking the serial checkbox preserves the
+profile-owned setting), `bind-missing-checkbox-save` (an unchanged missing
+binding leaves its editable checkbox under the standalone save path);
+`dialog-new-edit`,
 `dialog-clone-regenerate`, `dialog-import-export`, `dialog-delete-guard`.
 
 A passing run here is not runtime validation of the hook, of SbieSvc

--- a/SandboxiePlus/tests/identity-profile/README.md
+++ b/SandboxiePlus/tests/identity-profile/README.md
@@ -20,7 +20,7 @@ the offscreen platform. On Windows the selected Qt DLL directory must be on
 
 | Evidence | What it is | What it proves |
 | --- | --- | --- |
-| Simulated tests (this target) | 27 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
+| Simulated tests (this target) | 28 CTest cases over the real model, store, binding and dialog code with injected storage and box | Persistence, validation, atomic save, revision/staleness, two boxes, templates untouched, host untouched, dialog flows |
 | Build | `SandMan.exe` and `QSbieAPI.dll` built with MSVC from the same commit | The Advanced page integration, `.ui` widgets and project registration compile and link |
 | Runtime | Not part of this change | What a process inside a bound sandbox actually observes from `GetVolumeInformationByHandleW`, and that the host is unchanged, needs a probe run on Windows with Sandboxie installed |
 
@@ -34,7 +34,9 @@ does), `clone-new-id`, `import-new-id`, `export-atomic`; `bind-apply`,
 re-applied boxes), `bind-refuses-running`, `bind-refuses-manual`,
 `bind-stale-after-regenerate`, `bind-diverged`, `bind-missing`, `bind-unbind`,
 `bind-keeps-templates`, `bind-write-failure`, `host-untouched` (only the
-profile directory and the box target change); `dialog-new-edit`,
+profile directory and the box target change), `bind-deferred-commit` (writes
+stay invisible until `Flush()`, as with SbieSvc while SandMan batches a save;
+a commit that drops them is reported); `dialog-new-edit`,
 `dialog-clone-regenerate`, `dialog-import-export`, `dialog-delete-guard`.
 
 A passing run here is not runtime validation of the hook, of SbieSvc

--- a/SandboxiePlus/tests/identity-profile/RUNTIME.md
+++ b/SandboxiePlus/tests/identity-profile/RUNTIME.md
@@ -1,0 +1,56 @@
+# Runtime check of the volume serial profile
+
+This is the manual, real-driver check that the simulated tests and the build
+cannot replace. It was run once for commit `6ef86f5f` on a lab VM; the steps
+are here so that anyone can repeat it. Nothing in this file is executed by
+CTest.
+
+## Lab conditions
+
+- Windows 10 x64 VM with the official Sandboxie-Plus 1.18.4 installer, then
+  `SandMan.exe` and `QSbieAPI.dll` replaced by the build from this branch.
+- The official driver only accepts a signed manager as session agent
+  (`STATUS_INVALID_SIGNATURE` otherwise), so the VM ran in Windows
+  test-signing mode, where `MyIsCallerSigned` short-circuits. This is a
+  lab condition for running a development manager; it is not a requirement of
+  the feature and says nothing about production security.
+- Two volumes: the system volume (`HarddiskVolumeN`, N from
+  `QueryDosDevice`) and a small fixed VHD mounted as `D:`. Two empty
+  sandboxes `BoxA` and `BoxB`, one host control process outside any box.
+
+## Steps
+
+1. Note the host serials: `powershell -File volume_probe.ps1 -PathList C:\,D:\`.
+2. Map letters to device names (`QueryDosDevice C:`), for example
+   `C: -> \Device\HarddiskVolume3`, `D: -> \Device\HarddiskVolume4`.
+3. In SandMan: BoxA > Sandbox Options > Advanced Options > Privacy >
+   **Identity Profiles...** > **New**. Name it, set the two rows to the device
+   names from step 2 with synthetic serials (`A1A1-0001`, `A1A1-0002`), Save,
+   Close, choose the profile in the combo box, OK. No error dialog may appear.
+4. Repeat for BoxB with a second profile (`B2B2-0001`, `B2B2-0002`).
+5. Check `Sandboxie.ini`: each box section has `HideDiskSerialNumber=y`,
+   `IdentityProfile=<id>`, `IdentityProfileRevision=1` and one
+   `DiskSerialNumber=<device>,<serial>` per row; the JSON files are under the
+   SandMan data directory in `IdentityProfiles`.
+6. Run the probe inside each box through `Start.exe /box:<box> /wait` and on
+   the host; repeat in fresh processes, then reboot, reattach the VHD (a VHD
+   does not reattach by itself) and repeat again without touching the profiles.
+
+## Result for 6ef86f5f (anonymised)
+
+| Process | C: by handle | D: by handle | Notes |
+| --- | --- | --- | --- |
+| BoxA (profile A), 4 fresh processes + after reboot | `A1A1-0001` | `A1A1-0002` | D: only after the VHD was reattached |
+| BoxB (profile B), 2 fresh processes + after reboot | `B2B2-0001` | `B2B2-0002` | while BoxB was briefly bound to profile A it showed the A1A1 values |
+| Host control, before/between/after | real serial, unchanged | real serial, unchanged | not reproduced here |
+
+Two boxes present two different identities, a shared profile presents the
+same identity in both, and the host is untouched. Values survived process
+restarts and a reboot for both volumes. `GetVolumeInformationW` returned the
+same substituted value inside the boxes on this build; that is an observation,
+not part of the covered surface. Physical disk serials, WMI and the native
+query were not checked and are not claimed.
+
+An earlier build (06af52de) reported "configuration read back does not match
+the profile" from this exact flow although the INI was correct after commit;
+that is why the binding now commits before reading back.

--- a/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
+++ b/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
@@ -1,0 +1,688 @@
+#include <QApplication>
+#include <QDir>
+#include <QFile>
+#include <QJsonDocument>
+#include <QMap>
+#include <QSet>
+#include <QTemporaryDir>
+#include <cstdio>
+#include <cstdlib>
+
+#include "Helpers/IdentityProfile.h"
+#include "Windows/IdentityProfilesDialog.h"
+
+#define CHECK(condition) do { if (!(condition)) { \
+	std::fprintf(stderr, "FAIL at line %d: %s\n", __LINE__, #condition); std::exit(1); \
+} } while (0)
+
+// Synthetic box section: a multimap of setting -> values, plus template values that must stay untouched.
+struct SFakeBox : public CIdentityIniTarget
+{
+	QMap<QString, QStringList> Values;
+	QMap<QString, QStringList> TemplateValues;
+	int Processes = 0;
+	bool FailWrites = false;
+	int Writes = 0;
+
+	QString GetText(const QString& Setting) const { return Values.value(Setting).value(0); }
+	QStringList GetTextList(const QString& Setting, bool withTemplates) const
+	{
+		QStringList List = Values.value(Setting);
+		if (withTemplates) List.append(TemplateValues.value(Setting));
+		return List;
+	}
+	bool SetText(const QString& Setting, const QString& Value)
+	{
+		++Writes; if (FailWrites) return false;
+		Values[Setting] = QStringList() << Value; return true;
+	}
+	bool AppendText(const QString& Setting, const QString& Value)
+	{
+		++Writes; if (FailWrites) return false;
+		Values[Setting].append(Value); return true;
+	}
+	bool DelValue(const QString& Setting, const QString& Value)
+	{
+		++Writes; if (FailWrites) return false;
+		if (Value.isEmpty()) Values.remove(Setting);
+		else { Values[Setting].removeOne(Value); if (Values[Setting].isEmpty()) Values.remove(Setting); }
+		return true;
+	}
+	int GetActiveProcessCount() const { return Processes; }
+};
+
+static CIdentityProfile MakeProfile(const QString& Name, int Volumes = 2)
+{
+	CIdentityProfile Profile;
+	Profile.Id = CIdentityProfile::NewId();
+	Profile.Name = Name;
+	for (int i = 1; i <= Volumes; i++) {
+		SIdentityVolume Volume;
+		Volume.Device = "HarddiskVolume" + QString::number(i);
+		Volume.Serial = QString("%1-%2").arg(i, 4, 16, QChar('0')).arg(0xABCD, 4, 16, QChar('0')).toUpper();
+		Profile.Volumes.append(Volume);
+	}
+	return Profile;
+}
+
+static QStringList Sorted(QStringList List) { List.sort(); return List; }
+
+static QSet<QString> Snapshot(const QString& Dir)
+{
+	QSet<QString> Files;
+	QDir Root(Dir);
+	foreach(const QString& Entry, Root.entryList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot, QDir::Name))
+		Files.insert(Entry);
+	return Files;
+}
+
+//---------------------------------------------------------------------------
+
+static void NormalizeDevice()
+{
+	CHECK(CIdentityProfile::NormalizeDevice("HarddiskVolume3") == "HarddiskVolume3");
+	CHECK(CIdentityProfile::NormalizeDevice("\\Device\\HarddiskVolume12") == "HarddiskVolume12");
+	CHECK(CIdentityProfile::NormalizeDevice("  harddiskvolume7 ") == "HarddiskVolume7");
+	QString Error;
+	CHECK(CIdentityProfile::NormalizeDevice("C:", &Error).isEmpty() && Error.contains("C:"));
+	CHECK(CIdentityProfile::NormalizeDevice("HarddiskVolume0").isEmpty());
+	CHECK(CIdentityProfile::NormalizeDevice("PhysicalDrive0").isEmpty());
+	CHECK(CIdentityProfile::NormalizeDevice("HarddiskVolume1\\x").isEmpty());
+	CHECK(CIdentityProfile::NormalizeDevice("").isEmpty());
+}
+
+static void NormalizeSerial()
+{
+	CHECK(CIdentityProfile::NormalizeSerial("1234-abcd") == "1234-ABCD");
+	CHECK(CIdentityProfile::NormalizeSerial("1234ABCD") == "1234-ABCD");
+	CHECK(CIdentityProfile::NormalizeSerial(" 0000-0000 ") == "0000-0000");
+	CHECK(CIdentityProfile::NormalizeSerial("1234-ABC").isEmpty());
+	CHECK(CIdentityProfile::NormalizeSerial("1234-ABCDE").isEmpty());
+	CHECK(CIdentityProfile::NormalizeSerial("GGGG-0000").isEmpty());
+	CHECK(CIdentityProfile::NormalizeSerial("").isEmpty());
+	for (int i = 0; i < 64; i++) {
+		QString Random = CIdentityProfile::RandomSerial();
+		CHECK(CIdentityProfile::NormalizeSerial(Random) == Random);
+	}
+	QString A = CIdentityProfile::RandomSerial();
+	CHECK(CIdentityProfile::NormalizeSerial(A) == A);
+	CHECK(A.size() == 9 && A[4] == '-');
+}
+
+static void ValidateInvalid()
+{
+	CIdentityProfile Good = MakeProfile("good");
+	CHECK(Good.IsValid());
+
+	CIdentityProfile P = Good; P.Version = 2;
+	CHECK(!P.IsValid());
+	P = Good; P.Id = "not-a-uuid";
+	CHECK(!P.IsValid());
+	P = Good; P.Name = "   ";
+	CHECK(!P.IsValid());
+	P = Good; P.Volumes.clear();
+	CHECK(!P.IsValid());
+	P = Good; P.Volumes.append(P.Volumes[0]);
+	CHECK(!P.IsValid());
+	P = Good; P.Volumes[0].Device = "harddiskvolume1";
+	CHECK(!P.IsValid());
+	P = Good; P.Volumes[0].Serial = "1234abcd";
+	CHECK(!P.IsValid());
+	P = Good; P.Volumes[1].Serial = "XYZ";
+	CHECK(!P.IsValid());
+	P = Good; P.Revision = -1;
+	CHECK(!P.IsValid());
+}
+
+static void JsonCorrupt()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	QString Id = CIdentityProfile::NewId();
+	QString Path = Store.PathFor(Id);
+	QDir().mkpath(Dir.path());
+
+	CIdentityProfile Profile; QString Error;
+	QFile File(Path); CHECK(File.open(QIODevice::WriteOnly)); File.write("{ not json"); File.close();
+	CHECK(!Store.Load(Id, Profile, &Error) && !Error.isEmpty());
+
+	CHECK(File.open(QIODevice::WriteOnly | QIODevice::Truncate)); File.write("[1,2,3]"); File.close();
+	CHECK(!Store.Load(Id, Profile, &Error));
+
+	CHECK(File.open(QIODevice::WriteOnly | QIODevice::Truncate)); File.write("{\"format\":\"something-else\",\"version\":1,\"volumes\":[]}"); File.close();
+	CHECK(!Store.Load(Id, Profile, &Error) && Error.contains("not an identity profile"));
+
+	CIdentityProfile Other = MakeProfile("other");
+	CHECK(File.open(QIODevice::WriteOnly | QIODevice::Truncate)); File.write(QJsonDocument(Other.ToJson()).toJson()); File.close();
+	CHECK(!Store.Load(Id, Profile, &Error) && Error.contains("does not match"));
+
+	QJsonObject Json = Other.ToJson(); Json["version"] = 99;
+	CHECK(File.open(QIODevice::WriteOnly | QIODevice::Truncate)); File.write(QJsonDocument(Json).toJson()); File.close();
+	CHECK(!Store.Load(Id, Profile, &Error) && Error.contains("version"));
+}
+
+static void StoreRoundtrip()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfile Profile = MakeProfile("round trip", 3);
+	{
+		CIdentityProfileStore Store(Dir.path() + "/profiles");
+		CHECK(Store.Save(Profile));
+		CHECK(Profile.Revision == 1 && !Profile.Created.isEmpty() && Profile.Updated == Profile.Created);
+	}
+	{
+		// A second store instance stands in for a new SandMan process.
+		CIdentityProfileStore Store(Dir.path() + "/profiles");
+		CIdentityProfile Loaded;
+		CHECK(Store.Load(Profile.Id, Loaded));
+		CHECK(Loaded.ToJson() == Profile.ToJson());
+		CHECK(Loaded.Volumes.size() == 3 && Loaded.Volumes[2].Device == "HarddiskVolume3");
+		CHECK(Loaded.DiskSerialNumberValues() == (QStringList() << "HarddiskVolume1,0001-ABCD" << "HarddiskVolume2,0002-ABCD" << "HarddiskVolume3,0003-ABCD"));
+		Loaded.Name = "renamed";
+		CHECK(Store.Save(Loaded));
+		CHECK(Loaded.Revision == 2 && Loaded.Created == Profile.Created);
+		CIdentityProfile Again;
+		CHECK(Store.Load(Profile.Id, Again) && Again.Name == "renamed" && Again.Revision == 2);
+		CHECK(Again.Volumes == Profile.Volumes);
+	}
+}
+
+static void StoreAtomicFailure()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("atomic");
+	CHECK(Store.Save(Profile));
+	QByteArray Before; { QFile File(Store.PathFor(Profile.Id)); CHECK(File.open(QIODevice::ReadOnly)); Before = File.readAll(); }
+
+	// Make the target path a directory so the replacement cannot be committed.
+	CHECK(QFile::remove(Store.PathFor(Profile.Id)));
+	CHECK(QDir().mkpath(Store.PathFor(Profile.Id)));
+	CIdentityProfile Changed = Profile; Changed.Name = "changed";
+	QString Error;
+	CHECK(!Store.Save(Changed, &Error) && !Error.isEmpty());
+	CHECK(Changed.Revision == Profile.Revision && Changed.Name == "changed");
+	CHECK(QDir(Store.PathFor(Profile.Id)).exists());
+	CHECK(QDir(Store.PathFor(Profile.Id)).entryList(QDir::Files).isEmpty());
+	CHECK(QDir().rmdir(Store.PathFor(Profile.Id)));
+	{ QFile File(Store.PathFor(Profile.Id)); CHECK(File.open(QIODevice::WriteOnly)); File.write(Before); }
+	CIdentityProfile Loaded;
+	CHECK(Store.Load(Profile.Id, Loaded) && Loaded.Name == "atomic" && Loaded.Revision == 1);
+
+	// Every save leaves exactly one file behind, no temporaries.
+	CHECK(Store.Save(Loaded));
+	CHECK(QDir(Dir.path()).entryList(QDir::Files).size() == 1);
+}
+
+static void StoreListSkipsBad()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile A = MakeProfile("a"), B = MakeProfile("b");
+	CHECK(Store.Save(A) && Store.Save(B));
+	{ QFile File(Dir.path() + "/notes.json"); CHECK(File.open(QIODevice::WriteOnly)); File.write("{}"); }
+	{ QFile File(Store.PathFor(CIdentityProfile::NewId())); CHECK(File.open(QIODevice::WriteOnly)); File.write("garbage"); }
+	QStringList Problems;
+	QList<CIdentityProfile> List = Store.List(&Problems);
+	CHECK(List.size() == 2 && Problems.size() == 2);
+	QStringList Names; foreach(const CIdentityProfile& P, List) Names.append(P.Name);
+	CHECK(Sorted(Names) == (QStringList() << "a" << "b"));
+}
+
+static void StoreRemove()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile A = MakeProfile("a");
+	CHECK(Store.Save(A));
+	QString Error;
+	CHECK(!Store.Remove("../etc", &Error));
+	CHECK(!Store.Remove(CIdentityProfile::NewId(), &Error) && Error.contains("not exist"));
+	CHECK(Store.Remove(A.Id));
+	CHECK(!QFile::exists(Store.PathFor(A.Id)));
+	CHECK(Store.List().isEmpty());
+}
+
+static void RegenerateExplicit()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("regen", 3);
+	CHECK(Store.Save(Profile));
+	QList<SIdentityVolume> Original = Profile.Volumes;
+
+	// Loading, editing the name and saving keeps every serial: nothing regenerates on its own.
+	CIdentityProfile Loaded; CHECK(Store.Load(Profile.Id, Loaded));
+	Loaded.Name = "renamed";
+	CHECK(Store.Save(Loaded) && Loaded.Volumes == Original);
+	CHECK(Store.Load(Profile.Id, Loaded) && Loaded.Volumes == Original);
+
+	Loaded.Regenerate();
+	CHECK(Loaded.Volumes.size() == 3);
+	for (int i = 0; i < 3; i++) {
+		CHECK(Loaded.Volumes[i].Device == Original[i].Device);
+		CHECK(Loaded.Volumes[i].Serial != Original[i].Serial);
+		CHECK(CIdentityProfile::NormalizeSerial(Loaded.Volumes[i].Serial) == Loaded.Volumes[i].Serial);
+	}
+	CHECK(Loaded.Id == Profile.Id);
+	CHECK(Store.Save(Loaded) && Loaded.Revision == 3);
+}
+
+static void CloneNewId()
+{
+	CIdentityProfile Profile = MakeProfile("source", 2);
+	Profile.Revision = 5; Profile.Created = "2026-01-01T00:00:00Z"; Profile.Updated = Profile.Created;
+	CIdentityProfile Copy = Profile.Clone("copy");
+	CHECK(Copy.Id != Profile.Id && CIdentityProfile::IsValidId(Copy.Id));
+	CHECK(Copy.Name == "copy" && Copy.Revision == 0 && Copy.Created.isEmpty());
+	CHECK(Copy.Volumes == Profile.Volumes);
+	CHECK(Copy.IsValid());
+}
+
+static void ImportNewId()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path() + "/store");
+	CIdentityProfile Profile = MakeProfile("exported", 2);
+	CHECK(Store.Save(Profile));
+	QString Path = Dir.path() + "/exported.json";
+	CHECK(Store.Export(Profile, Path));
+
+	CIdentityProfile Imported; QString Error;
+	CHECK(Store.Import(Path, Imported, &Error));
+	CHECK(Imported.Id != Profile.Id && Imported.Revision == 0 && Imported.Volumes == Profile.Volumes);
+	CHECK(Imported.Name == "exported");
+	CHECK(Store.Save(Imported));
+	CHECK(Store.List().size() == 2);
+	CIdentityProfile Original; CHECK(Store.Load(Profile.Id, Original) && Original.Revision == 1);
+
+	{ QFile File(Path); CHECK(File.open(QIODevice::WriteOnly | QIODevice::Truncate)); File.write("{\"format\":\"sandboxie-identity-profile\",\"version\":1,\"id\":\"x\",\"name\":\"bad\",\"volumes\":[{\"device\":\"C:\",\"serial\":\"1\"}]}"); }
+	CHECK(!Store.Import(Path, Imported, &Error) && Error.contains("invalid volume device"));
+	CHECK(!Store.Import(Dir.path() + "/missing.json", Imported, &Error));
+}
+
+static void ExportAtomic()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("export");
+	QString Path = Dir.path() + "/out/profile.json";
+	QString Error;
+	CHECK(!Store.Export(Profile, Path, &Error));	// unsaved profile with revision 0 is still valid, but the directory is missing
+	CHECK(!QFile::exists(Path));
+	CHECK(QDir().mkpath(Dir.path() + "/out"));
+	CHECK(Store.Export(Profile, Path));
+	CHECK(QDir(Dir.path() + "/out").entryList(QDir::Files) == (QStringList() << "profile.json"));
+	CIdentityProfile Invalid = Profile; Invalid.Volumes.clear();
+	CHECK(!Store.Export(Invalid, Path, &Error) && Error.contains("no volumes"));
+}
+
+//---------------------------------------------------------------------------
+
+static void BindApply()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("bind", 2);
+	CHECK(Store.Save(Profile));
+
+	SFakeBox Box;
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eUnbound);
+	QString Error;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile, &Error));
+	CHECK(Box.Values["IdentityProfile"] == (QStringList() << Profile.Id));
+	CHECK(Box.Values["IdentityProfileRevision"] == (QStringList() << "1"));
+	CHECK(Box.Values["HideDiskSerialNumber"] == (QStringList() << "y"));
+	CHECK(Sorted(Box.Values["DiskSerialNumber"]) == Sorted(Profile.DiskSerialNumberValues()));
+	CHECK(Box.Values.size() == 4);
+
+	SIdentityBindingState State = CIdentityProfileBinding::Read(Box, Store);
+	CHECK(State.State == SIdentityBindingState::eApplied && State.AppliedRevision == 1 && State.ProfileRevision == 1);
+
+	// Re-applying the same revision is idempotent.
+	int Writes = Box.Writes;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile, &Error));
+	CHECK(Box.Values["DiskSerialNumber"].size() == 2);
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eApplied);
+	CHECK(Box.Writes > Writes);
+}
+
+static void BindTwoBoxes()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile A = MakeProfile("a", 1), B = MakeProfile("b", 2);
+	B.Volumes[0].Serial = "DEAD-BEEF";
+	CHECK(Store.Save(A) && Store.Save(B));
+
+	SFakeBox BoxA, BoxB, BoxC;
+	CHECK(CIdentityProfileBinding::Apply(BoxA, A));
+	CHECK(CIdentityProfileBinding::Apply(BoxB, B));
+	CHECK(CIdentityProfileBinding::Apply(BoxC, B));	// two boxes may share one profile
+	CHECK(BoxA.Values["DiskSerialNumber"] == (QStringList() << "HarddiskVolume1,0001-ABCD"));
+	CHECK(BoxB.Values["DiskSerialNumber"] == (QStringList() << "HarddiskVolume1,DEAD-BEEF" << "HarddiskVolume2,0002-ABCD"));
+	CHECK(BoxC.Values["DiskSerialNumber"] == BoxB.Values["DiskSerialNumber"]);
+	CHECK(BoxA.Values["IdentityProfile"] != BoxB.Values["IdentityProfile"]);
+	CHECK(CIdentityProfileBinding::Read(BoxA, Store).State == SIdentityBindingState::eApplied);
+	CHECK(CIdentityProfileBinding::Read(BoxB, Store).State == SIdentityBindingState::eApplied);
+
+	// Regenerating B only affects boxes bound to B, and only after they are re-applied.
+	B.Regenerate(); CHECK(Store.Save(B));
+	CHECK(CIdentityProfileBinding::Read(BoxA, Store).State == SIdentityBindingState::eApplied);
+	CHECK(CIdentityProfileBinding::Read(BoxB, Store).State == SIdentityBindingState::eStale);
+	CHECK(BoxB.Values["DiskSerialNumber"][0] == "HarddiskVolume1,DEAD-BEEF");
+	CHECK(CIdentityProfileBinding::Apply(BoxB, B));
+	CHECK(BoxB.Values["DiskSerialNumber"] == B.DiskSerialNumberValues());
+	CHECK(BoxC.Values["DiskSerialNumber"][0] == "HarddiskVolume1,DEAD-BEEF");
+	CHECK(CIdentityProfileBinding::Read(BoxC, Store).State == SIdentityBindingState::eStale);
+}
+
+static void BindRefusesRunning()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("running");
+	CHECK(Store.Save(Profile));
+	SFakeBox Box; Box.Processes = 1;
+	QString Error;
+	CHECK(!CIdentityProfileBinding::Apply(Box, Profile, &Error) && Error.contains("stop all processes"));
+	CHECK(Box.Values.isEmpty() && Box.Writes == 0);
+	Box.Processes = 0;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	Box.Processes = 2;
+	CHECK(!CIdentityProfileBinding::Unbind(Box, &Error) && Error.contains("stop all processes"));
+	CHECK(Box.Values["IdentityProfile"] == (QStringList() << Profile.Id));
+}
+
+static void BindRefusesManual()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("manual");
+	CHECK(Store.Save(Profile));
+	SFakeBox Box;
+	Box.Values["DiskSerialNumber"] = QStringList() << "HarddiskVolume9,1111-2222";
+	Box.Values["HideDiskSerialNumber"] = QStringList() << "y";
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eManual);
+	QString Error;
+	CHECK(!CIdentityProfileBinding::Apply(Box, Profile, &Error) && Error.contains("manual DiskSerialNumber"));
+	CHECK(Box.Values["DiskSerialNumber"] == (QStringList() << "HarddiskVolume9,1111-2222"));
+	CHECK(Box.Writes == 0);
+	CHECK(!CIdentityProfileBinding::Unbind(Box, &Error) && Error.contains("no identity profile"));
+	CHECK(Box.Values["DiskSerialNumber"] == (QStringList() << "HarddiskVolume9,1111-2222"));
+}
+
+static void BindStaleAfterRegenerate()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("stale");
+	CHECK(Store.Save(Profile));
+	SFakeBox Box;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	QStringList Applied = Box.Values["DiskSerialNumber"];
+
+	Profile.Regenerate(); CHECK(Store.Save(Profile));
+	SIdentityBindingState State = CIdentityProfileBinding::Read(Box, Store);
+	CHECK(State.State == SIdentityBindingState::eStale && State.AppliedRevision == 1 && State.ProfileRevision == 2);
+	CHECK(Box.Values["DiskSerialNumber"] == Applied);	// nothing changed silently
+	CHECK(State.Describe().contains("revision 1") && State.Describe().contains("revision 2"));
+
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	CHECK(Box.Values["DiskSerialNumber"] != Applied);
+	CHECK(Sorted(Box.Values["DiskSerialNumber"]) == Sorted(Profile.DiskSerialNumberValues()));
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eApplied);
+}
+
+static void BindDiverged()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("diverged");
+	CHECK(Store.Save(Profile));
+	SFakeBox Box;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	Box.Values["DiskSerialNumber"].append("HarddiskVolume5,5555-5555");	// raw INI edit behind SandMan's back
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eDiverged);
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	CHECK(Sorted(Box.Values["DiskSerialNumber"]) == Sorted(Profile.DiskSerialNumberValues()));
+	Box.Values["HideDiskSerialNumber"] = QStringList() << "n";
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eDiverged);
+}
+
+static void BindMissing()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("missing");
+	CHECK(Store.Save(Profile));
+	SFakeBox Box;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	CHECK(Store.Remove(Profile.Id));
+	SIdentityBindingState State = CIdentityProfileBinding::Read(Box, Store);
+	CHECK(State.State == SIdentityBindingState::eMissing && State.ProfileId == Profile.Id);
+	CHECK(Box.Values["DiskSerialNumber"].size() == 2);	// the configured values stay in place
+	CHECK(CIdentityProfileBinding::Unbind(Box));
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eUnbound);
+}
+
+static void BindUnbind()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("unbind");
+	CHECK(Store.Save(Profile));
+	SFakeBox Box;
+	Box.Values["Enabled"] = QStringList() << "y";
+	Box.Values["HideFirmwareInfo"] = QStringList() << "y";
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	CHECK(CIdentityProfileBinding::Unbind(Box));
+	CHECK(!Box.Values.contains("IdentityProfile") && !Box.Values.contains("IdentityProfileRevision"));
+	CHECK(!Box.Values.contains("DiskSerialNumber"));
+	CHECK(Box.Values["HideDiskSerialNumber"] == (QStringList() << "y"));	// left to the existing checkbox
+	CHECK(Box.Values["Enabled"] == (QStringList() << "y") && Box.Values["HideFirmwareInfo"] == (QStringList() << "y"));
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eUnbound);
+}
+
+static void BindKeepsTemplates()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("templates", 1);
+	CHECK(Store.Save(Profile));
+	SFakeBox Box;
+	Box.TemplateValues["DiskSerialNumber"] = QStringList() << "HarddiskVolume1,7777-7777";
+	Box.Values["Template"] = QStringList() << "SomeTemplate";
+	SIdentityBindingState Before = CIdentityProfileBinding::Read(Box, Store);
+	CHECK(Before.State == SIdentityBindingState::eUnbound && Before.TemplateSerials == Box.TemplateValues["DiskSerialNumber"]);
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	CHECK(Box.TemplateValues["DiskSerialNumber"] == (QStringList() << "HarddiskVolume1,7777-7777"));
+	CHECK(Box.Values["Template"] == (QStringList() << "SomeTemplate"));
+	CHECK(Box.Values["DiskSerialNumber"] == Profile.DiskSerialNumberValues());
+	SIdentityBindingState After = CIdentityProfileBinding::Read(Box, Store);
+	CHECK(After.State == SIdentityBindingState::eApplied && After.TemplateSerials.size() == 1);
+	CHECK(CIdentityProfileBinding::Unbind(Box));
+	CHECK(Box.TemplateValues["DiskSerialNumber"].size() == 1 && Box.Values["Template"].size() == 1);
+}
+
+static void BindWriteFailure()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("failure");
+	CHECK(Store.Save(Profile));
+	SFakeBox Box; Box.FailWrites = true;
+	QString Error;
+	CHECK(!CIdentityProfileBinding::Apply(Box, Profile, &Error) && Error.contains("failed to add DiskSerialNumber"));
+	CHECK(Box.Values.isEmpty());
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eUnbound);
+	Box.FailWrites = false;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	Box.FailWrites = true;
+	CHECK(!CIdentityProfileBinding::Unbind(Box, &Error) && Error.contains("failed to remove"));
+	CHECK(Box.Values["IdentityProfile"] == (QStringList() << Profile.Id));
+}
+
+static void HostUntouched()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	QString Outside = Dir.path() + "/outside";
+	CHECK(QDir().mkpath(Outside));
+	{ QFile File(Outside + "/host.txt"); CHECK(File.open(QIODevice::WriteOnly)); File.write("host"); }
+	QSet<QString> Before = Snapshot(Dir.path());
+	QSet<QString> OutsideBefore = Snapshot(Outside);
+
+	CIdentityProfileStore Store(Dir.path() + "/profiles");
+	CIdentityProfile Profile = MakeProfile("host");
+	CHECK(Store.Save(Profile));
+	Profile.Regenerate(); CHECK(Store.Save(Profile));
+	CIdentityProfile Copy = Profile.Clone("copy"); CHECK(Store.Save(Copy));
+	SFakeBox Box;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile));
+	CHECK(CIdentityProfileBinding::Unbind(Box));
+	CHECK(Store.Remove(Copy.Id));
+
+	QSet<QString> After = Snapshot(Dir.path());
+	After.remove("profiles");
+	CHECK(After == Before);
+	CHECK(Snapshot(Outside) == OutsideBefore);
+	CHECK(Snapshot(Dir.path() + "/profiles") == (QSet<QString>() << Profile.Id + ".json"));
+	// Only the box section was written; a global section would be a different target object.
+	CHECK(Box.Values.size() == 1 && Box.Values.contains("HideDiskSerialNumber"));
+}
+
+//---------------------------------------------------------------------------
+
+static void DialogNewEdit()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Draft;
+	Draft.Id = CIdentityProfile::NewId();
+	CIdentityProfileEditDialog Editor(Store, Draft);
+	CHECK(!Editor.Save());	// no name, no volumes
+	Editor.SetName("edited");
+	CHECK(!Editor.Save() && Editor.GetLastError().contains("no volumes"));
+	Editor.AddVolume("\\Device\\HarddiskVolume2", "abcd1234");
+	Editor.AddVolume("HarddiskVolume2", "0000-0000");
+	CHECK(!Editor.Save() && Editor.GetLastError().contains("duplicate"));
+	Editor.RemoveSelectedVolume();	// nothing selected: no-op
+	CHECK(Editor.GetVolumesText().size() == 2);
+	Editor.AddVolume("HarddiskVolume3", "not-a-serial");
+	CHECK(!Editor.Save() && Editor.GetLastError().contains("invalid volume serial"));
+	CIdentityProfileEditDialog BadDevice(Store, Draft);
+	BadDevice.SetName("bad device");
+	BadDevice.AddVolume("D:", "0000-0000");
+	CHECK(!BadDevice.Save() && BadDevice.GetLastError().contains("invalid volume device"));
+	CHECK(!QFile::exists(Store.PathFor(Draft.Id)));
+
+	CIdentityProfileEditDialog Clean(Store, Draft);
+	Clean.SetName("edited");
+	Clean.AddVolume("\\Device\\HarddiskVolume2", "abcd1234");
+	CHECK(Clean.Save());
+	CHECK(Clean.GetProfile().Volumes.size() == 1);
+	CHECK(Clean.GetProfile().Volumes[0].Device == "HarddiskVolume2" && Clean.GetProfile().Volumes[0].Serial == "ABCD-1234");
+	CIdentityProfile Loaded;
+	CHECK(Store.Load(Draft.Id, Loaded) && Loaded.Name == "edited" && Loaded.Revision == 1);
+
+	CIdentityProfileEditDialog Again(Store, Loaded);
+	CHECK(Again.GetVolumesText() == (QStringList() << "HarddiskVolume2,ABCD-1234"));
+	Again.SetName("edited twice");
+	CHECK(Again.Save());
+	CHECK(Store.Load(Draft.Id, Loaded) && Loaded.Name == "edited twice" && Loaded.Revision == 2 && Loaded.Volumes[0].Serial == "ABCD-1234");
+
+	CIdentityProfilesDialog List(Store, nullptr);
+	CHECK(List.GetProfileCount() == 1);
+	List.SelectId(Draft.Id);
+	CHECK(List.GetSelectedId() == Draft.Id);
+}
+
+static void DialogCloneRegenerate()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("origin", 2);
+	CHECK(Store.Save(Profile));
+
+	CIdentityProfilesDialog Dialog(Store, nullptr);
+	Dialog.SelectId(Profile.Id);
+	CHECK(Dialog.CloneSelected("copy"));
+	QString CopyId = Dialog.GetSelectedId();
+	CHECK(CopyId != Profile.Id && Dialog.GetProfileCount() == 2);
+	CIdentityProfile Copy; CHECK(Store.Load(CopyId, Copy));
+	CHECK(Copy.Volumes == Profile.Volumes && Copy.Name == "copy" && Copy.Revision == 1);
+
+	CHECK(Dialog.RegenerateSelected());
+	CIdentityProfile Regenerated; CHECK(Store.Load(CopyId, Regenerated));
+	CHECK(Regenerated.Revision == 2 && Regenerated.Volumes != Profile.Volumes);
+	CIdentityProfile Origin; CHECK(Store.Load(Profile.Id, Origin));
+	CHECK(Origin.Volumes == Profile.Volumes && Origin.Revision == 1);	// the source is untouched
+
+	CIdentityProfileEditDialog Editor(Store, Origin);
+	Editor.RegenerateSerials();
+	CHECK(Editor.GetVolumesText() != Origin.DiskSerialNumberValues());
+	CHECK(Store.Load(Profile.Id, Origin) && Origin.Volumes == Profile.Volumes);	// draft only until saved
+}
+
+static void DialogImportExport()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path() + "/store");
+	CIdentityProfile Profile = MakeProfile("shared", 2);
+	CHECK(Store.Save(Profile));
+	CIdentityProfilesDialog Dialog(Store, nullptr);
+	Dialog.SelectId(Profile.Id);
+	QString Path = Dir.path() + "/shared.json";
+	CHECK(Dialog.ExportSelected(Path) && QFile::exists(Path));
+	QString NewId;
+	CHECK(Dialog.ImportFile(Path, &NewId));
+	CHECK(NewId != Profile.Id && Dialog.GetSelectedId() == NewId && Dialog.GetProfileCount() == 2);
+	CIdentityProfile Imported; CHECK(Store.Load(NewId, Imported));
+	CHECK(Imported.Volumes == Profile.Volumes && Imported.Revision == 1);
+	CHECK(!Dialog.ImportFile(Dir.path() + "/nope.json") && !Dialog.GetLastError().isEmpty());
+	CHECK(Dialog.GetProfileCount() == 2);
+}
+
+static void DialogDeleteGuard()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Used = MakeProfile("used"), Free = MakeProfile("free");
+	CHECK(Store.Save(Used) && Store.Save(Free));
+	QString UsedId = Used.Id;
+	CIdentityProfilesDialog Dialog(Store, [UsedId](const QString& Id) { return Id == UsedId ? QStringList() << "DefaultBox" << "Other" : QStringList(); });
+	Dialog.SelectId(Used.Id);
+	CHECK(!Dialog.DeleteSelected(false) && Dialog.GetLastError().contains("DefaultBox"));
+	CHECK(Dialog.GetProfileCount() == 2 && QFile::exists(Store.PathFor(Used.Id)));
+	Dialog.SelectId(Free.Id);
+	CHECK(Dialog.DeleteSelected(false));
+	CHECK(Dialog.GetProfileCount() == 1 && !QFile::exists(Store.PathFor(Free.Id)));
+	Dialog.SelectId(Used.Id);
+	CHECK(Dialog.DeleteSelected(true));
+	CHECK(Dialog.GetProfileCount() == 0);
+}
+
+int main(int argc, char** argv)
+{
+	QApplication App(argc, argv);
+	QMap<QString, void(*)()> Cases = {
+		{"normalize-device", NormalizeDevice}, {"normalize-serial", NormalizeSerial},
+		{"validate-invalid", ValidateInvalid}, {"json-corrupt", JsonCorrupt},
+		{"store-roundtrip", StoreRoundtrip}, {"store-atomic-failure", StoreAtomicFailure},
+		{"store-list-skips-bad", StoreListSkipsBad}, {"store-remove", StoreRemove},
+		{"regenerate-explicit", RegenerateExplicit}, {"clone-new-id", CloneNewId},
+		{"import-new-id", ImportNewId}, {"export-atomic", ExportAtomic},
+		{"bind-apply", BindApply}, {"bind-two-boxes", BindTwoBoxes},
+		{"bind-refuses-running", BindRefusesRunning}, {"bind-refuses-manual", BindRefusesManual},
+		{"bind-stale-after-regenerate", BindStaleAfterRegenerate}, {"bind-diverged", BindDiverged},
+		{"bind-missing", BindMissing}, {"bind-unbind", BindUnbind},
+		{"bind-keeps-templates", BindKeepsTemplates}, {"bind-write-failure", BindWriteFailure},
+		{"host-untouched", HostUntouched},
+		{"dialog-new-edit", DialogNewEdit}, {"dialog-clone-regenerate", DialogCloneRegenerate},
+		{"dialog-import-export", DialogImportExport}, {"dialog-delete-guard", DialogDeleteGuard}
+	};
+	if (argc != 2 || !Cases.contains(QString::fromUtf8(argv[1]))) return 2;
+	Cases.value(QString::fromUtf8(argv[1]))();
+	std::printf("PASS: %s\n", argv[1]);
+	return 0;
+}

--- a/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
+++ b/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
@@ -2,6 +2,7 @@
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
+#include <QLockFile>
 #include <QMap>
 #include <QSet>
 #include <QTemporaryDir>
@@ -200,6 +201,42 @@ static void StoreRoundtrip()
 		CHECK(Store.Load(Profile.Id, Again) && Again.Name == "renamed" && Again.Revision == 2);
 		CHECK(Again.Volumes == Profile.Volumes);
 	}
+}
+
+static void StoreStaleWriter()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore First(Dir.path()), Second(Dir.path());
+	CIdentityProfile Profile = MakeProfile("original");
+	CHECK(First.Save(Profile));
+	CIdentityProfile Stale; CHECK(Second.Load(Profile.Id, Stale));
+	Profile.Volumes[0].Serial = "1234-5678";
+	CHECK(First.Save(Profile));
+	Stale.Name = "stale rename";
+	QString Error;
+	CHECK(!Second.Save(Stale, &Error) && Error.contains("changed"));
+	CIdentityProfile Loaded; CHECK(First.Load(Profile.Id, Loaded));
+	CHECK(Loaded.ToJson() == Profile.ToJson() && Stale.Revision == 1);
+	CHECK(Second.Load(Profile.Id, Stale));
+	Stale.Name = "fresh rename";
+	CHECK(Second.Save(Stale) && Stale.Revision == 3);
+	CHECK(First.Remove(Profile.Id));
+	CHECK(!Second.Save(Stale, &Error) && !QFile::exists(Second.PathFor(Profile.Id)));
+}
+
+static void StoreLockedWriter()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("locked");
+	CHECK(Store.Save(Profile));
+	QLockFile Lock(Store.PathFor(Profile.Id) + ".lock");
+	CHECK(Lock.tryLock(0));
+	QString Error;
+	CHECK(!Store.Save(Profile, &Error) && !Error.isEmpty());
+	CHECK(!Store.Remove(Profile.Id, &Error));
+	Lock.unlock();
+	CHECK(Store.Save(Profile) && Profile.Revision == 2);
 }
 
 static void StoreAtomicFailure()
@@ -707,6 +744,7 @@ int main(int argc, char** argv)
 		{"normalize-device", NormalizeDevice}, {"normalize-serial", NormalizeSerial},
 		{"validate-invalid", ValidateInvalid}, {"json-corrupt", JsonCorrupt},
 		{"store-roundtrip", StoreRoundtrip}, {"store-atomic-failure", StoreAtomicFailure},
+		{"store-stale-writer", StoreStaleWriter}, {"store-locked-writer", StoreLockedWriter},
 		{"store-list-skips-bad", StoreListSkipsBad}, {"store-remove", StoreRemove},
 		{"regenerate-explicit", RegenerateExplicit}, {"clone-new-id", CloneNewId},
 		{"import-new-id", ImportNewId}, {"export-atomic", ExportAtomic},

--- a/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
+++ b/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
@@ -23,6 +23,11 @@ struct SFakeBox : public CIdentityIniTarget
 	int Processes = 0;
 	bool FailWrites = false;
 	int Writes = 0;
+	bool Deferred = false;		// writes land in Pending until Flush(), like SbieSvc with refresh disabled
+	bool DropOnFlush = false;	// Flush() discards the pending writes instead of publishing them
+	int Flushes = 0;
+	QMap<QString, QStringList> Pending;
+	bool HasPending = false;
 
 	QString GetText(const QString& Setting) const { return Values.value(Setting).value(0); }
 	QStringList GetTextList(const QString& Setting, bool withTemplates) const
@@ -31,24 +36,34 @@ struct SFakeBox : public CIdentityIniTarget
 		if (withTemplates) List.append(TemplateValues.value(Setting));
 		return List;
 	}
+	QMap<QString, QStringList>& Store() { if (Deferred) { if (!HasPending) { Pending = Values; HasPending = true; } return Pending; } return Values; }
 	bool SetText(const QString& Setting, const QString& Value)
 	{
 		++Writes; if (FailWrites) return false;
-		Values[Setting] = QStringList() << Value; return true;
+		Store()[Setting] = QStringList() << Value; return true;
 	}
 	bool AppendText(const QString& Setting, const QString& Value)
 	{
 		++Writes; if (FailWrites) return false;
-		Values[Setting].append(Value); return true;
+		Store()[Setting].append(Value); return true;
 	}
 	bool DelValue(const QString& Setting, const QString& Value)
 	{
 		++Writes; if (FailWrites) return false;
-		if (Value.isEmpty()) Values.remove(Setting);
-		else { Values[Setting].removeOne(Value); if (Values[Setting].isEmpty()) Values.remove(Setting); }
+		QMap<QString, QStringList>& S = Store();
+		if (Value.isEmpty()) S.remove(Setting);
+		else { S[Setting].removeOne(Value); if (S[Setting].isEmpty()) S.remove(Setting); }
 		return true;
 	}
 	int GetActiveProcessCount() const { return Processes; }
+	bool Flush()
+	{
+		++Flushes;
+		if (!Deferred) return true;
+		if (!DropOnFlush && HasPending) Values = Pending;
+		Pending.clear(); HasPending = false;
+		return true;
+	}
 };
 
 static CIdentityProfile MakeProfile(const QString& Name, int Volumes = 2)
@@ -551,6 +566,29 @@ static void HostUntouched()
 	CHECK(Box.Values.size() == 1 && Box.Values.contains("HideDiskSerialNumber"));
 }
 
+static void BindDeferredCommit()
+{
+	// SandMan's options dialog batches INI writes and the service publishes them on commit only;
+	// the read-back must run after Flush(), otherwise a correct apply is reported as a mismatch.
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("deferred", 2);
+	CHECK(Store.Save(Profile));
+	SFakeBox Box; Box.Deferred = true;
+	QString Error;
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile, &Error));
+	CHECK(Box.Flushes == 1 && !Box.HasPending);
+	CHECK(Sorted(Box.Values["DiskSerialNumber"]) == Sorted(Profile.DiskSerialNumberValues()));
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eApplied);
+	CHECK(CIdentityProfileBinding::Unbind(Box, &Error));
+	CHECK(Box.Flushes == 2 && !Box.Values.contains("IdentityProfile") && !Box.Values.contains("DiskSerialNumber"));
+
+	// A commit that loses the writes is reported, not hidden.
+	SFakeBox Lossy; Lossy.Deferred = true; Lossy.DropOnFlush = true;
+	CHECK(!CIdentityProfileBinding::Apply(Lossy, Profile, &Error) && Error.contains("read back"));
+	CHECK(Lossy.Values.isEmpty());
+}
+
 //---------------------------------------------------------------------------
 
 static void DialogNewEdit()
@@ -677,7 +715,7 @@ int main(int argc, char** argv)
 		{"bind-stale-after-regenerate", BindStaleAfterRegenerate}, {"bind-diverged", BindDiverged},
 		{"bind-missing", BindMissing}, {"bind-unbind", BindUnbind},
 		{"bind-keeps-templates", BindKeepsTemplates}, {"bind-write-failure", BindWriteFailure},
-		{"host-untouched", HostUntouched},
+		{"host-untouched", HostUntouched}, {"bind-deferred-commit", BindDeferredCommit},
 		{"dialog-new-edit", DialogNewEdit}, {"dialog-clone-regenerate", DialogCloneRegenerate},
 		{"dialog-import-export", DialogImportExport}, {"dialog-delete-guard", DialogDeleteGuard}
 	};

--- a/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
+++ b/SandboxiePlus/tests/identity-profile/identity_profile_test.cpp
@@ -41,6 +41,7 @@ struct SFakeBox : public CIdentityIniTarget
 	bool SetText(const QString& Setting, const QString& Value)
 	{
 		++Writes; if (FailWrites) return false;
+		if (Deferred && Values.value(Setting) == (QStringList() << Value)) return true;
 		Store()[Setting] = QStringList() << Value; return true;
 	}
 	bool AppendText(const QString& Setting, const QString& Value)
@@ -626,6 +627,54 @@ static void BindDeferredCommit()
 	CHECK(Lossy.Values.isEmpty());
 }
 
+static void BindDeferredCheckboxSave()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	CIdentityProfile Profile = MakeProfile("checkbox save", 2);
+	CHECK(Store.Save(Profile));
+
+	SFakeBox Legacy; Legacy.Deferred = true;
+	Legacy.Values["HideDiskSerialNumber"] = QStringList() << "y";
+	CHECK(Legacy.DelValue("HideDiskSerialNumber", QString()));
+	QString Error;
+	CHECK(!CIdentityProfileBinding::Apply(Legacy, Profile, &Error) && Error.contains("read back"));
+	CHECK(!Legacy.Values.contains("HideDiskSerialNumber"));
+
+	SFakeBox Box; Box.Deferred = true;
+	Box.Values["HideDiskSerialNumber"] = QStringList() << "y";
+	QString Selected = Profile.Id;
+	QString Bound;
+	bool HideSerialChecked = false;
+	if (!CIdentityProfileBinding::WillApplyProfile(Selected, Bound, SIdentityBindingState::eUnbound)) {
+		if (HideSerialChecked) CHECK(Box.SetText("HideDiskSerialNumber", "y"));
+		else CHECK(Box.DelValue("HideDiskSerialNumber", QString()));
+	}
+	CHECK(CIdentityProfileBinding::Apply(Box, Profile, &Error));
+	CHECK(Box.Values["HideDiskSerialNumber"] == (QStringList() << "y"));
+	CHECK(CIdentityProfileBinding::Read(Box, Store).State == SIdentityBindingState::eApplied);
+}
+
+static void BindMissingCheckboxSave()
+{
+	QTemporaryDir Dir; CHECK(Dir.isValid());
+	CIdentityProfileStore Store(Dir.path());
+	SFakeBox Box; Box.Deferred = true;
+	QString MissingId = CIdentityProfile::NewId();
+	Box.Values["IdentityProfile"] = QStringList() << MissingId;
+	Box.Values["HideDiskSerialNumber"] = QStringList() << "y";
+	SIdentityBindingState State = CIdentityProfileBinding::Read(Box, Store);
+	CHECK(State.State == SIdentityBindingState::eMissing);
+
+	QString Selected = State.ProfileId;
+	QString Bound = State.ProfileId;
+	if (!CIdentityProfileBinding::WillApplyProfile(Selected, Bound, State.State))
+		CHECK(Box.DelValue("HideDiskSerialNumber", QString()));
+	CHECK(Box.Flush());
+	CHECK(!Box.Values.contains("HideDiskSerialNumber"));
+	CHECK(Box.Values["IdentityProfile"] == (QStringList() << MissingId));
+}
+
 //---------------------------------------------------------------------------
 
 static void DialogNewEdit()
@@ -754,6 +803,8 @@ int main(int argc, char** argv)
 		{"bind-missing", BindMissing}, {"bind-unbind", BindUnbind},
 		{"bind-keeps-templates", BindKeepsTemplates}, {"bind-write-failure", BindWriteFailure},
 		{"host-untouched", HostUntouched}, {"bind-deferred-commit", BindDeferredCommit},
+		{"bind-deferred-checkbox-save", BindDeferredCheckboxSave},
+		{"bind-missing-checkbox-save", BindMissingCheckboxSave},
 		{"dialog-new-edit", DialogNewEdit}, {"dialog-clone-regenerate", DialogCloneRegenerate},
 		{"dialog-import-export", DialogImportExport}, {"dialog-delete-guard", DialogDeleteGuard}
 	};

--- a/SandboxiePlus/tests/identity-profile/volume_probe.ps1
+++ b/SandboxiePlus/tests/identity-profile/volume_probe.ps1
@@ -1,0 +1,54 @@
+# Read-only volume serial probe for the identity profile runtime check.
+# Prints JSON per root path: the by-handle serial (GetVolumeInformationByHandleW,
+# the hook covered by identity profiles), the path-based serial
+# (GetVolumeInformationW, recorded for comparison only) and whether SbieDll is
+# loaded in this process. Run it on the host and inside a box, for example:
+#   powershell -ExecutionPolicy Bypass -File volume_probe.ps1 -PathList C:\,D:\
+#   Start.exe /box:BoxA /wait cmd /c "powershell -ExecutionPolicy Bypass -File volume_probe.ps1 -PathList C:\,D:\ > out.txt"
+# It prints only the observed serials and error codes, no other identifiers.
+param([string]$PathList = "C:\")
+$Paths = $PathList -split ","
+
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public static class VolProbe {
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern IntPtr CreateFileW(string name, uint access, uint share, IntPtr sec, uint disp, uint flags, IntPtr tmpl);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern bool CloseHandle(IntPtr h);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern bool GetVolumeInformationByHandleW(IntPtr h, StringBuilder name, uint nameSize, out uint serial, out uint maxLen, out uint flags, StringBuilder fs, uint fsSize);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    public static extern bool GetVolumeInformationW(string root, StringBuilder name, uint nameSize, out uint serial, out uint maxLen, out uint flags, StringBuilder fs, uint fsSize);
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    public static extern IntPtr GetModuleHandleW(string name);
+}
+"@
+
+$result = [ordered]@{
+    pid = $PID
+    sbieDllLoaded = ([VolProbe]::GetModuleHandleW("SbieDll.dll") -ne [IntPtr]::Zero)
+    boxName = $env:SBIE_BOX_NAME
+    volumes = @()
+}
+foreach ($p in $Paths) {
+    $entry = [ordered]@{ path = $p; byHandle = $null; byHandleError = 0; byPath = $null; byPathError = 0 }
+    $h = [VolProbe]::CreateFileW($p, 0, 7, [IntPtr]::Zero, 3, 0x02000000, [IntPtr]::Zero)
+    if ($h -ne [IntPtr]-1) {
+        $serial = [uint32]0; $ml = [uint32]0; $fl = [uint32]0
+        $name = New-Object System.Text.StringBuilder 261; $fs = New-Object System.Text.StringBuilder 261
+        if ([VolProbe]::GetVolumeInformationByHandleW($h, $name, 261, [ref]$serial, [ref]$ml, [ref]$fl, $fs, 261)) {
+            $entry.byHandle = ('{0:X4}-{1:X4}' -f ($serial -shr 16), ($serial -band 0xFFFF))
+        } else { $entry.byHandleError = [Runtime.InteropServices.Marshal]::GetLastWin32Error() }
+        [VolProbe]::CloseHandle($h) | Out-Null
+    } else { $entry.byHandleError = [Runtime.InteropServices.Marshal]::GetLastWin32Error() }
+    $serial2 = [uint32]0; $ml2 = [uint32]0; $fl2 = [uint32]0
+    $name2 = New-Object System.Text.StringBuilder 261; $fs2 = New-Object System.Text.StringBuilder 261
+    if ([VolProbe]::GetVolumeInformationW($p, $name2, 261, [ref]$serial2, [ref]$ml2, [ref]$fl2, $fs2, 261)) {
+        $entry.byPath = ('{0:X4}-{1:X4}' -f ($serial2 -shr 16), ($serial2 -band 0xFFFF))
+    } else { $entry.byPathError = [Runtime.InteropServices.Marshal]::GetLastWin32Error() }
+    $result.volumes += $entry
+}
+$result | ConvertTo-Json -Compress -Depth 4


### PR DESCRIPTION
first functional slice of per-sandbox identity profiles: a persistent, versioned profile of volume serials that you create and edit in sandman, bind to a box, and whose values are actually consumed by the one mechanism that supports them today, the `GetVolumeInformationByHandleW` hook via `HideDiskSerialNumber` + `DiskSerialNumber`. no driver, svc or dll change, based on `master` and independent of #5593 and of the volume serial cache branch (that one improves cache keying inside the hook, this one decides what values the hook is fed)

what you get

- `Helpers/IdentityProfile.{h,cpp}`: `CIdentityProfile` (version 1, id, name, revision, `HarddiskVolumeN` -> `XXXX-XXXX`), validation and normalization (`\Device\HarddiskVolume1` accepted, drive letters / `PhysicalDriveN` / duplicates rejected), `CIdentityProfileStore` (one json per profile under the sandman data dir, `QSaveFile` atomic write + read-back, list/load/save/remove/export/import), `CIdentityProfileBinding` (apply/unbind/read state against a small `CIdentityIniTarget` interface)
- `Windows/IdentityProfilesDialog.{h,cpp}`: list dialog (new, edit, clone, regenerate, import, export, delete) and the editor with an explicit **Regenerate Serials** button
- advanced > privacy: a profile combo next to *Hide Disk Serial Number* plus **Identity Profiles...**; apply/ok binds or unbinds through the normal `SaveAdvanced` path, errors surface via `SB_STATUS` like every other option
- `IdentityProfile` / `IdentityProfileRevision` box settings, documented in `SbieSettings.ini`; changelog line; `Docs/IdentityProfiles.md` and the 22-category `Docs/IdentityCoverage.md` matrix (only category 8 and the profile plumbing in 1/15/19/20 move in this slice, everything else is marked as not in this slice or preserved real)

the rules the binding enforces

- the profile is the source of the values; the box section is the applied copy; nothing here claims verified protection, the ui text says so
- apply and unbind refuse while the box has running processes (already running dlls keep their values), and binding refuses over manual `DiskSerialNumber` entries, remove those first
- regenerate is explicit, bumps the revision, and bound boxes show *stale* until re-applied while stopped; nothing is rewritten on its own. raw ini edits show as *diverged*, a deleted profile as *missing*
- clone = new id, same serials; import = always a new id, serials preserved, never overwrites; export goes through `QSaveFile`
- templates and the global section are never written, `Template=` references stay, and boxes without a profile keep exactly their current `HideDiskSerialNumber` behaviour (unbind leaves that checkbox as it was)
- no environment variable, seed or external process is an authority for the profile, and the store only ever touches its own directory

what it does not do, on purpose

- only the by-handle volume query: `GetVolumeInformationW/A`, `NtQueryVolumeInformationFile`, wmi and physical disk serials are not covered and not claimed
- this is the **volume** serial (`vol`), not the physical disk serial
- `HarddiskVolumeN` is a name windows can reassign, not a physical volume binding
- no runtime "protection active" indicator, no fail-closed launch, no service-side atomic ini transaction (profile file is atomic, the ini write is read-back verified only)
- no rollback of a half-applied ini write beyond reporting the failure; the binding state tells you what is there
- the profile file itself now has compare-and-swap on its revision and a per-profile lock (see the follow-up); the "no concurrent-writer protection" caveat is about the box ini section, not the profile store

tests, three kinds kept apart

- simulated: new `SandboxiePlus/tests/identity-profile` ctest target, 28 cases compiling the shipped helper and dialog sources unchanged against a `QTemporaryDir` store and a synthetic box target. covers persistence across store instances, atomic save failure with the old file intact, invalid input and corrupt json, multiple volumes, two profiles across three boxes, refusing running boxes and manual entries, stale/diverged/missing states, templates untouched, host untouched, and the dialog flows (new/edit/clone/regenerate/import/export/delete guard), plus `bind-deferred-commit` for writes that only become visible on commit. 28/28 locally with g++ 16.2 + qt 6.11 offscreen
- build, split by revision (all on my fork, none is an upstream check):
  - 23b54d07, runs https://github.com/Kizuno18/sbxie/actions/runs/34160114364 and https://github.com/Kizuno18/sbxie/actions/runs/34160253007: qt5 and qt6 27/27 both times; the windows job died in workflow plumbing before touching the code (cmake configure against the repo qt package, which ships no `Qt6EntryPointd.lib`, then a wrong `jom.exe` path). no code evidence from those two windows jobs
  - 23b54d07, run https://github.com/Kizuno18/sbxie/actions/runs/34160376589: windows msvc + repo qt6 ran all 27 cases, 27/27, but the real `SandMan.exe` link failed with `LNK2019` on `CIdentityProfileStore`/`CIdentityProfilesDialog` symbols: the new sources were in `SandMan.vcxproj` but not in `SandMan.pri`, and `qmake_plus.cmd` builds from the qmake project. real code gap, fixed in 06af52de
  - 06af52de, run https://github.com/Kizuno18/sbxie/actions/runs/34166990071: qt5 27/27, qt6 27/27, windows msvc 27/27, `QSbieAPI.dll` and `SandMan.exe` x64 build and link. compile-and-link proof for the `.ui`/`OptionsAdvanced` integration, nothing more
  - 6ef86f5f (current head), run https://github.com/Kizuno18/sbxie/actions/runs/34169383236: qt5 28/28, qt6 28/28, windows msvc 28/28, `QSbieAPI.dll` and `SandMan.exe` x64 build, sha256 and blob hashes in `identity-manifest.txt`, which match this branch
- runtime, done by hand on a lab vm with the real driver and the real sandman ui against 6ef86f5f; the probe script and the exact steps are in the branch (`tests/identity-profile/volume_probe.ps1`, `tests/identity-profile/RUNTIME.md`), the anonymised result table too. 664ad0fb on top is that documentation only, no code change after 6ef86f5f
  - lab conditions: windows 10 x64 vm, official sandboxie-plus 1.18.4 installer, then `SandMan.exe`/`QSbieAPI.dll` swapped for the fork ci artifacts of 6ef86f5f (hashes checked against the run manifest). the official driver refuses an unsigned manager as session agent (`STATUS_INVALID_SIGNATURE`), so the vm ran in test-signing mode where `MyIsCallerSigned` short-circuits: that is a lab condition for running a development manager, not a requirement of the feature and not a statement about production security. two volumes, C: and a fixed vhd D: (`HarddiskVolume3`/`HarddiskVolume4` there), two empty boxes, one host control process outside any box
  - the same ui flow on 06af52de hit a real bug: "identity profile not applied: configuration read back does not match the profile" although the ini was correct once `SaveConfig` committed (`SaveConfig` disables refresh-on-change, sbiesvc publishes batched writes on commit only, the read-back ran before). 6ef86f5f fixes it with a `Flush()` hook on the target (sandman adapter = `CSbieIni::CommitIniChanges()`) before every read-back, unbind verifies too, `bind-deferred-commit` models it in the suite
  - with 6ef86f5f: profile a bound to BoxA, profile b bound to BoxB through the dialog, no error dialog; `Sandboxie.ini` shows per box `HideDiskSerialNumber=y`, `IdentityProfile=<id>`, `IdentityProfileRevision=1` and the two `DiskSerialNumber` rows; two json files with revision 1 in the sandman data dir
  - observed by `GetVolumeInformationByHandleW` inside the boxes: BoxA `A1A1-0001`/`A1A1-0002`, BoxB `B2B2-0001`/`B2B2-0002`, stable over fresh processes and over a reboot. per volume: C: was checked in every run; D: only counts where the vhd was attached, so after the reboot the same vhd was reattached and both boxes plus the host were queried again without recreating or re-applying anything, and both volumes kept their values in both boxes. while BoxB was briefly bound to profile a (keyboard slip in the combo) it showed the A1A1 values, i.e. a shared profile behaves as designed. the host control kept its real serials on every run, before and after; those values are not published
  - still not claimed: physical disk serial, wmi, native `NtQueryVolumeInformationFile`. `GetVolumeInformationW` happened to return the same substituted value inside the boxes on this windows build, recorded as an observation only. no runtime "protection active" indicator, no fail-closed launch, no service-side transaction


Follow-up: profile saves now take the same per-profile lock as removal and check the stored revision before replacing the file. A stale editor cannot overwrite newer serials using the same revision or recreate a profile that another instance deleted. Two new regressions failed on 664ad0fb (verified: `store-stale-writer`, `store-locked-writer` fail there) and pass with this fix. Linux/GCC 16.2.1/Qt 6.11.2: `cmake -S SandboxiePlus/tests/identity-profile -B build/identity-profile -DCMAKE_BUILD_TYPE=Release`, `cmake --build build/identity-profile -j4`, and `ctest --test-dir build/identity-profile --output-on-failure` all exit 0, 30/30 cases, and the fork run https://github.com/Kizuno18/sbxie/actions/runs/34241271777 on `dbc47de4` (current head `f498bfe9` is the same tree plus a CHANGELOG-only commit) is green on qt5, qt6 and windows msvc + the real `SandMan.exe`/`QSbieAPI.dll` x64 build. This follow-up has not been tested against Windows file locking or the full manager; the earlier Windows/runtime evidence above applies only to its recorded revisions.

