### PR TITLE
Added error handling and UI refresh

### DIFF
--- a/SandboxiePlus/SandMan/AddonManager.cpp
+++ b/SandboxiePlus/SandMan/AddonManager.cpp
@@ -7,6 +7,7 @@
 #include <QUrlQuery>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QSettings>
 #include "../QSbieAPI/Sandboxie/SbieTemplates.h"
 #include <QtConcurrent>
 #include "../../SandboxieTools/UpdUtil/UpdUtil.h"
@@ -85,8 +86,9 @@ QList<CAddonInfoPtr> CAddonManager::GetAddons()
 			bool Installed = false;
 			
 			QString Key = pAddon->GetSpecificEntry("uninstallKey").toString();
-			if (!Key.isEmpty()) {
-				if(theGUI->GetCompat()->CheckRegistryKey(Key)) {
+			if (!Key.isEmpty() && theGUI->GetCompat()->CheckRegistryKey(Key)) {
+				QSettings reg(Key, QSettings::NativeFormat);
+				if (!reg.value("UninstallString").toString().isEmpty()) {
 					Installed = true;
 					m_Installed.append(CAddonPtr(new CAddon(pAddon->Data)));
 				}

--- a/SandboxiePlus/SandMan/AddonManager.cpp
+++ b/SandboxiePlus/SandMan/AddonManager.cpp
@@ -45,7 +45,7 @@ void CAddonManager::OnUpdateData(const QVariantMap& Data, const QVariantMap& Par
 {
     if (Data.isEmpty() || Data["error"].toBool()) {
         if (Data.contains("errorMsg"))
-            QMessageBox::warning(theGUI, "Sandboxie-Plus", 
+            QMessageBox::warning(theGUI, "Sandboxie-Plus",
                 tr("Updater failed to perform add-on operation, error: %1").arg(Data["errorMsg"].toString()));
         return;
     }

--- a/SandboxiePlus/SandMan/AddonManager.cpp
+++ b/SandboxiePlus/SandMan/AddonManager.cpp
@@ -43,8 +43,12 @@ void CAddonManager::UpdateAddons()
 
 void CAddonManager::OnUpdateData(const QVariantMap& Data, const QVariantMap& Params)
 {
-    if (Data.isEmpty() || Data["error"].toBool())
+    if (Data.isEmpty() || Data["error"].toBool()) {
+        if (Data.contains("errorMsg"))
+            QMessageBox::warning(theGUI, "Sandboxie-Plus", 
+                tr("Updater failed to perform add-on operation, error: %1").arg(Data["errorMsg"].toString()));
         return;
+    }
 
     QVariantMap Addons = Data["addons"].toMap();
 

--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -2474,7 +2474,8 @@ void CSettingsWindow::OnInstallAddon()
 
 	QString Id = pItem->data(0, Qt::UserRole).toString();
 	SB_PROGRESS Status = theGUI->GetAddonManager()->TryInstallAddon(Id, this);
-	if (Status.GetStatus() == OP_ASYNC) connect(Status.GetValue().data(), SIGNAL(Finished()), this, SLOT(OnLoadAddon()));
+	if (Status.GetStatus() == OP_ASYNC)
+		connect(Status.GetValue().data(), &CSbieProgress::Finished, this, &CSettingsWindow::OnLoadAddon);
 }
 
 void CSettingsWindow::OnRemoveAddon()
@@ -2489,7 +2490,8 @@ void CSettingsWindow::OnRemoveAddon()
 		return;
 	}
 	SB_PROGRESS Status = theGUI->GetAddonManager()->TryRemoveAddon(Id, this);
-	if (Status.GetStatus() == OP_ASYNC) connect(Status.GetValue().data(), SIGNAL(Finished()), this, SLOT(OnLoadAddon()));
+	if (Status.GetStatus() == OP_ASYNC)
+		connect(Status.GetValue().data(), &CSbieProgress::Finished, this, &CSettingsWindow::OnLoadAddon);
 }
 
 void CSettingsWindow::OnBrowse()

--- a/SandboxieTools/UpdUtil/UpdUtil.cpp
+++ b/SandboxieTools/UpdUtil/UpdUtil.cpp
@@ -1579,7 +1579,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 					return ERROR_GET;
 				}
 			}
-			else if (bModify) {
+			else if (bModify && !add_addons.empty()) {
 				std::wcout << L"Failed to download add-on data" << std::endl;
 				return ERROR_GET;
 			}

--- a/SandboxieTools/UpdUtil/UpdUtil.cpp
+++ b/SandboxieTools/UpdUtil/UpdUtil.cpp
@@ -1579,6 +1579,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 					return ERROR_GET;
 				}
 			}
+			else if (bModify) {
+				std::wcout << L"Failed to download add-on data" << std::endl;
+				return ERROR_GET;
+			}
 
 			ret = 0;
 


### PR DESCRIPTION
Affects Sandboxie-Plus only

1. Added error handling during extension installation to prevent silent failures caused by network issues (especially for users in China) that would previously show as successful installation.

2. Refresh UI state after removing an extension; the previous behavior kept showing it as still installed after removal.

Additionally, I noticed that the latest version of SbieHide is now 2.0.1, while Sandboxie detects it as 1.0. I originally planned to modify the extension detection logic, but I found that the Addon interacts with sandboxie-plus.com/update.php to fetch version information, so I did not change that part.

Is it possible to modify the detection logic for the latest extension version? If this is rejected for compatibility or security reasons, would it be possible to add support for the latest SbieHide version? https://github.com/VeroFess/SbieHide/releases/tag/v2.0.1 — it seems they changed the file naming and added new DLL. I manually downloaded it and specified InjectDll manually, and it works normally.

Also, the check for ImDisk in the extensions seems to be behind the latest version as well?
