### PR TITLE
Diagnose SbieShellExt package activation

### DIFF
--- a/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
+++ b/SandboxiePlus/SandMan/Windows/SettingsWindow.cpp
@@ -25,6 +25,7 @@
 #include <QRegularExpression>
 #include <QScreen>
 #include <QSet>
+#include <QDateTime>
 
 
 #include <windows.h>
@@ -108,6 +109,166 @@ static void CUpdateMonitorComboFallbackLabel(QComboBox* pCombo, int fallbackInde
 		bool isFallback = markFallback && i == fallbackIndex;
 		pCombo->setItemText(i, CBuildMonitorOptionLabel(baseLabel, isDefault, isFallback));
 	}
+}
+
+
+static bool CShellExtDebugEnabled()
+{
+	return !qgetenv("SBIE_SHELL_EXT_DEBUG").isEmpty();
+}
+
+static QString CShellExtDebugOutput(const QByteArray& output)
+{
+	QString text = QString::fromLocal8Bit(output);
+	text.replace('\r', "\\r");
+	text.replace('\n', "\\n");
+	if (text.size() > 2048)
+		text = text.left(2048) + "...";
+	return text;
+}
+
+static void CShellExtDebugLog(const QString& message)
+{
+	if (!CShellExtDebugEnabled())
+		return;
+
+	static constexpr qint64 kMaxDebugLogSize = 1024 * 1024;
+	QString line = QString("[%1 pid=%2] %3\r\n")
+		.arg(QDateTime::currentDateTime().toString(Qt::ISODateWithMs))
+		.arg(QCoreApplication::applicationPid())
+		.arg(message);
+	OutputDebugStringW(reinterpret_cast<LPCWSTR>(line.utf16()));
+
+	QByteArray utf8Line = line.toUtf8();
+	QFile file(QDir(QDir::tempPath()).filePath("SbieShellExt.log"));
+	if (file.open(QIODevice::WriteOnly | QIODevice::Append)) {
+		qint64 logSize = file.size();
+		if (logSize < 0)
+			return;
+		if (logSize + utf8Line.size() > kMaxDebugLogSize && !file.resize(0))
+			return;
+		file.write(utf8Line);
+	}
+}
+
+static bool CRunShellExtPackageCommand(const QString& exportName, int waitMs)
+{
+	QProcess proc;
+	QString program = "rundll32.exe";
+	QStringList arguments = QStringList() << QString("SbieShellExt.dll,%1Rundll").arg(exportName);
+	CShellExtDebugLog(QString("package command start export=%1 program=%2 cwd=%3 arguments=%4")
+		.arg(exportName)
+		.arg(program)
+		.arg(QDir::currentPath())
+		.arg(arguments.join(" ")));
+	proc.start(program, arguments);
+	if (!proc.waitForStarted(5000)) {
+		CShellExtDebugLog(QString("package command start failed export=%1 error=%2")
+			.arg(exportName).arg(proc.errorString()));
+		return false;
+	}
+
+	qint64 processId = proc.processId();
+	bool finished = proc.waitForFinished(waitMs);
+	QByteArray standardOutput = proc.readAllStandardOutput();
+	QByteArray standardError = proc.readAllStandardError();
+	CShellExtDebugLog(QString("package command finish export=%1 pid=%2 finished=%3 exitStatus=%4 exitCode=%5 error=%6 stdout=%7 stderr=%8")
+		.arg(exportName)
+		.arg(processId)
+		.arg(finished)
+		.arg(static_cast<int>(proc.exitStatus()))
+		.arg(proc.exitCode())
+		.arg(proc.errorString())
+		.arg(CShellExtDebugOutput(standardOutput))
+		.arg(CShellExtDebugOutput(standardError)));
+	if (!finished)
+		return false;
+	return proc.exitStatus() == QProcess::NormalExit && proc.exitCode() == 0;
+}
+
+static QStringList CQuerySbieShellExtModuleHolders()
+{
+	QProcess proc;
+	proc.start("tasklist.exe", QStringList() << "/M" << "SbieShellExt.dll");
+	if (!proc.waitForStarted(5000) || !proc.waitForFinished(5000))
+		return QStringList();
+
+	QString output = QString::fromLocal8Bit(proc.readAllStandardOutput());
+	QStringList lines = output.split(QRegularExpression("[\\r\\n]+"), Qt::SkipEmptyParts);
+	QSet<QString> holders;
+
+	for (const QString& line : lines) {
+		QString trimmed = line.trimmed();
+		if (trimmed.isEmpty() || trimmed.startsWith("Image Name", Qt::CaseInsensitive) || trimmed.startsWith("=", Qt::CaseInsensitive) || trimmed.startsWith("INFO:", Qt::CaseInsensitive))
+			continue;
+
+		QString simplified = trimmed.simplified();
+		QStringList columns = simplified.split(' ', Qt::SkipEmptyParts);
+		if (columns.isEmpty())
+			continue;
+
+		QString imageName = columns.first();
+		if (imageName.endsWith(".exe", Qt::CaseInsensitive))
+			holders.insert(imageName);
+	}
+
+	QStringList result = holders.values();
+	result.sort();
+	return result;
+}
+
+static bool CRunShellExtPackageCommandWithRecovery(const QString& exportName, const QString& actionText, int waitMs)
+{
+	bool initialResult = CRunShellExtPackageCommand(exportName, waitMs);
+	if (initialResult)
+		return true;
+
+	QStringList holders = CQuerySbieShellExtModuleHolders();
+	QString holderText = holders.isEmpty() ? QObject::tr("(not available)") : holders.join(", ");
+	bool hasDllHost = holders.contains("dllhost.exe", Qt::CaseInsensitive);
+	bool hasRunDll = holders.contains("rundll32.exe", Qt::CaseInsensitive);
+	bool canOfferTerminate = hasDllHost || hasRunDll;
+	CShellExtDebugLog(QString("package command recovery export=%1 action=%2 holders=%3 canOfferTerminate=%4")
+		.arg(exportName).arg(actionText).arg(holderText).arg(canOfferTerminate));
+
+	if (canOfferTerminate) {
+		QMessageBox::StandardButton answer = QMessageBox::question(nullptr,
+			QObject::tr("Sandboxie Plus"),
+			QObject::tr("%1 did not finish in time.\n\n"
+			   "Processes currently holding SbieShellExt.dll:\n%2\n\n"
+			   "Terminate only rundll32.exe/dllhost.exe holders and retry?")
+				.arg(actionText)
+				.arg(holderText),
+			QMessageBox::Yes | QMessageBox::No,
+			QMessageBox::Yes);
+
+		if (answer == QMessageBox::Yes) {
+			CShellExtDebugLog(QString("package command recovery terminate and retry export=%1").arg(exportName));
+			QProcess::execute("taskkill.exe", QStringList() << "/IM" << "dllhost.exe" << "/FI" << "MODULES eq SbieShellExt.dll" << "/F");
+			QProcess::execute("taskkill.exe", QStringList() << "/IM" << "rundll32.exe" << "/FI" << "MODULES eq SbieShellExt.dll" << "/F");
+
+			bool retryResult = CRunShellExtPackageCommand(exportName, waitMs);
+			CShellExtDebugLog(QString("package command recovery retry result export=%1 result=%2")
+				.arg(exportName).arg(retryResult));
+			if (retryResult)
+				return true;
+
+			QMessageBox::warning(nullptr,
+				QObject::tr("Sandboxie Plus"),
+				QObject::tr("%1 still failed. Please close the listed holder processes or sign out and try again.")
+					.arg(actionText));
+		}
+	} else {
+		QMessageBox::warning(nullptr,
+			QObject::tr("Sandboxie Plus"),
+			QObject::tr("%1 did not finish in time.\n\n"
+			   "Processes currently holding SbieShellExt.dll:\n%2\n\n"
+			   "Sandboxie will not terminate these processes automatically. Please close them manually and try again.")
+				.arg(actionText)
+				.arg(holderText));
+	}
+
+	return false;
 }
 
 
@@ -1312,35 +1473,60 @@ Qt::CheckState CSettingsWindow::IsContextMenu()
 {
 	//QSettings Package("HKEY_LOCAL_MACHINE\\SOFTWARE\\Classes\\PackagedCom\\Package", QSettings::NativeFormat);
 	QSettings Package("HKEY_CURRENT_USER\\Software\\Classes\\PackagedCom\\Package", QSettings::NativeFormat);
+	QString packageMatch;
 	foreach(const QString & Key, Package.childGroups()) {
-		if (Key.indexOf("SandboxieShell") == 0)
-			return Qt::Checked;
+		if (Key.indexOf("SandboxieShell") == 0) {
+			packageMatch = Key;
+			break;
+		}
 	}
 
 	QString cmd = CSbieUtils::GetContextMenuStartCmd();
-	if (cmd.contains("SandMan.exe", Qt::CaseInsensitive)) 
-		return Qt::Checked; // set up and sandman
-	if (!cmd.isEmpty()) // ... probably sbiectrl.exe
-		return Qt::PartiallyChecked; 
-	return Qt::Unchecked; // not set up
+	Qt::CheckState state = Qt::Unchecked;
+	if (!packageMatch.isEmpty())
+		state = Qt::Checked;
+	else if (cmd.contains("SandMan.exe", Qt::CaseInsensitive))
+		state = Qt::Checked; // set up and sandman
+	else if (!cmd.isEmpty()) // ... probably sbiectrl.exe
+		state = Qt::PartiallyChecked;
+
+	CShellExtDebugLog(QString("IsContextMenu build=%1 packageMatch=%2 legacyCommand=%3 state=%4")
+		.arg(QSettings("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", QSettings::NativeFormat)
+			.value("CurrentBuild").toInt())
+		.arg(packageMatch.isEmpty() ? "<none>" : packageMatch)
+		.arg(cmd.isEmpty() ? "<empty>" : cmd)
+		.arg(static_cast<int>(state)));
+	return state;
 }
 
 void CSettingsWindow::AddContextMenu(bool bAlwaysClassic)
 {
 	QSettings CurrentVersion("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", QSettings::NativeFormat);
-	if (CurrentVersion.value("CurrentBuild").toInt() >= 22000 && !bAlwaysClassic) // Windows 11
+	int currentBuild = CurrentVersion.value("CurrentBuild").toInt();
+	QString applicationDir = QCoreApplication::applicationDirPath().replace("/", "\\");
+	CShellExtDebugLog(QString("AddContextMenu alwaysClassic=%1 build=%2 applicationDir=%3")
+		.arg(bAlwaysClassic).arg(currentBuild).arg(applicationDir));
+	if (currentBuild >= 22000 && !bAlwaysClassic) // Windows 11
 	{
+		constexpr int kWaitMs = 15000;
 		QSettings MyReg("HKEY_CURRENT_USER\\SOFTWARE\\Xanasoft\\Sandboxie-Plus\\SbieShellExt\\Lang", QSettings::NativeFormat);
 		MyReg.setValue("Open Sandboxed", CSettingsWindow::tr("Run &Sandboxed"));
 		MyReg.setValue("Explore Sandboxed", CSettingsWindow::tr("Run &Sandboxed"));
 		
-		QDir::setCurrent(QCoreApplication::applicationDirPath());
-		QProcess Proc;
-		Proc.execute("rundll32.exe", QStringList() << "SbieShellExt.dll,RegisterPackage");
-		Proc.waitForFinished();
+		bool currentDirectoryResult = QDir::setCurrent(applicationDir);
+		CShellExtDebugLog(QString("AddContextMenu modern register requestedCwd=%1 cwdResult=%2 cwd=%3 openTitle=%4 exploreTitle=%5")
+			.arg(applicationDir)
+			.arg(currentDirectoryResult)
+			.arg(QDir::currentPath())
+			.arg(MyReg.value("Open Sandboxed").toString())
+			.arg(MyReg.value("Explore Sandboxed").toString()));
+		bool result = CRunShellExtPackageCommandWithRecovery("RegisterPackage", CSettingsWindow::tr("Adding shell integration"), kWaitMs);
+		CShellExtDebugLog(QString("AddContextMenu modern register result=%1").arg(result));
 		return;
 	}
 
+	QString startPath = applicationDir + "\\SandMan.exe";
+	CShellExtDebugLog(QString("AddContextMenu legacy register startPath=%1").arg(startPath));
 	CSbieUtils::AddContextMenu(QApplication::applicationDirPath().replace("/", "\\") + "\\SandMan.exe",
 		CSettingsWindow::tr("Run &Sandboxed")/*, //CSettingsWindow::tr("Explore &Sandboxed"),
 			QApplication::applicationDirPath().replace("/", "\\") + "\\Start.exe"*/);
@@ -1349,12 +1535,18 @@ void CSettingsWindow::AddContextMenu(bool bAlwaysClassic)
 void CSettingsWindow::RemoveContextMenu()
 {
 	QSettings CurrentVersion("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", QSettings::NativeFormat);
-	if (CurrentVersion.value("CurrentBuild").toInt() >= 22000) // Windows 11
+	int currentBuild = CurrentVersion.value("CurrentBuild").toInt();
+	QString applicationDir = QCoreApplication::applicationDirPath().replace("/", "\\");
+	CShellExtDebugLog(QString("RemoveContextMenu build=%1 applicationDir=%2").arg(currentBuild).arg(applicationDir));
+	if (currentBuild >= 22000) // Windows 11
 	{
-		QDir::setCurrent(QCoreApplication::applicationDirPath());
-		QProcess Proc;
-		Proc.execute("rundll32.exe", QStringList() << "SbieShellExt.dll,RemovePackage");
-		Proc.waitForFinished();
+		constexpr int kWaitMs = 15000;
+		bool currentDirectoryResult = QDir::setCurrent(applicationDir);
+		CShellExtDebugLog(QString("RemoveContextMenu modern remove requestedCwd=%1 cwdResult=%2 cwd=%3")
+			.arg(applicationDir).arg(currentDirectoryResult).arg(QDir::currentPath()));
+
+		bool result = CRunShellExtPackageCommandWithRecovery("RemovePackage", CSettingsWindow::tr("Removing shell integration"), kWaitMs);
+		CShellExtDebugLog(QString("RemoveContextMenu modern remove result=%1").arg(result));
 	}
 
 	CSbieUtils::RemoveContextMenu();

--- a/SandboxiePlus/SbieShell/SbieShellExt/dllmain.cpp
+++ b/SandboxiePlus/SbieShell/SbieShellExt/dllmain.cpp
@@ -5,6 +5,8 @@
 #include <wrl/client.h>
 #include <shobjidl_core.h>
 #include <wil\resource.h>
+#include <cstdarg>
+#include <exception>
 #include <string>
 #include <vector>
 #include <sstream>
@@ -12,9 +14,107 @@
 
 using namespace Microsoft::WRL;
 
+namespace
+{
+// Set SBIE_SHELL_EXT_DEBUG to any non-empty value to enable diagnostics.
+constexpr wchar_t kDebugEnvironmentVariable[] = L"SBIE_SHELL_EXT_DEBUG";
+constexpr wchar_t kDebugLogFileName[] = L"SbieShellExt.log";
+constexpr LONGLONG kMaxDebugLogSize = 1024 * 1024;
+
+bool IsDebugLoggingEnabled()
+{
+    wchar_t value[2] = {};
+    return GetEnvironmentVariableW(kDebugEnvironmentVariable, value, _countof(value)) != 0;
+}
+
+void DebugLog(const wchar_t* format, ...) noexcept
+{
+    if (!IsDebugLoggingEnabled())
+        return;
+
+    try
+    {
+        wchar_t message[2048] = {};
+        va_list args;
+        va_start(args, format);
+        _vsnwprintf_s(message, _countof(message), _TRUNCATE, format, args);
+        va_end(args);
+
+        SYSTEMTIME time = {};
+        GetLocalTime(&time);
+
+        wchar_t line[2304] = {};
+        _snwprintf_s(line, _countof(line), _TRUNCATE,
+            L"[%04u-%02u-%02u %02u:%02u:%02u.%03u pid=%lu tid=%lu] %ls\r\n",
+            time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute, time.wSecond,
+            time.wMilliseconds, GetCurrentProcessId(), GetCurrentThreadId(), message);
+
+        OutputDebugStringW(line);
+
+        wchar_t tempPath[MAX_PATH] = {};
+        DWORD tempPathLength = GetTempPathW(_countof(tempPath), tempPath);
+        if (tempPathLength == 0 || tempPathLength >= _countof(tempPath))
+            return;
+
+        std::wstring logPath(tempPath, tempPathLength);
+        logPath += kDebugLogFileName;
+
+        wil::unique_hfile logFile(CreateFileW(logPath.c_str(), GENERIC_READ | GENERIC_WRITE | FILE_APPEND_DATA,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_ALWAYS,
+            FILE_ATTRIBUTE_NORMAL, nullptr));
+        if (!logFile)
+            return;
+
+        int utf8Length = WideCharToMultiByte(CP_UTF8, 0, line, -1, nullptr, 0, nullptr, nullptr);
+        if (utf8Length > 1)
+        {
+            std::string utf8(static_cast<size_t>(utf8Length), '\0');
+            int converted = WideCharToMultiByte(CP_UTF8, 0, line, -1, &utf8[0], utf8Length, nullptr, nullptr);
+            if (converted > 1)
+            {
+                LARGE_INTEGER logSize = {};
+                if (!GetFileSizeEx(logFile.get(), &logSize))
+                    return;
+
+                if (logSize.QuadPart + converted - 1 > kMaxDebugLogSize)
+                {
+                    LARGE_INTEGER beginning = {};
+                    if (!SetFilePointerEx(logFile.get(), beginning, nullptr, FILE_BEGIN) ||
+                        !SetEndOfFile(logFile.get()))
+                        return;
+                }
+
+                LARGE_INTEGER end = {};
+                if (!SetFilePointerEx(logFile.get(), end, nullptr, FILE_END))
+                    return;
+
+                DWORD bytesWritten = 0;
+                WriteFile(logFile.get(), utf8.data(), static_cast<DWORD>(converted - 1), &bytesWritten, nullptr);
+            }
+        }
+    }
+    catch (...)
+    {
+    }
+}
+
+std::wstring GuidToString(REFGUID guid)
+{
+    try
+    {
+        wchar_t text[64] = {};
+        if (StringFromGUID2(guid, text, _countof(text)) == 0)
+            return L"<invalid>";
+        return text;
+    }
+    catch (...)
+    {
+        return L"<invalid>";
+    }
+}
+}
+
 std::wstring g_path;
-
-
 LONG GetDWORDRegKey(HKEY hKey, const std::wstring& strValueName, DWORD& nValue)
 {
     DWORD dwBufferSize(sizeof(DWORD));
@@ -34,19 +134,85 @@ LONG GetDWORDRegKey(HKEY hKey, const std::wstring& strValueName, DWORD& nValue)
 
 LONG GetStringRegKey(HKEY hKey, const std::wstring& strValueName, std::wstring& strValue)
 {
+    if (hKey == nullptr)
+        return ERROR_INVALID_HANDLE;
+
     WCHAR szBuffer[512];
     DWORD dwBufferSize = sizeof(szBuffer);
+    DWORD type = REG_NONE;
     ULONG nError;
-    nError = RegQueryValueExW(hKey, strValueName.c_str(), 0, NULL, (LPBYTE)szBuffer, &dwBufferSize);
+    nError = RegQueryValueExW(hKey, strValueName.c_str(), 0, &type, (LPBYTE)szBuffer, &dwBufferSize);
     if (ERROR_SUCCESS == nError)
     {
-        strValue = szBuffer;
+        if (type != REG_SZ || dwBufferSize < sizeof(WCHAR) ||
+            dwBufferSize > sizeof(szBuffer) || dwBufferSize % sizeof(WCHAR) != 0)
+            return ERROR_INVALID_DATA;
+
+        const WCHAR* terminator = wmemchr(szBuffer, L'\0', dwBufferSize / sizeof(WCHAR));
+        if (!terminator)
+            return ERROR_INVALID_DATA;
+
+        strValue.assign(szBuffer, static_cast<size_t>(terminator - szBuffer));
     }
     return nError;
 }
 
 std::wstring g_ExploreSandboxed = L"Explore Sandboxed";
 std::wstring g_OpenSandboxed = L"Open Sandboxed";
+HMODULE g_module = nullptr;
+INIT_ONCE g_initializeOnce = INIT_ONCE_STATIC_INIT;
+DWORD g_initializationError = ERROR_SUCCESS;
+
+BOOL CALLBACK InitializeShellExtension(PINIT_ONCE, PVOID, PVOID*) noexcept try
+{
+    wchar_t path[MAX_PATH] = {};
+    DWORD pathLength = GetModuleFileNameW(g_module, path, _countof(path));
+    if (pathLength == 0 || pathLength >= _countof(path))
+    {
+        g_initializationError = pathLength == 0 ? GetLastError() : ERROR_INSUFFICIENT_BUFFER;
+        DebugLog(L"InitializeShellExtension: GetModuleFileNameW failed length=%lu error=%lu",
+            pathLength, g_initializationError);
+        return FALSE;
+    }
+
+    wchar_t* ptr = wcsrchr(path, L'\\');
+    if (!ptr)
+    {
+        g_initializationError = ERROR_BAD_PATHNAME;
+        DebugLog(L"InitializeShellExtension: module path has no directory path=%ls", path);
+        return FALSE;
+    }
+
+    *ptr = L'\0';
+    g_path = path;
+    DebugLog(L"InitializeShellExtension: moduleDirectory=%ls", g_path.c_str());
+
+    HKEY hKey = nullptr;
+    LONG result = RegOpenKeyExW(HKEY_CURRENT_USER,
+        L"SOFTWARE\\Xanasoft\\Sandboxie-Plus\\SbieShellExt\\Lang", 0, KEY_READ, &hKey);
+    DebugLog(L"InitializeShellExtension: RegOpenKeyExW Lang result=%ld", result);
+    if (result == ERROR_SUCCESS)
+    {
+        LONG exploreResult = GetStringRegKey(hKey, L"Explore Sandboxed", g_ExploreSandboxed);
+        LONG openResult = GetStringRegKey(hKey, L"Open Sandboxed", g_OpenSandboxed);
+        DebugLog(L"InitializeShellExtension: language values exploreResult=%ld openResult=%ld explore=%ls open=%ls",
+            exploreResult, openResult, g_ExploreSandboxed.c_str(), g_OpenSandboxed.c_str());
+        RegCloseKey(hKey);
+    }
+
+    return TRUE;
+}
+catch (...)
+{
+    g_initializationError = ERROR_UNHANDLED_EXCEPTION;
+    DebugLog(L"InitializeShellExtension: unexpected exception");
+    return FALSE;
+}
+
+bool EnsureShellExtensionInitialized()
+{
+    return InitOnceExecuteOnce(&g_initializeOnce, InitializeShellExtension, nullptr, nullptr) != FALSE;
+}
 
 BOOL APIENTRY DllMain( HMODULE hModule,
                        DWORD  ul_reason_for_call,
@@ -56,23 +222,8 @@ BOOL APIENTRY DllMain( HMODULE hModule,
     switch (ul_reason_for_call)
     {
         case DLL_PROCESS_ATTACH:
-        {
-            wchar_t path[MAX_PATH];
-            GetModuleFileName(hModule, path, MAX_PATH);
-            wchar_t* ptr = wcsrchr(path, L'\\');
-            *ptr = L'\0';
-            g_path = std::wstring(path);
-
-            HKEY hKey;
-            LONG lRes = RegOpenKeyExW(HKEY_CURRENT_USER, L"SOFTWARE\\Xanasoft\\Sandboxie-Plus\\SbieShellExt\\Lang", 0, KEY_READ, &hKey);
-            bool bExistsAndSuccess(lRes == ERROR_SUCCESS);
-            bool bDoesNotExistsSpecifically(lRes == ERROR_FILE_NOT_FOUND);
-            GetStringRegKey(hKey, L"Explore Sandboxed", g_ExploreSandboxed);
-            GetStringRegKey(hKey, L"Open Sandboxed", g_OpenSandboxed);
-            CloseHandle(hKey);
-
+            g_module = hModule;
             break;
-        }
         case DLL_THREAD_ATTACH:
         case DLL_THREAD_DETACH:
         case DLL_PROCESS_DETACH:
@@ -92,6 +243,7 @@ public:
     IFACEMETHODIMP GetTitle(_In_opt_ IShellItemArray* items, _Outptr_result_nullonfailure_ PWSTR* name)
     {
         *name = nullptr;
+        DebugLog(L"GetTitle: title=%ls", Title());
         auto title = wil::make_cotaskmem_string_nothrow(Title());
         RETURN_IF_NULL_ALLOC(title);
         *name = title.release();
@@ -100,6 +252,7 @@ public:
     IFACEMETHODIMP GetIcon(_In_opt_ IShellItemArray*, _Outptr_result_nullonfailure_ PWSTR* icon)// { *icon = nullptr; return E_NOTIMPL; }
     {
         std::wstring bpPath = g_path + L"\\SandMan.exe,-0";
+        DebugLog(L"GetIcon: path=%ls", bpPath.c_str());
         auto iconPath = wil::make_cotaskmem_string_nothrow(bpPath.c_str());
         RETURN_IF_NULL_ALLOC(iconPath);
         *icon = iconPath.release();
@@ -110,6 +263,8 @@ public:
     IFACEMETHODIMP GetState(_In_opt_ IShellItemArray* selection, _In_ BOOL okToBeSlow, _Out_ EXPCMDSTATE* cmdState)
     {
         *cmdState = State(selection);
+        DebugLog(L"GetState: title=%ls okToBeSlow=%d state=0x%08lX", Title(), okToBeSlow,
+            static_cast<unsigned long>(*cmdState));
         return S_OK;
     }
     enum ECommand {
@@ -143,17 +298,39 @@ public:
 
         MessageBox(parent, title.str().c_str(), L"TestCommand", MB_OK);*/
 
+        DebugLog(L"Invoke: title=%ls command=%ls selection=%p", Title(),
+            GetCommand() == eExplore ? L"Explore" : L"Open", selection);
 
         if (selection)
         {
             DWORD fileCount = 0;
-            RETURN_IF_FAILED(selection->GetCount(&fileCount));
+            HRESULT result = selection->GetCount(&fileCount);
+            if (FAILED(result))
+            {
+                DebugLog(L"Invoke: IShellItemArray::GetCount failed hr=0x%08lX",
+                    static_cast<unsigned long>(result));
+                return result;
+            }
+            DebugLog(L"Invoke: selectionCount=%lu", fileCount);
             for (DWORD i = 0; i < fileCount; i++)
             {
-                IShellItem* shellItem = nullptr;
-                selection->GetItemAt(i, &shellItem);
-                LPWSTR itemName = nullptr;
-                shellItem->GetDisplayName(SIGDN_FILESYSPATH, &itemName);
+                ComPtr<IShellItem> shellItem;
+                result = selection->GetItemAt(i, &shellItem);
+                if (FAILED(result))
+                {
+                    DebugLog(L"Invoke: GetItemAt index=%lu failed hr=0x%08lX", i,
+                        static_cast<unsigned long>(result));
+                    return result;
+                }
+
+                wil::unique_cotaskmem_string itemName;
+                result = shellItem->GetDisplayName(SIGDN_FILESYSPATH, &itemName);
+                if (FAILED(result))
+                {
+                    DebugLog(L"Invoke: GetDisplayName index=%lu failed hr=0x%08lX", i,
+                        static_cast<unsigned long>(result));
+                    return result;
+                }
                 if (itemName)
                 {
                     std::wstring file = g_path + L"\\SandMan.exe";
@@ -162,15 +339,16 @@ public:
                     if(GetCommand() == eExplore)
                         params += L" C:\\WINDOWS\\explorer.exe";
                     params += L" \"";
-                    params += itemName;
+                    params += itemName.get();
                     params += L"\"";
 
-                    // Since the program is run from rundll32.exe, the working directory needs to be set to the program's one.
-                    // Otherwise, the rundll32.exe's one will be used (usually "C:\Windows\System32").
+                    // The extension runs in a surrogate process, so set the selected item's directory explicitly.
                     std::vector<wchar_t> drive(_MAX_DRIVE), dir(_MAX_DIR);
-                    _wsplitpath_s(itemName, drive.data(), drive.size(), dir.data(), dir.size(), nullptr, 0, nullptr, 0);
+                    _wsplitpath_s(itemName.get(), drive.data(), drive.size(), dir.data(), dir.size(), nullptr, 0, nullptr, 0);
                     std::wstring currentDirectory(drive.data());
                     currentDirectory += dir.data();
+                    DebugLog(L"Invoke: index=%lu item=%ls currentDirectory=%ls params=%ls", i,
+                        itemName.get(), currentDirectory.c_str(), params.c_str());
 
                     SHELLEXECUTEINFO shExecInfo = { sizeof(SHELLEXECUTEINFO) };
                     shExecInfo.hwnd = nullptr;
@@ -179,10 +357,12 @@ public:
                     shExecInfo.lpParameters = params.c_str();
                     shExecInfo.lpDirectory = currentDirectory.c_str();
                     shExecInfo.nShow = SW_NORMAL;
-                    ShellExecuteEx(&shExecInfo);
-
-                    CoTaskMemFree(itemName);
+                    BOOL executeResult = ShellExecuteExW(&shExecInfo);
+                    DebugLog(L"Invoke: ShellExecuteExW index=%lu result=%d error=%lu", i,
+                        executeResult, executeResult ? ERROR_SUCCESS : GetLastError());
                 }
+                else
+                    DebugLog(L"Invoke: GetDisplayName index=%lu returned no path", i);
             }
         }
 
@@ -194,7 +374,12 @@ public:
     IFACEMETHODIMP EnumSubCommands(_COM_Outptr_ IEnumExplorerCommand** enumCommands) { *enumCommands = nullptr; return E_NOTIMPL; }
 
     // IObjectWithSite
-    IFACEMETHODIMP SetSite(_In_ IUnknown* site) noexcept { m_site = site; return S_OK; }
+    IFACEMETHODIMP SetSite(_In_ IUnknown* site) noexcept
+    {
+        DebugLog(L"SetSite: site=%p", site);
+        m_site = site;
+        return S_OK;
+    }
     IFACEMETHODIMP GetSite(_In_ REFIID riid, _COM_Outptr_ void** site) noexcept { return m_site.CopyTo(riid, site); }
 
 protected:
@@ -411,7 +596,12 @@ CoCreatableClassWrlCreatorMapInclude(TestExplorerHiddenCommandHandler)
 
 STDAPI DllGetActivationFactory(_In_ HSTRING activatableClassId, _COM_Outptr_ IActivationFactory** factory)
 {
-    return Module<ModuleType::InProc>::GetModule().GetActivationFactory(activatableClassId, factory);
+    if (!EnsureShellExtensionInitialized())
+        return HRESULT_FROM_WIN32(g_initializationError);
+
+    HRESULT result = Module<ModuleType::InProc>::GetModule().GetActivationFactory(activatableClassId, factory);
+    DebugLog(L"DllGetActivationFactory: result=0x%08lX", static_cast<unsigned long>(result));
+    return result;
 }
 
 STDAPI DllCanUnloadNow()
@@ -421,7 +611,15 @@ STDAPI DllCanUnloadNow()
 
 STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _COM_Outptr_ void** instance)
 {
-    return Module<InProc>::GetModule().GetClassObject(rclsid, riid, instance);
+    if (!EnsureShellExtensionInitialized())
+        return HRESULT_FROM_WIN32(g_initializationError);
+
+    HRESULT result = Module<InProc>::GetModule().GetClassObject(rclsid, riid, instance);
+    std::wstring classId = GuidToString(rclsid);
+    std::wstring interfaceId = GuidToString(riid);
+    DebugLog(L"DllGetClassObject: clsid=%ls riid=%ls result=0x%08lX", classId.c_str(),
+        interfaceId.c_str(), static_cast<unsigned long>(result));
+    return result;
 }
 
 
@@ -433,80 +631,150 @@ STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _COM_Outptr_ vo
 #include <winrt/Windows.ApplicationModel.h>
 
 #pragma comment(lib, "windowsapp.lib")
+#pragma comment(lib, "ole32.lib")
 
 int RegisterSparsePackage(const std::wstring& sparseExtPath, const std::wstring& sparsePackagePath)
 {
-    winrt::Windows::Management::Deployment::PackageManager manager;
-    winrt::Windows::Management::Deployment::AddPackageOptions options;
-    winrt::Windows::Foundation::Uri externalUri(sparseExtPath.c_str());
-    winrt::Windows::Foundation::Uri packageUri(sparsePackagePath.c_str());
-    options.ExternalLocationUri(externalUri);
-    auto deploymentOperation = manager.AddPackageByUriAsync(packageUri, options);
+    DebugLog(L"RegisterSparsePackage: begin externalPath=%ls packagePath=%ls", sparseExtPath.c_str(),
+        sparsePackagePath.c_str());
 
-    auto deployResult = deploymentOperation.get();
+    DWORD externalAttributes = GetFileAttributesW(sparseExtPath.c_str());
+    DWORD externalError = externalAttributes == INVALID_FILE_ATTRIBUTES ? GetLastError() : ERROR_SUCCESS;
+    DWORD packageAttributes = GetFileAttributesW(sparsePackagePath.c_str());
+    DWORD packageError = packageAttributes == INVALID_FILE_ATTRIBUTES ? GetLastError() : ERROR_SUCCESS;
+    DebugLog(L"RegisterSparsePackage: externalAttributes=0x%08lX externalError=%lu packageAttributes=0x%08lX packageError=%lu",
+        externalAttributes, externalError, packageAttributes, packageError);
 
-    if (!SUCCEEDED(deployResult.ExtendedErrorCode()))
+    try
     {
-        // Deployment failed
-        std::wstring error = L"AddPackageByUriAsync failed (Errorcode: ";
-        error += std::to_wstring(deployResult.ExtendedErrorCode());
-        error += L"):\n";
-        error += deployResult.ErrorText();
+        winrt::Windows::Management::Deployment::PackageManager manager;
+        winrt::Windows::Management::Deployment::AddPackageOptions options;
+        winrt::Windows::Foundation::Uri externalUri(sparseExtPath.c_str());
+        winrt::Windows::Foundation::Uri packageUri(sparsePackagePath.c_str());
+        options.ExternalLocationUri(externalUri);
+        auto deploymentOperation = manager.AddPackageByUriAsync(packageUri, options);
 
+        auto deployResult = deploymentOperation.get();
+        long extendedError = static_cast<long>(deployResult.ExtendedErrorCode());
+        std::wstring errorText = deployResult.ErrorText().c_str();
+        DebugLog(L"RegisterSparsePackage: deployment result=0x%08lX errorText=%ls",
+            static_cast<unsigned long>(extendedError), errorText.c_str());
+
+        if (!SUCCEEDED(extendedError))
+        {
+            // Deployment failed
+            std::wstring error = L"AddPackageByUriAsync failed (Errorcode: ";
+            error += std::to_wstring(extendedError);
+            error += L"):\n";
+            error += errorText;
+
+            return -1;
+        }
+        return 0;
+    }
+    catch (const winrt::hresult_error& ex)
+    {
+        DebugLog(L"RegisterSparsePackage: hresult_error code=0x%08lX message=%ls",
+            static_cast<unsigned long>(ex.code().value), ex.message().c_str());
         return -1;
     }
-    return 0;
+    catch (const std::exception&)
+    {
+        DebugLog(L"RegisterSparsePackage: std::exception");
+        return -1;
+    }
+    catch (...)
+    {
+        DebugLog(L"RegisterSparsePackage: unknown exception");
+        return -1;
+    }
 }
 
 int UnregisterSparsePackage(const std::wstring& sparsePackageName)
 {
+    DebugLog(L"UnregisterSparsePackage: begin packageName=%ls", sparsePackageName.c_str());
 
-    winrt::Windows::Management::Deployment::PackageManager manager;
-    winrt::Windows::Foundation::Collections::IIterable<winrt::Windows::ApplicationModel::Package> packages;
     try
     {
+        winrt::Windows::Management::Deployment::PackageManager manager;
+        winrt::Windows::Foundation::Collections::IIterable<winrt::Windows::ApplicationModel::Package> packages;
         packages = manager.FindPackagesForUser(L"");
+
+        bool found = false;
+        for (const auto& package : packages)
+        {
+            auto packageId = package.Id();
+            if (packageId.Name() != sparsePackageName)
+                continue;
+
+            found = true;
+            winrt::hstring fullName = packageId.FullName();
+            DebugLog(L"UnregisterSparsePackage: removing fullName=%ls", fullName.c_str());
+            auto deploymentOperation = manager.RemovePackageAsync(fullName, winrt::Windows::Management::Deployment::RemovalOptions::None);
+            auto deployResult = deploymentOperation.get();
+            long extendedError = static_cast<long>(deployResult.ExtendedErrorCode());
+            std::wstring errorText = deployResult.ErrorText().c_str();
+            DebugLog(L"UnregisterSparsePackage: deployment result=0x%08lX errorText=%ls",
+                static_cast<unsigned long>(extendedError), errorText.c_str());
+            if (SUCCEEDED(extendedError))
+                break;
+
+            // Undeployment failed
+            std::wstring error = L"RemovePackageAsync failed (Errorcode: ";
+            error += std::to_wstring(extendedError);
+            error += L"):\n";
+            error += errorText;
+
+            return -1;
+        }
+
+        DebugLog(L"UnregisterSparsePackage: packageFound=%d", found);
+        return 0;
     }
     catch (winrt::hresult_error const& ex)
     {
-        std::wstring error = L"FindPackagesForUser failed (Errorcode: ";
-        error += std::to_wstring(ex.code().value);
-        error += L"):\n";
-        error += ex.message();
+        DebugLog(L"UnregisterSparsePackage: hresult_error code=0x%08lX message=%ls",
+            static_cast<unsigned long>(ex.code().value), ex.message().c_str());
         return -1;
     }
-
-    for (const auto& package : packages)
+    catch (const std::exception&)
     {
-        if (package.Id().Name() != sparsePackageName)
-            continue;
-
-        winrt::hstring fullName = package.Id().FullName();
-        auto deploymentOperation = manager.RemovePackageAsync(fullName, winrt::Windows::Management::Deployment::RemovalOptions::None);
-        auto deployResult = deploymentOperation.get();
-        if (SUCCEEDED(deployResult.ExtendedErrorCode()))
-            break;
-
-        // Undeployment failed
-        std::wstring error = L"RemovePackageAsync failed (Errorcode: ";
-        error += std::to_wstring(deployResult.ExtendedErrorCode());
-        error += L"):\n";
-        error += deployResult.ErrorText();
-
+        DebugLog(L"UnregisterSparsePackage: std::exception");
         return -1;
     }
-    return 0;
+    catch (...)
+    {
+        DebugLog(L"UnregisterSparsePackage: unknown exception");
+        return -1;
+    }
 }
 
 extern "C" __declspec(dllexport) int RegisterPackage()
 {
+    if (!EnsureShellExtensionInitialized())
+        return static_cast<int>(HRESULT_FROM_WIN32(g_initializationError));
+
     std::wstring sparseExtPath = g_path;
     std::wstring sparsePackagePath = g_path + L"\\SbieShellPkg.msix";
-    return RegisterSparsePackage(sparseExtPath, sparsePackagePath);
+    int result = RegisterSparsePackage(sparseExtPath, sparsePackagePath);
+    DebugLog(L"RegisterPackage: result=%d", result);
+    return result;
 }
 
 extern "C" __declspec(dllexport) int RemovePackage()
 {
     std::wstring sparsePackageName = L"SandboxieShell";
-    return UnregisterSparsePackage(sparsePackageName);
+    int result = UnregisterSparsePackage(sparsePackageName);
+    DebugLog(L"RemovePackage: result=%d", result);
+    return result;
+}
+
+extern "C" __declspec(dllexport) void CALLBACK RegisterPackageRundll(HWND, HINSTANCE, LPSTR, int)
+{
+    ExitProcess(static_cast<UINT>(RegisterPackage()));
+}
+
+extern "C" __declspec(dllexport) void CALLBACK RemovePackageRundll(HWND, HINSTANCE, LPSTR, int)
+{
+    ExitProcess(static_cast<UINT>(RemovePackage()));
 }


### PR DESCRIPTION
Add opt-in (`SBIE_SHELL_EXT_DEBUG`), size-bounded diagnostics for shell-extension deployment and Explorer command execution. Defer extension initialization, validate localized registry values, and expose Rundll32-compatible package callbacks.