### PR TITLE
Fix Classic UI build on systems using code page 936

### DIFF
--- a/Sandboxie/apps/control/AboutDialog.cpp
+++ b/Sandboxie/apps/control/AboutDialog.cpp
@@ -156,7 +156,7 @@ BOOL CAboutDialog::OnInitDialog()
     //
     //
 
-    text.Format(L"%S\r\n%S", MY_COPYRIGHT_STRING, MY_COPYRIGHT_STRING_OLD);
+    text.Format(L"%s\r\n%s", _T(MY_COPYRIGHT_STRING), _T(MY_COPYRIGHT_STRING_OLD));
     GetDlgItem(ID_ABOUT_COPYRIGHT)->SetWindowText(text);
 
     __declspec(align(8)) SCertInfo CertInfo = { 0 };


### PR DESCRIPTION
Building Sandboxie Classic with MSVC's default execution character set on a Windows system using code page 936 fails in `CAboutDialog::OnInitDialog`: the copyright macros contain U+00A9, which cannot be represented in that code page. MSVC emits C4566 and the project's warnings-as-errors setting causes C2220.

Use `_T(...)` for both copyright strings and change the wide-format string from `%S` to `%s` to match the wide arguments. This avoids converting the copyright literals to the system's narrow execution character set and follows the existing usage in `apps/start/aboutdlg.cpp`. The change affects the Classic About dialog only; the Plus UI is unaffected.

### Reproduction

On Windows 11 with system code page 936, VS 2022 Build Tools (MSVC v143), ATL/MFC, and Windows SDK 10.0.26100.0 installed, build the unmodified source with:

```bat
msbuild Sandboxie\SandboxDll.sln /t:Build /p:Configuration=SbieRelease /p:Platform=Win32 /m:8
msbuild Sandboxie\Sandbox.sln /t:Build /p:Configuration=SbieRelease /p:Platform=x64 /m:8
```

The second command fails at the copyright formatting call with C4566 for `\u00A9` in code page 936, followed by C2220. Apply the one-line fix and repeat the build.

### Validation

- On commit `46927b56f2ec8269d5c20dca52a61eaca621edae`, repeated the same x64 build with the original line and the fixed line: exit codes 1 and 0 respectively; the fixed build produced `SbieCtrl.exe`.
- Built the patched latest upstream base `487d5630` with `SandboxDll.sln` (`SbieRelease|Win32`) and `Sandbox.sln` (`SbieRelease|x64`).
- `git diff --check` passes.
- Runtime About-dialog rendering and ARM64 builds have not been tested.
