### PR TITLE
sandman: add redacted stack trace exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.18.4 / 5.73.4] - 2026-09-06
 
 ### Added
+- added a redacted stack-trace export in the SandMan trace view: the local stack details stay in the dialog, `Copy` and `Save` produce a share view built from an allow-list (opaque per-report module ids, no paths, no absolute addresses/offsets, no module or symbol names) and the atomic writer never falls back to a direct write
 - added low-noise `SbieTrace` logging for `Shell_NotifyIconW` calls, including the message, icon identity (`NIF_GUID`/GUID or `HWND`/`uID`), and effective direct/proxy route
 - added the `Show Future Settings` editor setting (enabled by default) to include future-version settings in SandMan INI completion candidates
 

--- a/SandboxiePlus/SandMan/Helpers/RedactedStackExport.cpp
+++ b/SandboxiePlus/SandMan/Helpers/RedactedStackExport.cpp
@@ -1,0 +1,158 @@
+#include "RedactedStackExport.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QMap>
+#include <QSaveFile>
+
+//---------------------------------------------------------------------------
+// SRedactedStack
+//---------------------------------------------------------------------------
+
+QJsonObject SRedactedStack::toJson() const
+{
+	QJsonObject json;
+	json["format"] = "sandboxie-stack-export";
+	json["version"] = version;
+	json["captureState"] = captureState;
+	json["frameCount"] = frameCount;
+	json["moduleCount"] = moduleCount;
+	QJsonArray array;
+	foreach (const SRedactedFrame& frame, frames) {
+		QJsonObject entry;
+		entry["index"] = frame.index;
+		entry["moduleId"] = frame.moduleId;
+		entry["moduleResolved"] = frame.moduleResolved;
+		entry["symbolResolved"] = frame.symbolResolved;
+		entry["line"] = frame.line;
+		array.append(entry);
+	}
+	json["frames"] = array;
+	json["note"] = QStringLiteral("Module identifiers are opaque and valid only inside this report. "
+		"Paths, module and symbol names, absolute addresses and offsets are omitted by design. "
+		"Preserving frame order and grouping does not prevent correlation between reports.");
+	return json;
+}
+
+QString SRedactedStack::toText() const
+{
+	QString out;
+	out += QStringLiteral("# Sandboxie-Plus redacted stack export v%1 (%2, %3 frames, %4 modules)\n")
+		.arg(version).arg(captureState).arg(frameCount).arg(moduleCount);
+	foreach (const SRedactedFrame& frame, frames)
+		out += QString::number(frame.index) + QLatin1Char('\t') + frame.line + QLatin1Char('\n');
+	return out;
+}
+
+//---------------------------------------------------------------------------
+// Redaction contract
+//---------------------------------------------------------------------------
+
+// Whitelist markers. They must be recognisable as markers, never as an
+// attribution to a real product.
+static const QLatin1String kModuleMarker("[module-%1]");
+static const QLatin1String kSymbolRedacted("[symbol redacted]");
+static const QLatin1String kUnresolvedFrame("[unresolved]");
+static const QLatin1String kUnresolvedModule("[unresolved module]");
+
+static QString moduleLabel(int id)
+{
+	return QString(kModuleMarker).arg(id, 2, 10, QLatin1Char('0'));
+}
+
+static QString frameLine(int moduleId, bool moduleResolved, bool symbolResolved)
+{
+	if (!moduleResolved && !symbolResolved)
+		return kUnresolvedFrame;
+	if (!moduleResolved)
+		return QString(kUnresolvedModule) + QLatin1Char('!') + kSymbolRedacted;
+	QString line = moduleLabel(moduleId);
+	line += QLatin1Char('!');
+	line += symbolResolved ? QString(kSymbolRedacted) : QString(kUnresolvedFrame);
+	return line;
+}
+
+static bool hasModuleInSymbol(const QString& symbol)
+{
+	// The resolver emits "Module!Function..." or "Module+0x..." when the
+	// module is known and the empty string when it is not.
+	return symbol.contains(QLatin1Char('!')) || symbol.contains(QLatin1Char('+'));
+}
+
+static bool hasSymbolName(const QString& symbol)
+{
+	// A resolved symbol always includes the "!Function" delimiter.
+	return symbol.contains(QLatin1Char('!'));
+}
+
+//---------------------------------------------------------------------------
+// CRedactedStackExport
+//---------------------------------------------------------------------------
+
+SRedactedStack CRedactedStackExport::transform(const SStackCapture& capture)
+{
+	SRedactedStack out;
+	out.captureState = capture.state == SStackCapture::ePartial
+		? QStringLiteral("partial") : QStringLiteral("complete");
+	out.frameCount = capture.frames.size();
+
+	QMap<QString, int> moduleIds;	// QMap keyed on a canonical string so any moduleKey type works
+	int nextModule = 0;
+	out.frames.reserve(capture.frames.size());
+	int index = 0;
+	foreach (const SStackFrame& frame, capture.frames) {
+		SRedactedFrame red;
+		red.index = index++;
+		red.moduleResolved = frame.moduleKey.isValid() && !frame.moduleKey.isNull() && hasModuleInSymbol(frame.symbol);
+		red.symbolResolved = red.moduleResolved && hasSymbolName(frame.symbol);
+		if (red.moduleResolved) {
+			// Canonical key: type-tagged so a QString and the same string
+			// wrapped in another variant type never collide.
+			QString key = QString::number(int(frame.moduleKey.type())) + QLatin1Char(':') + frame.moduleKey.toString();
+			QMap<QString, int>::const_iterator it = moduleIds.constFind(key);
+			if (it == moduleIds.constEnd()) {
+				++nextModule;
+				moduleIds.insert(key, nextModule);
+				red.moduleId = nextModule;
+			} else {
+				red.moduleId = it.value();
+			}
+		}
+		red.line = frameLine(red.moduleId, red.moduleResolved, red.symbolResolved);
+		out.frames.append(red);
+	}
+	out.moduleCount = nextModule;
+	return out;
+}
+
+bool CRedactedStackExport::writeAtomic(const QString& path, const QByteArray& content, QString* error)
+{
+	QSaveFile file(path);
+	file.setDirectWriteFallback(false);
+	if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+		if (error) *error = QStringLiteral("cannot open the export destination");
+		return false;
+	}
+	if (file.write(content) != content.size()) {
+		if (error) *error = QStringLiteral("cannot write the redacted export");
+		file.cancelWriting();
+		return false;
+	}
+	if (!file.commit()) {
+		if (error) *error = QStringLiteral("cannot commit the redacted export");
+		return false;
+	}
+	return true;
+}
+
+bool CRedactedStackExport::exportToFile(const SStackCapture& capture, const QString& path,
+	bool asJson, QString* error)
+{
+	SRedactedStack red = transform(capture);
+	QByteArray bytes;
+	if (asJson)
+		bytes = QJsonDocument(red.toJson()).toJson(QJsonDocument::Indented);
+	else
+		bytes = red.toText().toUtf8();
+	return writeAtomic(path, bytes, error);
+}

--- a/SandboxiePlus/SandMan/Helpers/RedactedStackExport.h
+++ b/SandboxiePlus/SandMan/Helpers/RedactedStackExport.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <QByteArray>
+#include <QJsonObject>
+#include <QString>
+#include <QVariant>
+#include <QVector>
+
+// Input model for one captured frame. All fields are private diagnostic data
+// that must never appear in the redacted output. `symbol` is the resolver's
+// display string ("Module.dll!Function+0x<hex>" or "Module.dll+0x<hex>" or
+// empty when unresolved). `moduleKey` is the private module identity the
+// caller uses to distinguish two modules that happen to share a base name;
+// pass the module base address, a stable handle, or an integer, never the
+// display name alone.
+struct SStackFrame
+{
+	quint64 address = 0;
+	QString symbol;
+	QVariant moduleKey;
+};
+
+struct SStackCapture
+{
+	enum ECaptureState { eComplete, ePartial };
+	QVector<SStackFrame> frames;
+	ECaptureState state = eComplete;
+};
+
+// Output model. Only the fields listed on the redaction allow-list are
+// populated; every other input field stays inside the capture and does not
+// reach the public model.
+struct SRedactedFrame
+{
+	int index = 0;
+	int moduleId = 0;			// opaque per-report id, 1-based; 0 = unresolved / no module
+	bool moduleResolved = false;
+	bool symbolResolved = false;	// true only when the resolver returned a symbol name
+	QString line;				// canonical text line, uses only the allowed markers
+};
+
+struct SRedactedStack
+{
+	int version = 1;
+	QString captureState;		// "complete" or "partial"
+	int frameCount = 0;
+	int moduleCount = 0;		// distinct modules referenced in this report
+	QVector<SRedactedFrame> frames;
+
+	QJsonObject toJson() const;
+	QString toText() const;
+};
+
+// Transformer contract:
+//  * takes an immutable capture, returns a new object built from the
+//    allow-list only, and never mutates the input
+//  * two references to the same `moduleKey` share the same opaque id
+//    inside one report; different keys never collide, even when the
+//    original module name matches
+//  * an unresolved frame is marked, never guessed
+//  * frame order and capture state are preserved
+class CRedactedStackExport
+{
+public:
+	static SRedactedStack transform(const SStackCapture& capture);
+
+	// Write the redacted content atomically via QSaveFile with the direct
+	// write fallback disabled. Returns false and fills `error` on any I/O
+	// or commit failure; the previous file is left intact and no temporary
+	// file survives. `content` must already be the transformed bytes,
+	// never a raw diagnostic buffer.
+	static bool writeAtomic(const QString& path, const QByteArray& content, QString* error);
+
+	// Fallible transform + write in one call. `wrote` is set only on true.
+	static bool exportToFile(const SStackCapture& capture, const QString& path,
+		bool asJson, QString* error);
+};

--- a/SandboxiePlus/SandMan/SandMan.pri
+++ b/SandboxiePlus/SandMan/SandMan.pri
@@ -22,6 +22,7 @@ HEADERS += ./stdafx.h \
     ./Helpers/FullScreen.h \
     ./Helpers/WinAdmin.h \
     ./Helpers/WinHelper.h \
+    ./Helpers/RedactedStackExport.h \
     ./Helpers/StorageInfo.h \
     ./Helpers/ReadDirectoryChanges.h \
     ./Helpers/ReadDirectoryChangesPrivate.h \
@@ -46,6 +47,7 @@ HEADERS += ./stdafx.h \
     ./Windows/BoxImageWindow.h \
     ./Windows/CompressDialog.h \
     ./Windows/ExtractDialog.h \
+    ./Windows/StackExportDialog.h \
     ./Windows/RenameSandboxDialog.h \
     ./Engine/BoxEngine.h \
     ./Engine/ScriptManager.h \
@@ -81,6 +83,7 @@ SOURCES += ./main.cpp \
     ./Helpers/FullScreen.cpp \
     ./Helpers/WinAdmin.cpp \
     ./Helpers/WinHelper.cpp \
+    ./Helpers/RedactedStackExport.cpp \
     ./Helpers/StorageInfo.cpp \
     ./Helpers/ReadDirectoryChanges.cpp \
     ./Helpers/ReadDirectoryChangesPrivate.cpp \
@@ -105,6 +108,7 @@ SOURCES += ./main.cpp \
     ./Windows/BoxImageWindow.cpp \
     ./Windows/CompressDialog.cpp \
     ./Windows/ExtractDialog.cpp \
+    ./Windows/StackExportDialog.cpp \
     ./Windows/RenameSandboxDialog.cpp \
     ./Engine/BoxEngine.cpp \
     ./Engine/ScriptManager.cpp \

--- a/SandboxiePlus/SandMan/SandMan.vcxproj
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj
@@ -300,6 +300,7 @@
     <ClCompile Include="Helpers\IniHighlighter.cpp" />
     <ClCompile Include="Helpers\ReadDirectoryChanges.cpp" />
     <ClCompile Include="Helpers\ReadDirectoryChangesPrivate.cpp" />
+    <ClCompile Include="Helpers\RedactedStackExport.cpp" />
     <ClCompile Include="Helpers\StorageInfo.cpp" />
     <ClCompile Include="Helpers\TabOrder.cpp" />
     <ClCompile Include="Helpers\WinAdmin.cpp" />
@@ -383,6 +384,7 @@
     </ClCompile>
     <ClCompile Include="Windows\CompressDialog.cpp" />
     <ClCompile Include="Windows\ExtractDialog.cpp" />
+    <ClCompile Include="Windows\StackExportDialog.cpp" />
     <ClCompile Include="Windows\RenameSandboxDialog.cpp" />
     <ClCompile Include="Windows\OptionsAccess.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -510,6 +512,7 @@
     <QtMoc Include="Windows\ExtractDialog.h" />
     <QtMoc Include="Windows\TestProxyDialog.h" />
     <QtMoc Include="Windows\CompressDialog.h" />
+    <QtMoc Include="Windows\StackExportDialog.h" />
     <QtMoc Include="Windows\RenameSandboxDialog.h" />
     <QtMoc Include="Wizards\BoxAssistant.h" />
     <QtMoc Include="Windows\BoxImageWindow.h" />
@@ -551,6 +554,7 @@
     <QtMoc Include="Helpers\IniHighlighter.h" />
     <ClInclude Include="Helpers\ReadDirectoryChanges.h" />
     <ClInclude Include="Helpers\ReadDirectoryChangesPrivate.h" />
+    <ClInclude Include="Helpers\RedactedStackExport.h" />
     <ClInclude Include="Helpers\StorageInfo.h" />
     <ClInclude Include="Windows\PendingChanges.h" />
     <ClInclude Include="Helpers\TabOrder.h" />

--- a/SandboxiePlus/SandMan/SandMan.vcxproj.filters
+++ b/SandboxiePlus/SandMan/SandMan.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClCompile Include="Wizards\NewBoxWizard.cpp">
       <Filter>Wizards</Filter>
     </ClCompile>
+    <ClCompile Include="Helpers\RedactedStackExport.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
     <ClCompile Include="Helpers\StorageInfo.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
@@ -232,6 +235,9 @@
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Windows\ExtractDialog.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\StackExportDialog.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Windows\RenameSandboxDialog.cpp">
@@ -295,6 +301,9 @@
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="Helpers\MiniDumpFilter.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="Helpers\RedactedStackExport.h">
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="Helpers\StorageInfo.h">
@@ -427,6 +436,9 @@
       <Filter>Windows</Filter>
     </QtMoc>
     <QtMoc Include="Windows\ExtractDialog.h">
+      <Filter>Windows</Filter>
+    </QtMoc>
+    <QtMoc Include="Windows\StackExportDialog.h">
       <Filter>Windows</Filter>
     </QtMoc>
     <QtMoc Include="Windows\RenameSandboxDialog.h">

--- a/SandboxiePlus/SandMan/Views/StackView.cpp
+++ b/SandboxiePlus/SandMan/Views/StackView.cpp
@@ -2,6 +2,8 @@
 #include "..\SandMan.h"
 #include "StackView.h"
 #include "..\..\MiscHelpers\Common\Common.h"
+#include "..\Helpers\RedactedStackExport.h"
+#include "..\Windows\StackExportDialog.h"
 
 CStackView::CStackView(QWidget *parent)
 	: CPanelView(parent)
@@ -32,6 +34,9 @@ CStackView::CStackView(QWidget *parent)
 	AddPanelItemsToMenu();
 
 	m_pStackList->header()->restoreState(theConf->GetBlob("MainWindow/StackView_Columns"));
+
+	m_pMenu->addSeparator();
+	m_pMenu->addAction(tr("Export Redacted..."), this, SLOT(OnExportRedacted()));
 }
 
 CStackView::~CStackView()
@@ -118,4 +123,30 @@ void CStackView::OnSymbolChanged(quint64 Address)
 void CStackView::SetFilter(const QRegularExpression& Exp, int iOptions, int Col)
 {
 	CPanelWidgetEx::ApplyFilter(m_pStackList, &m_pFinder->GetSearchExp());
+}
+
+void CStackView::OnExportRedacted()
+{
+	SStackCapture Capture;
+	Capture.state = SStackCapture::eComplete;
+	Capture.frames.reserve(m_CurrentStack.size());
+	for (int i = 0; i < m_CurrentStack.size(); ++i) {
+		quint64 Address = m_CurrentStack[i];
+		SStackFrame Frame;
+		Frame.address = Address;
+		if (!m_pCurrentProcess.isNull())
+			Frame.symbol = m_pCurrentProcess->GetSymbol(Address);
+		// Module grouping: use the resolver's module short name because the
+		// live diagnostic path does not expose a base address here. Two
+		// modules that share a base name inside one report collide by
+		// design; the dialog and the docs state so.
+		int bang = Frame.symbol.indexOf(QLatin1Char('!'));
+		int plus = Frame.symbol.indexOf(QLatin1Char('+'));
+		int split = (bang >= 0 && (plus < 0 || bang < plus)) ? bang : plus;
+		if (split > 0)
+			Frame.moduleKey = Frame.symbol.left(split);
+		Capture.frames.append(Frame);
+	}
+	CStackExportDialog dlg(Capture, this);
+	dlg.exec();
 }

--- a/SandboxiePlus/SandMan/Views/StackView.h
+++ b/SandboxiePlus/SandMan/Views/StackView.h
@@ -27,6 +27,9 @@ public slots:
 
 	void					SetFilter(const QRegularExpression& Exp, int iOptions = 0, int Col = -1); // -1 = any
 
+private slots:
+	void					OnExportRedacted();
+
 protected:
 	//virtual void				OnMenu(const QPoint& Point);
 	virtual QTreeView*			GetView()	{ return m_pStackList; }

--- a/SandboxiePlus/SandMan/Windows/StackExportDialog.cpp
+++ b/SandboxiePlus/SandMan/Windows/StackExportDialog.cpp
@@ -1,0 +1,166 @@
+#include "StackExportDialog.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QDialogButtonBox>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QJsonDocument>
+#include <QMessageBox>
+#include <QSplitter>
+#include <QVBoxLayout>
+
+CStackExportDialog::CStackExportDialog(const SStackCapture& capture, QWidget* parent)
+	: QDialog(parent), m_Capture(capture)
+{
+	setWindowTitle(tr("Export Stack Trace"));
+	resize(760, 480);
+
+	// Freeze the redacted view for the entire dialog lifetime so a live
+	// diagnostic refresh cannot swap it out from under the copy/save button.
+	m_Redacted = CRedactedStackExport::transform(m_Capture);
+
+	QVBoxLayout* pLayout = new QVBoxLayout(this);
+
+	QLabel* pHeader = new QLabel(tr(
+		"The <b>share preview</b> is what Copy and Save will produce. "
+		"Selected fields are omitted from that view; this does not change "
+		"the visibility of the modules inside the process."));
+	pHeader->setWordWrap(true);
+	pLayout->addWidget(pHeader);
+
+	QSplitter* pSplit = new QSplitter(Qt::Vertical);
+	QWidget* pLocal = new QWidget();
+	QVBoxLayout* pLocalLayout = new QVBoxLayout(pLocal);
+	pLocalLayout->setContentsMargins(0, 0, 0, 0);
+	pLocalLayout->addWidget(new QLabel(tr("Local details (stay in this dialog)")));
+	m_pLocal = new QPlainTextEdit();
+	m_pLocal->setReadOnly(true);
+	m_pLocal->setPlainText(renderLocal(m_Capture));
+	pLocalLayout->addWidget(m_pLocal);
+	pSplit->addWidget(pLocal);
+
+	QWidget* pShare = new QWidget();
+	QVBoxLayout* pShareLayout = new QVBoxLayout(pShare);
+	pShareLayout->setContentsMargins(0, 0, 0, 0);
+	QHBoxLayout* pHeader2 = new QHBoxLayout();
+	pHeader2->addWidget(new QLabel(tr("Share preview (this is what leaves the dialog)")));
+	pHeader2->addStretch();
+	pHeader2->addWidget(new QLabel(tr("Format:")));
+	m_pFormat = new QComboBox();
+	m_pFormat->addItem(tr("Text"), QStringLiteral("text"));
+	m_pFormat->addItem(tr("JSON"), QStringLiteral("json"));
+	pHeader2->addWidget(m_pFormat);
+	pShareLayout->addLayout(pHeader2);
+	m_pShare = new QPlainTextEdit();
+	m_pShare->setReadOnly(true);
+	pShareLayout->addWidget(m_pShare);
+	pSplit->addWidget(pShare);
+	pLayout->addWidget(pSplit, 1);
+
+	m_pWarning = new QLabel();
+	m_pWarning->setWordWrap(true);
+	pLayout->addWidget(m_pWarning);
+
+	QHBoxLayout* pButtons = new QHBoxLayout();
+	m_pCopy = new QPushButton(tr("Copy Share View"));
+	m_pSave = new QPushButton(tr("Save Share View..."));
+	pButtons->addWidget(m_pCopy);
+	pButtons->addWidget(m_pSave);
+	pButtons->addStretch();
+	QDialogButtonBox* pBox = new QDialogButtonBox(QDialogButtonBox::Close);
+	pButtons->addWidget(pBox);
+	pLayout->addLayout(pButtons);
+
+	connect(m_pFormat, SIGNAL(currentIndexChanged(int)), this, SLOT(onFormatChanged()));
+	connect(m_pCopy, SIGNAL(clicked(bool)), this, SLOT(onCopy()));
+	connect(m_pSave, SIGNAL(clicked(bool)), this, SLOT(onSave()));
+	connect(pBox, SIGNAL(rejected()), this, SLOT(reject()));
+
+	onFormatChanged();
+}
+
+QString CStackExportDialog::renderLocal(const SStackCapture& capture) const
+{
+	QString out;
+	if (capture.state == SStackCapture::ePartial)
+		out += tr("(capture reported as partial)\n");
+	for (int i = 0; i < capture.frames.size(); ++i) {
+		const SStackFrame& frame = capture.frames[i];
+		out += QString::number(i);
+		out += QLatin1Char('\t');
+		out += frame.symbol.isEmpty() ? tr("<unresolved>") : frame.symbol;
+		out += QStringLiteral("  0x");
+		out += QString::number(frame.address, 16);
+		out += QLatin1Char('\n');
+	}
+	return out;
+}
+
+QByteArray CStackExportDialog::currentShareBytes(bool* asJson) const
+{
+	bool json = m_pFormat->currentData().toString() == QLatin1String("json");
+	if (asJson) *asJson = json;
+	if (json)
+		return QJsonDocument(m_Redacted.toJson()).toJson(QJsonDocument::Indented);
+	return m_Redacted.toText().toUtf8();
+}
+
+QString CStackExportDialog::localText() const { return m_pLocal->toPlainText(); }
+QString CStackExportDialog::shareText() const { return m_Redacted.toText(); }
+QString CStackExportDialog::shareJson() const { return QString::fromUtf8(QJsonDocument(m_Redacted.toJson()).toJson(QJsonDocument::Indented)); }
+
+void CStackExportDialog::onFormatChanged()
+{
+	QByteArray bytes = currentShareBytes();
+	m_pShare->setPlainText(QString::fromUtf8(bytes));
+	m_pWarning->setText(tr(
+		"Selected fields were omitted from the share view: paths, absolute "
+		"addresses and offsets, module and symbol names, capture owner and "
+		"free-form error messages. Module markers are opaque within this "
+		"report only. Preserving frame order does not prevent correlation "
+		"between reports."));
+}
+
+bool CStackExportDialog::copyShareToClipboard()
+{
+	m_LastError.clear();
+	QByteArray bytes = currentShareBytes();
+	QClipboard* pClipboard = QApplication::clipboard();
+	if (!pClipboard) {
+		m_LastError = QStringLiteral("no clipboard available");
+		return false;
+	}
+	pClipboard->setText(QString::fromUtf8(bytes));
+	return true;
+}
+
+bool CStackExportDialog::saveShareTo(const QString& path)
+{
+	m_LastError.clear();
+	bool json = false;
+	QByteArray bytes = currentShareBytes(&json);
+	if (!CRedactedStackExport::writeAtomic(path, bytes, &m_LastError))
+		return false;
+	return true;
+}
+
+void CStackExportDialog::onCopy()
+{
+	if (!copyShareToClipboard())
+		QMessageBox::warning(this, "Sandboxie-Plus",
+			tr("Copy failed: %1").arg(m_LastError));
+}
+
+void CStackExportDialog::onSave()
+{
+	bool json = m_pFormat->currentData().toString() == QLatin1String("json");
+	QString filter = json ? tr("Redacted stack (*.json)") : tr("Redacted stack (*.txt)");
+	QString path = QFileDialog::getSaveFileName(this, tr("Save redacted stack"), QString(), filter);
+	if (path.isEmpty())
+		return;
+	if (!saveShareTo(path))
+		QMessageBox::warning(this, "Sandboxie-Plus",
+			tr("Save failed: %1").arg(m_LastError));
+}

--- a/SandboxiePlus/SandMan/Windows/StackExportDialog.h
+++ b/SandboxiePlus/SandMan/Windows/StackExportDialog.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <QDialog>
+#include <QLabel>
+#include <QPlainTextEdit>
+#include <QComboBox>
+#include <QPushButton>
+
+#include "../Helpers/RedactedStackExport.h"
+
+// Displays two clearly separated presentations of one stack capture:
+//   - "Local details" mirrors the captured symbols and is only shown here
+//   - "Share preview" is the redacted transform, and matches the bytes that
+//     Copy or Save will produce.
+// Both views come from the same capture; a live refresh of the diagnostic
+// never swaps content out from under a Copy or Save the user just approved.
+class CStackExportDialog : public QDialog
+{
+	Q_OBJECT
+public:
+	CStackExportDialog(const SStackCapture& capture, QWidget* parent = nullptr);
+
+	// Non-interactive shims used by the smoke tests.
+	QString localText() const;
+	QString shareText() const;
+	QString shareJson() const;
+	QString lastError() const { return m_LastError; }
+	bool copyShareToClipboard();
+	bool saveShareTo(const QString& path);
+
+private slots:
+	void onFormatChanged();
+	void onCopy();
+	void onSave();
+
+private:
+	QString renderLocal(const SStackCapture& capture) const;
+	QByteArray currentShareBytes(bool* asJson = nullptr) const;
+
+	SStackCapture m_Capture;
+	SRedactedStack m_Redacted;
+	QPlainTextEdit* m_pLocal;
+	QPlainTextEdit* m_pShare;
+	QComboBox* m_pFormat;
+	QLabel* m_pWarning;
+	QPushButton* m_pCopy;
+	QPushButton* m_pSave;
+	QString m_LastError;
+};

--- a/SandboxiePlus/tests/redacted-stack-export/CMakeLists.txt
+++ b/SandboxiePlus/tests/redacted-stack-export/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+project(redacted_stack_export_tests CXX)
+
+set(CMAKE_AUTOMOC ON)
+enable_testing()
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core)
+
+set(SANDMAN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../SandMan")
+
+add_executable(redacted_stack_export_test
+    redacted_stack_export_test.cpp
+    "${SANDMAN_DIR}/Helpers/RedactedStackExport.cpp"
+    "${SANDMAN_DIR}/Helpers/RedactedStackExport.h")
+set_target_properties(redacted_stack_export_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
+target_include_directories(redacted_stack_export_test PRIVATE "${SANDMAN_DIR}")
+target_link_libraries(redacted_stack_export_test PRIVATE Qt${QT_VERSION_MAJOR}::Core)
+
+foreach(case
+    allow-list-privacy allow-list-fields
+    opaque-ids-per-report same-name-distinct-modules module-name-shared
+    frame-order-preserved unresolved-frame-marked partial-capture-preserved
+    unicode-and-punctuation
+    text-and-json-fidelity
+    save-atomic-happy save-open-failure save-commit-failure save-existing-file
+    save-does-not-touch-input concurrent-transforms-do-not-share-ids)
+    add_test(NAME redacted_${case} COMMAND redacted_stack_export_test ${case})
+    set_tests_properties(redacted_${case} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endforeach()

--- a/SandboxiePlus/tests/redacted-stack-export/README.md
+++ b/SandboxiePlus/tests/redacted-stack-export/README.md
@@ -1,0 +1,49 @@
+# Redacted stack export tests
+
+This target compiles the shipped `SandMan/Helpers/RedactedStackExport.cpp`
+unchanged and drives it with a synthetic capture. Storage is a
+`QTemporaryDir`; there is no live diagnostic path, no SbieDll and no
+SbieSvc. The dialog (`SandMan/Windows/StackExportDialog.cpp`) is a thin
+consumer of the same transformer and is exercised in the runtime pass, not
+here.
+
+```sh
+cmake -S SandboxiePlus/tests/redacted-stack-export -B build/redacted-stack -DCMAKE_BUILD_TYPE=Release
+cmake --build build/redacted-stack --config Release
+ctest --test-dir build/redacted-stack -C Release --output-on-failure
+```
+
+Python is not needed. Qt 5 or Qt 6 Core is enough (no Widgets); CTest
+selects the offscreen platform.
+
+## What each case proves
+
+| Case | What it proves |
+| --- | --- |
+| `allow-list-privacy` | Every synthetic private token stays out of the text, the JSON, the on-disk file and the error message. |
+| `allow-list-fields` | The JSON has exactly the documented top-level keys and per-frame keys; nothing else. |
+| `opaque-ids-per-report` | Ids are 1-based order-of-appearance, distinct modules get distinct ids, the same key inside one report reuses its id. |
+| `same-name-distinct-modules` | Two frames sharing a display name but using different private module keys never collide. |
+| `module-name-shared` | When the caller passes the display name as the key (SandMan integration) they do collide, which is the documented limit of that integration. |
+| `frame-order-preserved` | Order and count of the output match the input; indices are dense. |
+| `unresolved-frame-marked` | An unresolved frame becomes `[unresolved]`, a module-only symbol becomes `[module-NN]![unresolved]`; neither is filled by a guess. |
+| `partial-capture-preserved` | `state == ePartial` propagates to both the JSON and the text header. |
+| `unicode-and-punctuation` | Unicode display names never appear in the output; different Unicode keys still get different ids. |
+| `text-and-json-fidelity` | Text has one line per frame plus one header line; JSON round-trips through `QJsonDocument`. |
+| `save-atomic-happy` | The written file is redacted, no temporary sibling survives. |
+| `save-open-failure` | Missing parent directory: `false` is returned, no file is created, the error string does not leak private tokens. |
+| `save-commit-failure` | A directory sitting on the destination path fails the commit; `directWriteFallback` is off so nothing is written. |
+| `save-existing-file` | A previous file at the destination is replaced atomically, no rogue temp file, previous content is gone. |
+| `save-does-not-touch-input` | The `SStackCapture` handed to the transformer is byte-for-byte the same after the export. |
+| `concurrent-transforms-do-not-share-ids` | Two independent reports each start their id space at 1, so the opaque ids are truly per-report. |
+
+## Three kinds of evidence, kept apart
+
+| Evidence | What it is | What it proves |
+| --- | --- | --- |
+| Simulated tests (this target) | 16 CTest cases over the real transformer with a `QTemporaryDir` store and a synthetic capture. | Privacy allow-list, fidelity, atomic write, opaque ids. |
+| Build | `SandMan.exe` and `QSbieAPI.dll` built with MSVC from the same commit. | The dialog integration, `.h`/`.cpp` registration and toolchain compile and link. |
+| Runtime | Manual on a Windows host with Sandboxie installed. | That the "Export Redacted..." action in the stack view context menu produces a share view matching this transformer's output, without altering the underlying capture or the observed process. |
+
+A passing run here is not runtime validation of the DbgHelp symbol
+resolver, of the real capture path, or of Windows clipboard semantics.

--- a/SandboxiePlus/tests/redacted-stack-export/redacted_stack_export_test.cpp
+++ b/SandboxiePlus/tests/redacted-stack-export/redacted_stack_export_test.cpp
@@ -1,0 +1,349 @@
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMap>
+#include <QSet>
+#include <QTemporaryDir>
+#include <QThread>
+#include <QVector>
+#include <cstdio>
+#include <cstdlib>
+
+#include "Helpers/RedactedStackExport.h"
+
+#define CHECK(condition) do { if (!(condition)) { \
+	std::fprintf(stderr, "FAIL at line %d: %s\n", __LINE__, #condition); std::exit(1); \
+} } while (0)
+
+//---------------------------------------------------------------------------
+// Fixture: private diagnostic tokens that must never leak into the share view.
+//---------------------------------------------------------------------------
+
+// Synthetic private strings. If any of these ever appears in the redacted
+// output, in the JSON or in the error message the test fails. They are the
+// only "sensitive" data in this file.
+static const QStringList kPrivateTokens = {
+	QStringLiteral("C:\\Users\\alice\\projeto-interno"),
+	QStringLiteral("C:/Users/alice/projeto-interno"),
+	QStringLiteral("bridge.dll"),
+	QStringLiteral("BridgeDispatchRequest"),
+	QStringLiteral("SbieDll.dll"),
+	QStringLiteral("Sbie_Init"),
+	QStringLiteral("app.exe"),
+	QStringLiteral("RunTask"),
+	QStringLiteral("kernel32.dll"),
+	QStringLiteral("CreateFileW"),
+	QStringLiteral("HelloDlgProc"),
+	QStringLiteral("0x7ffde1a04b30"),
+	QStringLiteral("SecretPath\\file\\with spaces"),
+	QStringLiteral("caixa-secreta"),
+	QStringLiteral("alice@example.internal"),
+};
+
+static bool leaksPrivate(const QString& s)
+{
+	foreach (const QString& token, kPrivateTokens) {
+		if (s.contains(token, Qt::CaseInsensitive)) return true;
+	}
+	// Hex byte sequences are also a leak signal for absolute addresses.
+	// The frame index is decimal, the module label uses "%1" (int), so
+	// there should be no "0x" in the redacted output at all.
+	return s.contains(QStringLiteral("0x"), Qt::CaseInsensitive);
+}
+
+static SStackCapture makeCapture(SStackCapture::ECaptureState state = SStackCapture::eComplete)
+{
+	SStackCapture c;
+	c.state = state;
+	SStackFrame f0; f0.address = 0x7ffde1a04b30ULL; f0.symbol = QStringLiteral("bridge.dll!BridgeDispatchRequest+0x2a"); f0.moduleKey = QStringLiteral("bridge.dll"); c.frames.append(f0);
+	SStackFrame f1; f1.address = 0x7ffde1a04a10ULL; f1.symbol = QStringLiteral("bridge.dll!Helper+0x10"); f1.moduleKey = QStringLiteral("bridge.dll"); c.frames.append(f1);
+	SStackFrame f2; f2.address = 0x7fffab001000ULL; f2.symbol = QStringLiteral("kernel32.dll!CreateFileW+0x100"); f2.moduleKey = QStringLiteral("kernel32.dll"); c.frames.append(f2);
+	SStackFrame f3; f3.address = 0x7fffde000000ULL; f3.symbol = QStringLiteral("SbieDll.dll+0x1234"); f3.moduleKey = QStringLiteral("SbieDll.dll"); c.frames.append(f3);
+	SStackFrame f4; f4.address = 0x7ffdeadbeef0ULL; f4.symbol = QString(); f4.moduleKey = QVariant(); c.frames.append(f4);
+	return c;
+}
+
+//---------------------------------------------------------------------------
+
+static void AllowListPrivacy()
+{
+	SStackCapture cap = makeCapture();
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	QString text = red.toText();
+	QString json = QString::fromUtf8(QJsonDocument(red.toJson()).toJson());
+	CHECK(!leaksPrivate(text));
+	CHECK(!leaksPrivate(json));
+
+	QString error;
+	QTemporaryDir dir; CHECK(dir.isValid());
+	QString path = dir.path() + QStringLiteral("/out.json");
+	CHECK(CRedactedStackExport::exportToFile(cap, path, true, &error));
+	QFile file(path); CHECK(file.open(QIODevice::ReadOnly));
+	QString onDisk = QString::fromUtf8(file.readAll());
+	CHECK(!leaksPrivate(onDisk));
+	CHECK(!leaksPrivate(error));
+
+	// Unknown/free-form fields never make it in.
+	SStackCapture withNoise = cap;
+	SStackFrame extra; extra.address = 0xdeadbeef; extra.symbol = QStringLiteral("password=hunter2 bridge.dll!DispatchRequest"); extra.moduleKey = QStringLiteral("bridge.dll");
+	withNoise.frames.append(extra);
+	SRedactedStack redNoise = CRedactedStackExport::transform(withNoise);
+	QString textNoise = redNoise.toText();
+	CHECK(!textNoise.contains(QStringLiteral("password")));
+	CHECK(!textNoise.contains(QStringLiteral("hunter2")));
+}
+
+static void AllowListFields()
+{
+	SStackCapture cap = makeCapture();
+	QJsonObject json = CRedactedStackExport::transform(cap).toJson();
+	QSet<QString> topKeys;
+	foreach (const QString& k, json.keys()) topKeys.insert(k);
+	CHECK(topKeys == (QSet<QString>() << QStringLiteral("format") << QStringLiteral("version") << QStringLiteral("captureState") << QStringLiteral("frameCount") << QStringLiteral("moduleCount") << QStringLiteral("frames") << QStringLiteral("note")));
+	QJsonArray frames = json.value(QStringLiteral("frames")).toArray();
+	CHECK(!frames.isEmpty());
+	QSet<QString> frameKeys;
+	foreach (const QString& k, frames[0].toObject().keys()) frameKeys.insert(k);
+	CHECK(frameKeys == (QSet<QString>() << QStringLiteral("index") << QStringLiteral("moduleId") << QStringLiteral("moduleResolved") << QStringLiteral("symbolResolved") << QStringLiteral("line")));
+	CHECK(json.value(QStringLiteral("format")).toString() == QStringLiteral("sandboxie-stack-export"));
+	CHECK(json.value(QStringLiteral("version")).toInt() == 1);
+}
+
+static void OpaqueIdsPerReport()
+{
+	SStackCapture cap = makeCapture();
+	SRedactedStack a = CRedactedStackExport::transform(cap);
+	SRedactedStack b = CRedactedStackExport::transform(cap);
+	// Order-of-appearance ids inside one report.
+	QSet<int> aIds, bIds;
+	foreach (const SRedactedFrame& f, a.frames) if (f.moduleId) aIds.insert(f.moduleId);
+	foreach (const SRedactedFrame& f, b.frames) if (f.moduleId) bIds.insert(f.moduleId);
+	CHECK(aIds == (QSet<int>() << 1 << 2 << 3));
+	CHECK(bIds == aIds);
+	// Frames of the same module share the id inside a report.
+	CHECK(a.frames[0].moduleId == a.frames[1].moduleId);
+	CHECK(a.frames[0].moduleId != a.frames[2].moduleId);
+	CHECK(a.moduleCount == 3);
+}
+
+static void SameNameDistinctModules()
+{
+	// Same visible name, different private module identities: the transformer
+	// must not merge them.
+	SStackCapture cap;
+	SStackFrame a; a.address = 0x100; a.symbol = QStringLiteral("bridge.dll!DispatchRequest+0x1"); a.moduleKey = 0x10000000ULL; cap.frames.append(a);
+	SStackFrame b; b.address = 0x200; b.symbol = QStringLiteral("bridge.dll!AnotherFn+0x2"); b.moduleKey = 0x20000000ULL; cap.frames.append(b);
+	SStackFrame c; c.address = 0x300; c.symbol = QStringLiteral("bridge.dll!AnotherFn+0x3"); c.moduleKey = 0x10000000ULL; cap.frames.append(c);
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	CHECK(red.frames[0].moduleId == 1);
+	CHECK(red.frames[1].moduleId == 2);
+	CHECK(red.frames[2].moduleId == 1);
+	CHECK(red.moduleCount == 2);
+}
+
+static void ModuleNameShared()
+{
+	// If the caller passes the module name as the key (SandMan integration),
+	// same-name frames collide by design. That behaviour is documented.
+	SStackCapture cap;
+	SStackFrame a; a.address = 0x100; a.symbol = QStringLiteral("bridge.dll!A+0x1"); a.moduleKey = QStringLiteral("bridge.dll"); cap.frames.append(a);
+	SStackFrame b; b.address = 0x200; b.symbol = QStringLiteral("bridge.dll!B+0x2"); b.moduleKey = QStringLiteral("bridge.dll"); cap.frames.append(b);
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	CHECK(red.frames[0].moduleId == red.frames[1].moduleId);
+	CHECK(red.moduleCount == 1);
+}
+
+static void FrameOrderPreserved()
+{
+	SStackCapture cap = makeCapture();
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	CHECK(red.frameCount == cap.frames.size());
+	for (int i = 0; i < red.frames.size(); ++i)
+		CHECK(red.frames[i].index == i);
+}
+
+static void UnresolvedFrameMarked()
+{
+	SStackCapture cap = makeCapture();
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	const SRedactedFrame& last = red.frames.last();
+	CHECK(!last.moduleResolved && !last.symbolResolved);
+	CHECK(last.moduleId == 0);
+	CHECK(last.line == QStringLiteral("[unresolved]"));
+	// A module-only symbol (no "!") is not resolved but the module is.
+	const SRedactedFrame& mod = red.frames[3];
+	CHECK(mod.moduleResolved && !mod.symbolResolved);
+	CHECK(mod.line.contains(QStringLiteral("!")));
+	CHECK(mod.line.endsWith(QStringLiteral("[unresolved]")));
+}
+
+static void PartialCapturePreserved()
+{
+	SStackCapture cap = makeCapture(SStackCapture::ePartial);
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	CHECK(red.captureState == QStringLiteral("partial"));
+	CHECK(red.toText().contains(QStringLiteral("partial")));
+	CHECK(red.toJson().value(QStringLiteral("captureState")).toString() == QStringLiteral("partial"));
+	SRedactedStack complete = CRedactedStackExport::transform(makeCapture(SStackCapture::eComplete));
+	CHECK(complete.captureState == QStringLiteral("complete"));
+}
+
+static void UnicodeAndPunctuation()
+{
+	SStackCapture cap;
+	SStackFrame a; a.address = 0x100; a.symbol = QStringLiteral("módulo-ção.dll!Função<T>+0xFF");
+	// Two different Unicode keys, then the same as key 1 again.
+	a.moduleKey = QStringLiteral("módulo-ção.dll@base1");
+	cap.frames.append(a);
+	SStackFrame b; b.address = 0x200; b.symbol = QStringLiteral("模块.dll!調用+0x1");
+	b.moduleKey = QStringLiteral("模块.dll@base1");
+	cap.frames.append(b);
+	SStackFrame c = a; c.address = 0x300;
+	cap.frames.append(c);
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	QString text = red.toText();
+	CHECK(!text.contains(QStringLiteral("módulo")));
+	CHECK(!text.contains(QStringLiteral("Função")));
+	CHECK(!text.contains(QStringLiteral("模块")));
+	CHECK(red.frames[0].moduleId == red.frames[2].moduleId);
+	CHECK(red.frames[0].moduleId != red.frames[1].moduleId);
+}
+
+static void TextAndJsonFidelity()
+{
+	SStackCapture cap = makeCapture();
+	SRedactedStack red = CRedactedStackExport::transform(cap);
+	QString text = red.toText();
+	int lines = text.count(QLatin1Char('\n'));
+	CHECK(lines == red.frameCount + 1);	// header + one line per frame
+
+	// JSON roundtrip: writing then parsing must yield the same object.
+	QByteArray bytes = QJsonDocument(red.toJson()).toJson(QJsonDocument::Indented);
+	QJsonParseError err{};
+	QJsonDocument parsed = QJsonDocument::fromJson(bytes, &err);
+	CHECK(err.error == QJsonParseError::NoError);
+	CHECK(parsed.object().value(QStringLiteral("frameCount")).toInt() == red.frameCount);
+	CHECK(parsed.object().value(QStringLiteral("frames")).toArray().size() == red.frameCount);
+}
+
+//---------------------------------------------------------------------------
+
+static void SaveAtomicHappy()
+{
+	QTemporaryDir dir; CHECK(dir.isValid());
+	QString path = dir.path() + QStringLiteral("/happy.json");
+	SStackCapture cap = makeCapture();
+	QString error;
+	CHECK(CRedactedStackExport::exportToFile(cap, path, true, &error) && error.isEmpty());
+	QFile file(path); CHECK(file.open(QIODevice::ReadOnly));
+	QString onDisk = QString::fromUtf8(file.readAll());
+	CHECK(!leaksPrivate(onDisk));
+	// One file, no temporary siblings.
+	CHECK(QDir(dir.path()).entryList(QDir::Files) == (QStringList() << QStringLiteral("happy.json")));
+}
+
+static void SaveOpenFailure()
+{
+	QTemporaryDir dir; CHECK(dir.isValid());
+	// Target sits inside a directory that does not exist: open fails.
+	QString path = dir.path() + QStringLiteral("/missing-dir/out.json");
+	SStackCapture cap = makeCapture();
+	QString error;
+	CHECK(!CRedactedStackExport::exportToFile(cap, path, true, &error) && !error.isEmpty());
+	CHECK(!leaksPrivate(error));
+	CHECK(!QFile::exists(path));
+	CHECK(QDir(dir.path()).entryList(QDir::Files).isEmpty());
+}
+
+static void SaveCommitFailure()
+{
+	QTemporaryDir dir; CHECK(dir.isValid());
+	QString path = dir.path() + QStringLiteral("/commit.json");
+	// Occupy the destination path with a directory so QSaveFile::commit()
+	// (rename over the file) fails; directWriteFallback is off, so it must
+	// not sneak past the failure by writing directly.
+	CHECK(QDir().mkpath(path));
+	SStackCapture cap = makeCapture();
+	QString error;
+	CHECK(!CRedactedStackExport::exportToFile(cap, path, true, &error) && !error.isEmpty());
+	CHECK(!leaksPrivate(error));
+	CHECK(QDir(path).exists());	// directory intact
+	CHECK(QDir(path).entryList(QDir::Files).isEmpty());	// no rogue file inside
+}
+
+static void SaveExistingFile()
+{
+	QTemporaryDir dir; CHECK(dir.isValid());
+	QString path = dir.path() + QStringLiteral("/prev.json");
+	{
+		QFile prev(path);
+		CHECK(prev.open(QIODevice::WriteOnly));
+		prev.write("previous content");
+	}
+	SStackCapture cap = makeCapture();
+	QString error;
+	CHECK(CRedactedStackExport::exportToFile(cap, path, true, &error));
+	QFile file(path); CHECK(file.open(QIODevice::ReadOnly));
+	QString onDisk = QString::fromUtf8(file.readAll());
+	CHECK(!onDisk.contains(QStringLiteral("previous content")));
+	CHECK(onDisk.contains(QStringLiteral("sandboxie-stack-export")));
+	CHECK(QDir(dir.path()).entryList(QDir::Files) == (QStringList() << QStringLiteral("prev.json")));
+}
+
+static void SaveDoesNotTouchInput()
+{
+	SStackCapture cap = makeCapture();
+	SStackCapture before = cap;
+	QTemporaryDir dir; CHECK(dir.isValid());
+	QString error;
+	CHECK(CRedactedStackExport::exportToFile(cap, dir.path() + QStringLiteral("/x.json"), true, &error));
+	CHECK(cap.frames.size() == before.frames.size());
+	for (int i = 0; i < cap.frames.size(); ++i) {
+		CHECK(cap.frames[i].address == before.frames[i].address);
+		CHECK(cap.frames[i].symbol == before.frames[i].symbol);
+		CHECK(cap.frames[i].moduleKey == before.frames[i].moduleKey);
+	}
+	CHECK(cap.state == before.state);
+}
+
+static void ConcurrentTransformsDoNotShareIds()
+{
+	// Two exports of two distinct captures must not share the id space.
+	// Even if a runs first and reserves id 1, running b with a different
+	// module set has to start again from 1 inside its own report.
+	SStackCapture a; { SStackFrame f; f.address = 1; f.symbol = QStringLiteral("A!x+0"); f.moduleKey = QStringLiteral("A"); a.frames.append(f); }
+	SStackCapture b; { SStackFrame f; f.address = 2; f.symbol = QStringLiteral("B!x+0"); f.moduleKey = QStringLiteral("B"); b.frames.append(f); }
+	SRedactedStack ra = CRedactedStackExport::transform(a);
+	SRedactedStack rb = CRedactedStackExport::transform(b);
+	CHECK(ra.frames[0].moduleId == 1 && rb.frames[0].moduleId == 1);
+}
+
+int main(int argc, char** argv)
+{
+	QCoreApplication app(argc, argv);
+	QMap<QString, void(*)()> cases = {
+		{"allow-list-privacy", AllowListPrivacy},
+		{"allow-list-fields", AllowListFields},
+		{"opaque-ids-per-report", OpaqueIdsPerReport},
+		{"same-name-distinct-modules", SameNameDistinctModules},
+		{"module-name-shared", ModuleNameShared},
+		{"frame-order-preserved", FrameOrderPreserved},
+		{"unresolved-frame-marked", UnresolvedFrameMarked},
+		{"partial-capture-preserved", PartialCapturePreserved},
+		{"unicode-and-punctuation", UnicodeAndPunctuation},
+		{"text-and-json-fidelity", TextAndJsonFidelity},
+		{"save-atomic-happy", SaveAtomicHappy},
+		{"save-open-failure", SaveOpenFailure},
+		{"save-commit-failure", SaveCommitFailure},
+		{"save-existing-file", SaveExistingFile},
+		{"save-does-not-touch-input", SaveDoesNotTouchInput},
+		{"concurrent-transforms-do-not-share-ids", ConcurrentTransformsDoNotShareIds},
+	};
+	if (argc != 2 || !cases.contains(QString::fromUtf8(argv[1]))) return 2;
+	cases.value(QString::fromUtf8(argv[1]))();
+	std::printf("PASS: %s\n", argv[1]);
+	return 0;
+}

--- a/SandboxiePlus/tests/redacted-stack-export/redacted_stack_export_test.cpp
+++ b/SandboxiePlus/tests/redacted-stack-export/redacted_stack_export_test.cpp
@@ -15,7 +15,9 @@
 #include "Helpers/RedactedStackExport.h"
 
 #define CHECK(condition) do { if (!(condition)) { \
-	std::fprintf(stderr, "FAIL at line %d: %s\n", __LINE__, #condition); std::exit(1); \
+	std::fprintf(stdout, "FAIL at line %d: %s\n", __LINE__, #condition); \
+	std::fprintf(stderr, "FAIL at line %d: %s\n", __LINE__, #condition); \
+	std::fflush(stdout); std::fflush(stderr); std::exit(1); \
 } } while (0)
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
sandman gains a redacted stack trace export in the trace-view stack panel: the local capture details stay in the dialog, `Copy` and `Save` produce a share view built from an allow-list. it never renames the bridge to a real vendor, never hides the sandboxie modules from anything else, and never touches the underlying capture; it only anonymises the diagnostic you decide to share

why the split matters

- **local details**: full symbol strings and addresses as they come from the resolver, visible only inside this dialog. useful for local debugging
- **share preview**: the exact bytes that copy or save will write, built from the transformer. what you see before you decide is what leaves the dialog
- the two are computed from one immutable capture: a live diagnostic refresh cannot swap the share content out from under a copy/save the user just approved

what changes

- new `Helpers/RedactedStackExport.{h,cpp}`: a pure transformer with an immutable `SStackCapture` input (address, symbol string, opaque module key) and an `SRedactedStack` output that only carries allow-list fields (`index`, opaque per-report `moduleId`, `moduleResolved`/`symbolResolved` booleans, a canonical `line`). writer is `QSaveFile` with `directWriteFallback` off, so a failed commit leaves the previous file intact and no temporary sibling survives
- new `Windows/StackExportDialog.{h,cpp}`: the two-pane dialog. text/json format switch; the same transformed bytes go to both preview and file
- `Views/StackView`: context-menu action **Export Redacted...** that builds a capture from the currently shown stack and pops the dialog. no live-diagnostic path is duplicated
- one changelog line

what it does not do, on purpose

- no re-attribution: markers say they are markers (`[module-01]`, `[symbol redacted]`, `[unresolved]`). never a real product name
- no hiding of sandboxie from anything: the sandboxie modules keep appearing in the diagnostic and in the local details, only the share view omits their names
- paths, absolute addresses and offsets, module and symbol names, capture owner, box name, arguments and free-form error strings never leave the transformer
- opaque module ids are valid within one report only; correlation between reports is not prevented and the note in the json says so
- no dumps, no screenshots, no upload, no changes to third-party dlls, no changes to the existing #5593/#5594 branches

tests, three kinds kept apart

- simulated: new `SandboxiePlus/tests/redacted-stack-export` ctest target, 16 cases against the shipped transformer with a `QTemporaryDir` store and a synthetic capture, driven by an allow-list of private tokens that must never appear in the text, the json, the on-disk file or the error string. covers allow-list keys, opaque-id semantics (order-of-appearance per report, distinct modules stay distinct, same key inside a report shares its id), same-name-distinct-modules vs same-name-shared, frame order, capture-state (`complete`/`partial`), unresolved frames marked (never guessed), unicode/punctuation, text/json round-trip, atomic save happy path, open failure, commit failure, existing-file replacement, input untouched, two exports starting the id space at 1 each
- build: fork run https://github.com/Kizuno18/sbxie/actions/runs/34245372447 on `d1429ad3` — qt5 and qt6 build and run 16/16, msvc + repo qt6 build and run 16/16, then the real `QSbieAPI.dll` and `SandMan.exe` x64 build and link, sha256 in `redacted-manifest.txt` next to the commit and the blob hashes of the new sources (the "not an upstream check" caveat applies)
- runtime: not part of this pr. real symbols come from dbghelp on a windows host with sandboxie installed; the runtime check is manual, driving the "Export Redacted..." action on a live capture and comparing the share view with what this transformer produces
